### PR TITLE
fixed gbalink and visigen CMakeList files

### DIFF
--- a/gbalink/CMakeLists.txt
+++ b/gbalink/CMakeLists.txt
@@ -1,3 +1,4 @@
 include_directories(. ./../Runtime ${ATHENA_INCLUDE_DIR} ${JBUS_INCLUDE_DIR})
-add_executable(gbalink main.cpp)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ldl")
+add_executable(gbalink main.cpp ../hecl/extern/boo/logvisor/lib/logvisor.cpp ../hecl/lib/hecl.cpp)
 target_link_libraries(gbalink jbus)

--- a/visigen/CMakeLists.txt
+++ b/visigen/CMakeLists.txt
@@ -19,7 +19,8 @@ endif()
 
 add_executable(visigen ${PLAT_SRCS}
                VISIRenderer.cpp VISIRenderer.hpp
-               VISIBuilder.cpp VISIBuilder.hpp)
+               VISIBuilder.cpp VISIBuilder.hpp
+               ../hecl/lib/hecl.cpp)
 target_link_libraries(visigen logvisor athena-core zeus glew xxhash ${BOO_SYS_LIBS})
 
 add_custom_command(TARGET visigen POST_BUILD


### PR DESCRIPTION
gbalink and visigen include some headers without compiling/linking the implementation.
This is probably not the best way to fix the problem, however. Maybe hecl and logvisor generate some library we should link ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/21)
<!-- Reviewable:end -->
