### PR TITLE
MP1/CMFGame: Remove erroneous forward declaration

### DIFF
--- a/Runtime/MP1/CMFGame.hpp
+++ b/Runtime/MP1/CMFGame.hpp
@@ -6,7 +6,6 @@
 
 namespace urde {
 class CStateManager;
-class CInGameGuiManager;
 class CToken;
 
 namespace MP1 {


### PR DESCRIPTION
This type is actually defined within the `urde::MP1` namespace, not the top-level `urde` namespace. We remove the namespace itself however, given the header for that type is already being included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/29)
<!-- Reviewable:end -->
