### PR TITLE
GuiSys/CInstruction: Correct erroneous assignment in TestLargestFont

### DIFF
--- a/Runtime/GuiSys/CInstruction.cpp
+++ b/Runtime/GuiSys/CInstruction.cpp
@@ -225,7 +225,7 @@ void CBlockInstruction::TestLargestFont(s32 monoW, s32 monoH, s32 baseline) {
     x28_largestBaseline = baseline;
 
   if (x20_largestMonoW < monoW)
-    monoW = x20_largestMonoW;
+    x20_largestMonoW = monoW;
 
   if (x24_largestMonoH < monoH) {
     x24_largestMonoH = monoH;


### PR DESCRIPTION
Without this, x20_largestMonoW will never be any value other than zero, which is indicative of a logic bug in the absence of comments

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/30)
<!-- Reviewable:end -->
