### PR TITLE
RuntimeCommonB: Use the override specifier where applicable

### DIFF
--- a/Runtime/Audio/CSfxManager.hpp
+++ b/Runtime/Audio/CSfxManager.hpp
@@ -125,16 +125,16 @@ public:
     float x55_cachedMaxVol;
 
   public:
-    bool IsPlaying() const;
-    void Play();
-    void Stop();
-    bool Ready();
-    ESfxAudibility GetAudible(const zeus::CVector3f&);
-    amuse::ObjToken<amuse::Voice> GetVoice() const { return x50_emitterHandle->getVoice(); }
-    u16 GetSfxId() const;
-    void UpdateEmitterSilent();
-    void UpdateEmitter();
-    void SetReverb(float rev);
+    bool IsPlaying() const override;
+    void Play() override;
+    void Stop() override;
+    bool Ready() override;
+    ESfxAudibility GetAudible(const zeus::CVector3f&) override;
+    amuse::ObjToken<amuse::Voice> GetVoice() const override { return x50_emitterHandle->getVoice(); }
+    u16 GetSfxId() const override;
+    void UpdateEmitterSilent() override;
+    void UpdateEmitter() override;
+    void SetReverb(float rev) override;
     CAudioSys::C3DEmitterParmData& GetEmitterData() { return x24_parmData; }
 
     amuse::ObjToken<amuse::Emitter> GetHandle() const { return x50_emitterHandle; }
@@ -154,16 +154,16 @@ public:
     bool x24_ready = true;
 
   public:
-    bool IsPlaying() const;
-    void Play();
-    void Stop();
-    bool Ready();
-    ESfxAudibility GetAudible(const zeus::CVector3f&) { return ESfxAudibility::Aud3; }
-    amuse::ObjToken<amuse::Voice> GetVoice() const { return x1c_voiceHandle; }
-    u16 GetSfxId() const;
-    void UpdateEmitterSilent();
-    void UpdateEmitter();
-    void SetReverb(float rev);
+    bool IsPlaying() const override;
+    void Play() override;
+    void Stop() override;
+    bool Ready() override;
+    ESfxAudibility GetAudible(const zeus::CVector3f&) override { return ESfxAudibility::Aud3; }
+    amuse::ObjToken<amuse::Voice> GetVoice() const override { return x1c_voiceHandle; }
+    u16 GetSfxId() const override;
+    void UpdateEmitterSilent() override;
+    void UpdateEmitter() override;
+    void SetReverb(float rev) override;
     void SetVolume(float vol) { x20_vol = vol; }
 
     CSfxWrapper(bool looped, s16 prio, u16 sfxId, float vol, float pan,

--- a/Runtime/Audio/CStaticAudioPlayer.hpp
+++ b/Runtime/Audio/CStaticAudioPlayer.hpp
@@ -37,8 +37,8 @@ class CStaticAudioPlayer {
 
   struct AudioVoiceCallback : boo::IAudioVoiceCallback {
     CStaticAudioPlayer& m_parent;
-    void preSupplyAudio(boo::IAudioVoice&, double) {}
-    size_t supplyAudio(boo::IAudioVoice& voice, size_t frames, int16_t* data) {
+    void preSupplyAudio(boo::IAudioVoice&, double) override {}
+    size_t supplyAudio(boo::IAudioVoice& voice, size_t frames, int16_t* data) override {
       if (m_parent.IsReady()) {
         m_parent.x38_dvdRequests.clear();
         m_parent.Decode(data, frames);

--- a/Runtime/CDvdFile.cpp
+++ b/Runtime/CDvdFile.cpp
@@ -18,20 +18,20 @@ class CFileDvdRequest : public IDvdRequest {
   std::function<void(u32)> m_callback;
 
 public:
-  ~CFileDvdRequest() { PostCancelRequest(); }
+  ~CFileDvdRequest() override { PostCancelRequest(); }
 
-  void WaitUntilComplete() {
+  void WaitUntilComplete() override {
     while (!m_complete.load() && !m_cancel.load()) {
       std::unique_lock<std::mutex> lk(CDvdFile::m_WaitMutex);
     }
   }
-  bool IsComplete() { return m_complete.load(); }
-  void PostCancelRequest() {
+  bool IsComplete() override { return m_complete.load(); }
+  void PostCancelRequest() override {
     std::unique_lock<std::mutex> waitlk(CDvdFile::m_WaitMutex);
     m_cancel.store(true);
   }
 
-  EMediaType GetMediaType() const { return EMediaType::File; }
+  EMediaType GetMediaType() const override { return EMediaType::File; }
 
   CFileDvdRequest(CDvdFile& file, void* buf, u32 len, ESeekOrigin whence, int off, std::function<void(u32)>&& cb)
   : m_reader(file.m_reader), m_buf(buf), m_len(len), m_whence(whence), m_offset(off), m_callback(std::move(cb)) {}

--- a/Runtime/CMainFlowBase.hpp
+++ b/Runtime/CMainFlowBase.hpp
@@ -12,7 +12,7 @@ protected:
 
 public:
   CMainFlowBase(const char* name) : CIOWin(name) {}
-  EMessageReturn OnMessage(const CArchitectureMessage& msg, CArchitectureQueue& queue);
+  EMessageReturn OnMessage(const CArchitectureMessage& msg, CArchitectureQueue& queue) override;
   virtual void AdvanceGameState(CArchitectureQueue& queue) = 0;
   virtual void SetGameState(EClientFlowStates state, CArchitectureQueue& queue) = 0;
 };

--- a/Runtime/CPlayMovieBase.hpp
+++ b/Runtime/CPlayMovieBase.hpp
@@ -10,8 +10,8 @@ class CPlayMovieBase : public CIOWin {
 
 public:
   CPlayMovieBase(const char* iowName, const char* path) : CIOWin(iowName), x18_moviePlayer(path, 0.0, false, false) {}
-  EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) { return EMessageReturn::Normal; }
-  void Draw() const {}
+  EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override { return EMessageReturn::Normal; }
+  void Draw() const override {}
 };
 
 } // namespace urde

--- a/Runtime/CResFactory.hpp
+++ b/Runtime/CResFactory.hpp
@@ -45,58 +45,64 @@ private:
 
 public:
   CResLoader& GetLoader() { return x4_loader; }
-  std::unique_ptr<IObj> Build(const SObjectTag&, const CVParamTransfer&, CObjectReference* selfRef);
-  void BuildAsync(const SObjectTag&, const CVParamTransfer&, std::unique_ptr<IObj>*, CObjectReference* selfRef);
-  void AsyncIdle();
-  void CancelBuild(const SObjectTag&);
+  std::unique_ptr<IObj> Build(const SObjectTag&, const CVParamTransfer&, CObjectReference* selfRef) override;
+  void BuildAsync(const SObjectTag&, const CVParamTransfer&, std::unique_ptr<IObj>*,
+                  CObjectReference* selfRef) override;
+  void AsyncIdle() override;
+  void CancelBuild(const SObjectTag&) override;
 
-  bool CanBuild(const SObjectTag& tag) { return x4_loader.ResourceExists(tag); }
+  bool CanBuild(const SObjectTag& tag) override { return x4_loader.ResourceExists(tag); }
 
-  u32 ResourceSize(const urde::SObjectTag& tag) { return x4_loader.ResourceSize(tag); }
+  u32 ResourceSize(const urde::SObjectTag& tag) override { return x4_loader.ResourceSize(tag); }
 
-  std::unique_ptr<u8[]> LoadResourceSync(const urde::SObjectTag& tag) { return x4_loader.LoadResourceSync(tag); }
+  std::unique_ptr<u8[]> LoadResourceSync(const urde::SObjectTag& tag) override {
+    return x4_loader.LoadResourceSync(tag);
+  }
 
-  std::unique_ptr<u8[]> LoadNewResourcePartSync(const urde::SObjectTag& tag, u32 off, u32 size) {
+  std::unique_ptr<u8[]> LoadNewResourcePartSync(const urde::SObjectTag& tag, u32 off, u32 size) override {
     return x4_loader.LoadNewResourcePartSync(tag, off, size);
   }
 
-  void GetTagListForFile(const char* pakName, std::vector<SObjectTag>& out) const {
+  void GetTagListForFile(const char* pakName, std::vector<SObjectTag>& out) const override {
     return x4_loader.GetTagListForFile(pakName, out);
   }
 
-  std::shared_ptr<IDvdRequest> LoadResourceAsync(const urde::SObjectTag& tag, void* target) {
+  std::shared_ptr<IDvdRequest> LoadResourceAsync(const urde::SObjectTag& tag, void* target) override {
     return x4_loader.LoadResourceAsync(tag, target);
   }
 
-  std::shared_ptr<IDvdRequest> LoadResourcePartAsync(const urde::SObjectTag& tag, u32 off, u32 size, void* target) {
+  std::shared_ptr<IDvdRequest> LoadResourcePartAsync(const urde::SObjectTag& tag, u32 off, u32 size,
+                                                     void* target) override {
     return x4_loader.LoadResourcePartAsync(tag, off, size, target);
   }
 
-  const SObjectTag* GetResourceIdByName(std::string_view name) const { return x4_loader.GetResourceIdByName(name); }
+  const SObjectTag* GetResourceIdByName(std::string_view name) const override {
+    return x4_loader.GetResourceIdByName(name);
+  }
 
-  FourCC GetResourceTypeById(CAssetId id) const { return x4_loader.GetResourceTypeById(id); }
+  FourCC GetResourceTypeById(CAssetId id) const override { return x4_loader.GetResourceTypeById(id); }
 
   std::vector<std::pair<std::string, SObjectTag>> GetResourceIdToNameList() const {
     return x4_loader.GetResourceIdToNameList();
   }
 
-  void EnumerateResources(const std::function<bool(const SObjectTag&)>& lambda) const {
+  void EnumerateResources(const std::function<bool(const SObjectTag&)>& lambda) const override {
     return x4_loader.EnumerateResources(lambda);
   }
 
-  void EnumerateNamedResources(const std::function<bool(std::string_view, const SObjectTag&)>& lambda) const {
+  void EnumerateNamedResources(const std::function<bool(std::string_view, const SObjectTag&)>& lambda) const override {
     return x4_loader.EnumerateNamedResources(lambda);
   }
 
   void LoadPersistentResources(CSimplePool& sp);
   void UnloadPersistentResources() { m_nonWorldTokens.clear(); }
 
-  void LoadOriginalIDs(CSimplePool& sp);
-  CAssetId TranslateOriginalToNew(CAssetId id) const;
-  CAssetId TranslateNewToOriginal(CAssetId id) const;
+  void LoadOriginalIDs(CSimplePool& sp) override;
+  CAssetId TranslateOriginalToNew(CAssetId id) const override;
+  CAssetId TranslateNewToOriginal(CAssetId id) const override;
 
-  CResLoader* GetResLoader() { return &x4_loader; }
-  CFactoryMgr* GetFactoryMgr() { return &x5c_factoryMgr; }
+  CResLoader* GetResLoader() override { return &x4_loader; }
+  CFactoryMgr* GetFactoryMgr() override { return &x5c_factoryMgr; }
 };
 
 } // namespace urde

--- a/Runtime/CSimplePool.hpp
+++ b/Runtime/CSimplePool.hpp
@@ -19,16 +19,16 @@ protected:
 
 public:
   CSimplePool(IFactory& factory);
-  ~CSimplePool();
-  CToken GetObj(const SObjectTag&, const CVParamTransfer&);
-  CToken GetObj(const SObjectTag&);
-  CToken GetObj(std::string_view);
-  CToken GetObj(std::string_view, const CVParamTransfer&);
-  bool HasObject(const SObjectTag&) const;
-  bool ObjectIsLive(const SObjectTag&) const;
-  IFactory& GetFactory() const { return x18_factory; }
-  void Flush();
-  void ObjectUnreferenced(const SObjectTag&);
+  ~CSimplePool() override;
+  CToken GetObj(const SObjectTag&, const CVParamTransfer&) override;
+  CToken GetObj(const SObjectTag&) override;
+  CToken GetObj(std::string_view) override;
+  CToken GetObj(std::string_view, const CVParamTransfer&) override;
+  bool HasObject(const SObjectTag&) const override;
+  bool ObjectIsLive(const SObjectTag&) const override;
+  IFactory& GetFactory() const override { return x18_factory; }
+  void Flush() override;
+  void ObjectUnreferenced(const SObjectTag&) override;
   std::vector<SObjectTag> GetReferencedTags() const;
 };
 

--- a/Runtime/GameObjectLists.hpp
+++ b/Runtime/GameObjectLists.hpp
@@ -8,39 +8,38 @@ class CActorList : public CObjectList {
 public:
   CActorList();
 
-  bool IsQualified(const CEntity&);
+  bool IsQualified(const CEntity&) override;
 };
 
 class CPhysicsActorList : public CObjectList {
 public:
   CPhysicsActorList();
-  bool IsQualified(const CEntity&);
+  bool IsQualified(const CEntity&) override;
 };
 
 class CGameCameraList : public CObjectList {
 public:
   CGameCameraList();
-  bool IsQualified(const CEntity&);
+  bool IsQualified(const CEntity&) override;
 };
 
 class CListeningAiList : public CObjectList {
 public:
   CListeningAiList();
-
-  bool IsQualified(const CEntity&);
+  bool IsQualified(const CEntity&) override;
 };
 
 class CAiWaypointList : public CObjectList {
 public:
   CAiWaypointList();
-  bool IsQualified(const CEntity&);
+  bool IsQualified(const CEntity&) override;
 };
 
 class CPlatformAndDoorList : public CObjectList {
 public:
   CPlatformAndDoorList();
 
-  bool IsQualified(const CEntity&);
+  bool IsQualified(const CEntity&) override;
   bool IsDoor(const CEntity&);
   bool IsPlatform(const CEntity&);
 };
@@ -49,7 +48,7 @@ class CGameLightList : public CObjectList {
 public:
   CGameLightList();
 
-  bool IsQualified(const CEntity&);
+  bool IsQualified(const CEntity&) override;
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CAuiEnergyBarT01.hpp
+++ b/Runtime/GuiSys/CAuiEnergyBarT01.hpp
@@ -36,10 +36,10 @@ private:
 
 public:
   CAuiEnergyBarT01(const CGuiWidgetParms& parms, CSimplePool* sp, CAssetId txtrId);
-  FourCC GetWidgetTypeID() const { return FOURCC('ENRG'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('ENRG'); }
   static std::pair<zeus::CVector3f, zeus::CVector3f> DownloadBarCoordFunc(float t);
-  void Update(float dt);
-  void Draw(const CGuiWidgetDrawParms& drawParms) const;
+  void Update(float dt) override;
+  void Draw(const CGuiWidgetDrawParms& drawParms) const override;
   float GetActualFraction() const { return xe0_maxEnergy == 0.f ? 0.f : xf4_setEnergy / xe0_maxEnergy; }
   float GetSetEnergy() const { return xf4_setEnergy; }
   float GetMaxEnergy() const { return xe0_maxEnergy; }

--- a/Runtime/GuiSys/CAuiImagePane.hpp
+++ b/Runtime/GuiSys/CAuiImagePane.hpp
@@ -38,13 +38,13 @@ public:
   CAuiImagePane(const CGuiWidgetParms& parms, CSimplePool* sp, CAssetId, CAssetId,
                 rstl::reserved_vector<zeus::CVector3f, 4>&& coords, rstl::reserved_vector<zeus::CVector2f, 4>&& uvs,
                 bool initTex);
-  FourCC GetWidgetTypeID() const { return FOURCC('IMGP'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('IMGP'); }
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 
-  void Reset(ETraversalMode mode);
-  void Update(float dt);
-  void Draw(const CGuiWidgetDrawParms& params) const;
-  bool GetIsFinishedLoadingWidgetSpecific() const;
+  void Reset(ETraversalMode mode) override;
+  void Update(float dt) override;
+  void Draw(const CGuiWidgetDrawParms& params) const override;
+  bool GetIsFinishedLoadingWidgetSpecific() const override;
   void SetTextureID0(CAssetId tex, CSimplePool* sp);
   void SetAnimationParms(const zeus::CVector2f& vec, float interval, float duration);
   void SetDeResFactor(float d) { x14c_deResFactor = d; }

--- a/Runtime/GuiSys/CAuiMeter.hpp
+++ b/Runtime/GuiSys/CAuiMeter.hpp
@@ -15,14 +15,14 @@ class CAuiMeter : public CGuiGroup {
 
 public:
   CAuiMeter(const CGuiWidgetParms& parms, bool noRoundUp, u32 maxCapacity, u32 workerCount);
-  FourCC GetWidgetTypeID() const { return FOURCC('METR'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('METR'); }
 
-  void OnVisibleChange();
+  void OnVisibleChange() override;
   void SetCurrValue(s32 val);
   void SetCapacity(s32 cap);
   void SetMaxCapacity(s32 cap);
-  CGuiWidget* GetWorkerWidget(int id) const;
-  bool AddWorkerWidget(CGuiWidget* worker);
+  CGuiWidget* GetWorkerWidget(int id) const override;
+  bool AddWorkerWidget(CGuiWidget* worker) override;
 
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 };

--- a/Runtime/GuiSys/CConsoleOutputWindow.hpp
+++ b/Runtime/GuiSys/CConsoleOutputWindow.hpp
@@ -7,8 +7,8 @@ namespace urde {
 class CConsoleOutputWindow : public CIOWin {
 public:
   CConsoleOutputWindow(int, float, float);
-  EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&);
-  void Draw() const;
+  EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
+  void Draw() const override;
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CErrorOutputWindow.hpp
+++ b/Runtime/GuiSys/CErrorOutputWindow.hpp
@@ -25,9 +25,9 @@ private:
 
 public:
   CErrorOutputWindow(bool);
-  EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&);
-  bool GetIsContinueDraw() const { return int(x14_state) < 2; }
-  void Draw() const;
+  EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
+  bool GetIsContinueDraw() const override { return int(x14_state) < 2; }
+  void Draw() const override;
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CGuiCamera.hpp
+++ b/Runtime/GuiSys/CGuiCamera.hpp
@@ -38,14 +38,14 @@ private:
 public:
   CGuiCamera(const CGuiWidgetParms& parms, float left, float right, float top, float bottom, float znear, float zfar);
   CGuiCamera(const CGuiWidgetParms& parms, float fov, float aspect, float znear, float zfar);
-  FourCC GetWidgetTypeID() const { return FOURCC('CAMR'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('CAMR'); }
 
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 
   zeus::CVector3f ConvertToScreenSpace(const zeus::CVector3f& vec) const;
   const SProjection& GetProjection() const { return m_proj; }
   void SetFov(float fov) { m_proj.xbc_fov = fov; }
-  void Draw(const CGuiWidgetDrawParms& parms) const;
+  void Draw(const CGuiWidgetDrawParms& parms) const override;
 
   std::shared_ptr<CGuiCamera> shared_from_this() {
     return std::static_pointer_cast<CGuiCamera>(CGuiObject::shared_from_this());

--- a/Runtime/GuiSys/CGuiCompoundWidget.hpp
+++ b/Runtime/GuiSys/CGuiCompoundWidget.hpp
@@ -7,10 +7,10 @@ namespace urde {
 class CGuiCompoundWidget : public CGuiWidget {
 public:
   CGuiCompoundWidget(const CGuiWidgetParms& parms);
-  FourCC GetWidgetTypeID() const { return FourCC(-1); }
+  FourCC GetWidgetTypeID() const override { return FourCC(-1); }
 
-  void OnVisibleChange();
-  void OnActiveChange();
+  void OnVisibleChange() override;
+  void OnActiveChange() override;
   virtual CGuiWidget* GetWorkerWidget(int id) const;
 };
 

--- a/Runtime/GuiSys/CGuiGroup.hpp
+++ b/Runtime/GuiSys/CGuiGroup.hpp
@@ -11,12 +11,12 @@ class CGuiGroup : public CGuiCompoundWidget {
 
 public:
   CGuiGroup(const CGuiWidgetParms& parms, int defaultWorker, bool b);
-  FourCC GetWidgetTypeID() const { return FOURCC('GRUP'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('GRUP'); }
 
   void SelectWorkerWidget(int workerId, bool setActive, bool setVisible);
   CGuiWidget* GetSelectedWidget();
-  bool AddWorkerWidget(CGuiWidget* worker);
-  void OnActiveChange();
+  bool AddWorkerWidget(CGuiWidget* worker) override;
+  void OnActiveChange() override;
 
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
   static void LoadWidgetFnMap();

--- a/Runtime/GuiSys/CGuiHeadWidget.hpp
+++ b/Runtime/GuiSys/CGuiHeadWidget.hpp
@@ -6,7 +6,7 @@ namespace urde {
 
 class CGuiHeadWidget : public CGuiWidget {
 public:
-  FourCC GetWidgetTypeID() const { return FOURCC('HWIG'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('HWIG'); }
   CGuiHeadWidget(const CGuiWidgetParms& parms);
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 

--- a/Runtime/GuiSys/CGuiLight.hpp
+++ b/Runtime/GuiSys/CGuiLight.hpp
@@ -19,12 +19,12 @@ class CGuiLight : public CGuiWidget {
   zeus::CColor xdc_ambColor = zeus::skBlack;
 
 public:
-  ~CGuiLight();
+  ~CGuiLight() override;
   CGuiLight(const CGuiWidgetParms& parms, const CLight& light);
-  FourCC GetWidgetTypeID() const { return FOURCC('LITE'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('LITE'); }
 
   CLight BuildLight() const;
-  void SetIsVisible(bool vis);
+  void SetIsVisible(bool vis) override;
   u32 GetLightId() const { return xd8_lightId; }
   const zeus::CColor& GetAmbientLightColor() const { return xdc_ambColor; }
   void SetSpotCutoff(float v) { xbc_spotCutoff = v; }

--- a/Runtime/GuiSys/CGuiModel.hpp
+++ b/Runtime/GuiSys/CGuiModel.hpp
@@ -14,14 +14,14 @@ class CGuiModel : public CGuiWidget {
 
 public:
   CGuiModel(const CGuiWidgetParms& parms, CSimplePool* sp, CAssetId modelId, u32 lightMask, bool flag);
-  FourCC GetWidgetTypeID() const { return FOURCC('MODL'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('MODL'); }
 
   std::vector<CAssetId> GetModelAssets() const { return {xc8_modelId}; }
   const TLockedToken<CModel>& GetModel() const { return xb8_model; }
-  bool GetIsFinishedLoadingWidgetSpecific() const;
-  void Touch() const;
-  void Draw(const CGuiWidgetDrawParms& parms) const;
-  bool TestCursorHit(const zeus::CMatrix4f& vp, const zeus::CVector2f& point) const;
+  bool GetIsFinishedLoadingWidgetSpecific() const override;
+  void Touch() const override;
+  void Draw(const CGuiWidgetDrawParms& parms) const override;
+  bool TestCursorHit(const zeus::CMatrix4f& vp, const zeus::CVector2f& point) const override;
 
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 };

--- a/Runtime/GuiSys/CGuiPane.hpp
+++ b/Runtime/GuiSys/CGuiPane.hpp
@@ -17,7 +17,7 @@ protected:
 
 public:
   CGuiPane(const CGuiWidgetParms& parms, const zeus::CVector2f& dim, const zeus::CVector3f& scaleCenter);
-  FourCC GetWidgetTypeID() const { return FOURCC('PANE'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('PANE'); }
 
   virtual void ScaleDimensions(const zeus::CVector3f& scale);
   virtual void SetDimensions(const zeus::CVector2f& dim, bool initVBO);

--- a/Runtime/GuiSys/CGuiSliderGroup.hpp
+++ b/Runtime/GuiSys/CGuiSliderGroup.hpp
@@ -35,7 +35,7 @@ private:
 
 public:
   CGuiSliderGroup(const CGuiWidgetParms& parms, float a, float b, float c, float d);
-  FourCC GetWidgetTypeID() const { return FOURCC('SLGP'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('SLGP'); }
 
   EState GetState() const { return xf0_state; }
   void SetSelectionChangedCallback(std::function<void(CGuiSliderGroup*, float)>&& func);
@@ -51,13 +51,13 @@ public:
   void SetCurVal(float cur);
   float GetGurVal() const { return xc0_roundedCurVal; }
 
-  bool TestCursorHit(const zeus::CMatrix4f& vp, const zeus::CVector2f& point) const;
+  bool TestCursorHit(const zeus::CMatrix4f& vp, const zeus::CVector2f& point) const override;
 
-  void ProcessUserInput(const CFinalInput& input);
-  void Update(float dt);
+  void ProcessUserInput(const CFinalInput& input) override;
+  void Update(float dt) override;
 
-  bool AddWorkerWidget(CGuiWidget* worker);
-  CGuiWidget* GetWorkerWidget(int id) const;
+  bool AddWorkerWidget(CGuiWidget* worker) override;
+  CGuiWidget* GetWorkerWidget(int id) const override;
 
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 };

--- a/Runtime/GuiSys/CGuiTableGroup.hpp
+++ b/Runtime/GuiSys/CGuiTableGroup.hpp
@@ -45,7 +45,7 @@ private:
 
 public:
   CGuiTableGroup(const CGuiWidgetParms& parms, int, int, bool);
-  FourCC GetWidgetTypeID() const { return FOURCC('TBGP'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('TBGP'); }
 
   void SetMenuAdvanceCallback(std::function<void(CGuiTableGroup*)>&& cb) { xd4_doMenuAdvance = std::move(cb); }
 
@@ -84,9 +84,9 @@ public:
 
   void SetWorkersMouseActive(bool);
 
-  void ProcessUserInput(const CFinalInput& input);
+  void ProcessUserInput(const CFinalInput& input) override;
 
-  bool AddWorkerWidget(CGuiWidget* worker) { return true; }
+  bool AddWorkerWidget(CGuiWidget* worker) override { return true; }
 
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 };

--- a/Runtime/GuiSys/CGuiTextPane.hpp
+++ b/Runtime/GuiSys/CGuiTextPane.hpp
@@ -12,17 +12,17 @@ public:
   CGuiTextPane(const CGuiWidgetParms& parms, CSimplePool* sp, const zeus::CVector2f& dim, const zeus::CVector3f& vec,
                CAssetId fontId, const CGuiTextProperties& props, const zeus::CColor& col1, const zeus::CColor& col2,
                s32 padX, s32 padY);
-  FourCC GetWidgetTypeID() const { return FOURCC('TXPN'); }
+  FourCC GetWidgetTypeID() const override { return FOURCC('TXPN'); }
 
   CGuiTextSupport& TextSupport() { return xd4_textSupport; }
   const CGuiTextSupport& GetTextSupport() const { return xd4_textSupport; }
-  void Update(float dt);
-  bool GetIsFinishedLoadingWidgetSpecific() const;
+  void Update(float dt) override;
+  bool GetIsFinishedLoadingWidgetSpecific() const override;
   std::vector<CAssetId> GetFontAssets() const { return {xd4_textSupport.x5c_fontId}; }
-  void SetDimensions(const zeus::CVector2f& dim, bool initVBO);
-  void ScaleDimensions(const zeus::CVector3f& scale);
-  void Draw(const CGuiWidgetDrawParms& parms) const;
-  bool TestCursorHit(const zeus::CMatrix4f& vp, const zeus::CVector2f& point) const;
+  void SetDimensions(const zeus::CVector2f& dim, bool initVBO) override;
+  void ScaleDimensions(const zeus::CVector3f& scale) override;
+  void Draw(const CGuiWidgetDrawParms& parms) const override;
+  bool TestCursorHit(const zeus::CMatrix4f& vp, const zeus::CVector2f& point) const override;
 
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 };

--- a/Runtime/GuiSys/CGuiWidget.hpp
+++ b/Runtime/GuiSys/CGuiWidget.hpp
@@ -86,10 +86,11 @@ public:
   static CGuiWidgetParms ReadWidgetHeader(CGuiFrame* frame, CInputStream& in);
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 
+  void Update(float dt) override;
+  void Draw(const CGuiWidgetDrawParms& drawParms) const override;
+  void Initialize() override;
+
   virtual void Reset(ETraversalMode mode);
-  virtual void Update(float dt);
-  virtual void Draw(const CGuiWidgetDrawParms& drawParms) const;
-  virtual void Initialize();
   virtual void ProcessUserInput(const CFinalInput& input);
   virtual void Touch() const;
   virtual bool GetIsVisible() const;

--- a/Runtime/GuiSys/CHudDecoInterface.hpp
+++ b/Runtime/GuiSys/CHudDecoInterface.hpp
@@ -53,15 +53,15 @@ class CHudDecoInterfaceCombat : public IHudDecoInterface {
 
 public:
   CHudDecoInterfaceCombat(CGuiFrame& selHud);
-  void SetIsVisibleDebug(bool v);
-  void SetIsVisibleGame(bool v);
-  void SetHudRotation(const zeus::CQuaternion& rot);
-  void SetHudOffset(const zeus::CVector3f& off);
-  void SetDamageTransform(const zeus::CMatrix3f& rotation, const zeus::CVector3f& position);
-  void SetFrameColorValue(float v);
-  void Update(float dt, const CStateManager& stateMgr);
-  void UpdateCameraDebugSettings(float fov, float y, float z);
-  void UpdateHudAlpha();
+  void SetIsVisibleDebug(bool v) override;
+  void SetIsVisibleGame(bool v) override;
+  void SetHudRotation(const zeus::CQuaternion& rot) override;
+  void SetHudOffset(const zeus::CVector3f& off) override;
+  void SetDamageTransform(const zeus::CMatrix3f& rotation, const zeus::CVector3f& position) override;
+  void SetFrameColorValue(float v) override;
+  void Update(float dt, const CStateManager& stateMgr) override;
+  void UpdateCameraDebugSettings(float fov, float y, float z) override;
+  void UpdateHudAlpha() override;
 };
 
 class CHudDecoInterfaceScan : public IHudDecoInterface {
@@ -104,22 +104,22 @@ class CHudDecoInterfaceScan : public IHudDecoInterface {
 
 public:
   CHudDecoInterfaceScan(CGuiFrame& selHud);
-  void SetIsVisibleDebug(bool v);
-  void SetIsVisibleGame(bool v);
-  void SetHudRotation(const zeus::CQuaternion& rot);
-  void SetHudOffset(const zeus::CVector3f& off);
-  void SetReticuleTransform(const zeus::CMatrix3f& xf);
-  void SetDamageTransform(const zeus::CMatrix3f& rotation, const zeus::CVector3f& position);
-  void SetFrameColorValue(float v);
+  void SetIsVisibleDebug(bool v) override;
+  void SetIsVisibleGame(bool v) override;
+  void SetHudRotation(const zeus::CQuaternion& rot) override;
+  void SetHudOffset(const zeus::CVector3f& off) override;
+  void SetReticuleTransform(const zeus::CMatrix3f& xf) override;
+  void SetDamageTransform(const zeus::CMatrix3f& rotation, const zeus::CVector3f& position) override;
+  void SetFrameColorValue(float v) override;
   void InitializeFlatFrame();
   const CScannableObjectInfo* GetCurrScanInfo(const CStateManager& stateMgr) const;
   void UpdateScanDisplay(const CStateManager& stateMgr, float dt);
-  void Update(float dt, const CStateManager& stateMgr);
-  void Draw() const;
-  void ProcessInput(const CFinalInput& input);
-  void UpdateCameraDebugSettings(float fov, float y, float z);
-  void UpdateHudAlpha();
-  float GetHudTextAlpha() const;
+  void Update(float dt, const CStateManager& stateMgr) override;
+  void Draw() const override;
+  void ProcessInput(const CFinalInput& input) override;
+  void UpdateCameraDebugSettings(float fov, float y, float z) override;
+  void UpdateHudAlpha() override;
+  float GetHudTextAlpha() const override;
 };
 
 class CHudDecoInterfaceXRay : public IHudDecoInterface {
@@ -142,17 +142,17 @@ class CHudDecoInterfaceXRay : public IHudDecoInterface {
 
 public:
   CHudDecoInterfaceXRay(CGuiFrame& selHud);
-  void SetIsVisibleDebug(bool v);
-  void SetIsVisibleGame(bool v);
-  void SetHudRotation(const zeus::CQuaternion& rot);
-  void SetHudOffset(const zeus::CVector3f& off);
-  void SetReticuleTransform(const zeus::CMatrix3f& xf);
-  void SetDecoRotation(float angle);
-  void SetDamageTransform(const zeus::CMatrix3f& rotation, const zeus::CVector3f& position);
-  void SetFrameColorValue(float v);
-  void Update(float dt, const CStateManager& stateMgr);
-  void UpdateCameraDebugSettings(float fov, float y, float z);
-  void UpdateHudAlpha();
+  void SetIsVisibleDebug(bool v) override;
+  void SetIsVisibleGame(bool v) override;
+  void SetHudRotation(const zeus::CQuaternion& rot) override;
+  void SetHudOffset(const zeus::CVector3f& off) override;
+  void SetReticuleTransform(const zeus::CMatrix3f& xf) override;
+  void SetDecoRotation(float angle) override;
+  void SetDamageTransform(const zeus::CMatrix3f& rotation, const zeus::CVector3f& position) override;
+  void SetFrameColorValue(float v) override;
+  void Update(float dt, const CStateManager& stateMgr) override;
+  void UpdateCameraDebugSettings(float fov, float y, float z) override;
+  void UpdateHudAlpha() override;
 };
 
 class CHudDecoInterfaceThermal : public IHudDecoInterface {
@@ -175,15 +175,15 @@ class CHudDecoInterfaceThermal : public IHudDecoInterface {
 
 public:
   CHudDecoInterfaceThermal(CGuiFrame& selHud);
-  void SetIsVisibleDebug(bool v);
-  void SetIsVisibleGame(bool v);
-  void SetHudRotation(const zeus::CQuaternion& rot);
-  void SetHudOffset(const zeus::CVector3f& off);
-  void SetReticuleTransform(const zeus::CMatrix3f& xf);
-  void SetDamageTransform(const zeus::CMatrix3f& rotation, const zeus::CVector3f& position);
-  void Update(float dt, const CStateManager& stateMgr);
-  void UpdateCameraDebugSettings(float fov, float y, float z);
-  void UpdateHudAlpha();
+  void SetIsVisibleDebug(bool v) override;
+  void SetIsVisibleGame(bool v) override;
+  void SetHudRotation(const zeus::CQuaternion& rot) override;
+  void SetHudOffset(const zeus::CVector3f& off) override;
+  void SetReticuleTransform(const zeus::CMatrix3f& xf) override;
+  void SetDamageTransform(const zeus::CMatrix3f& rotation, const zeus::CVector3f& position) override;
+  void Update(float dt, const CStateManager& stateMgr) override;
+  void UpdateCameraDebugSettings(float fov, float y, float z) override;
+  void UpdateHudAlpha() override;
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CHudFreeLookInterface.hpp
+++ b/Runtime/GuiSys/CHudFreeLookInterface.hpp
@@ -45,10 +45,10 @@ class CHudFreeLookInterface : public IFreeLookInterface {
 
 public:
   CHudFreeLookInterface(CGuiFrame& selHud, EHudType hudType, bool inFreeLook, bool lookControlHeld, bool lockedOnObj);
-  void Update(float dt);
-  void SetIsVisibleDebug(bool v);
-  void SetIsVisibleGame(bool v);
-  void SetFreeLookState(bool inFreeLook, bool lookControlHeld, bool lockedOnObj, float vertLookAngle);
+  void Update(float dt) override;
+  void SetIsVisibleDebug(bool v) override;
+  void SetIsVisibleGame(bool v) override;
+  void SetFreeLookState(bool inFreeLook, bool lookControlHeld, bool lockedOnObj, float vertLookAngle) override;
 };
 
 class CHudFreeLookInterfaceXRay : public IFreeLookInterface {
@@ -67,10 +67,10 @@ class CHudFreeLookInterfaceXRay : public IFreeLookInterface {
 
 public:
   CHudFreeLookInterfaceXRay(CGuiFrame& selHud, bool inFreeLook, bool lookControlHeld, bool lockedOnObj);
-  void Update(float dt);
-  void SetIsVisibleDebug(bool v);
-  void SetIsVisibleGame(bool v);
-  void SetFreeLookState(bool inFreeLook, bool lookControlHeld, bool lockedOnObj, float vertLookAngle);
+  void Update(float dt) override;
+  void SetIsVisibleDebug(bool v) override;
+  void SetIsVisibleGame(bool v) override;
+  void SetFreeLookState(bool inFreeLook, bool lookControlHeld, bool lockedOnObj, float vertLookAngle) override;
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CInstruction.hpp
+++ b/Runtime/GuiSys/CInstruction.hpp
@@ -25,8 +25,8 @@ class CColorInstruction : public CInstruction {
 
 public:
   CColorInstruction(EColorType tp, const CTextColor& color) : x4_cType(tp), x8_color(color) {}
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 class CColorOverrideInstruction : public CInstruction {
@@ -35,8 +35,8 @@ class CColorOverrideInstruction : public CInstruction {
 
 public:
   CColorOverrideInstruction(int idx, const CTextColor& color) : x4_overrideIdx(idx), x8_color(color) {}
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 class CFontInstruction : public CInstruction {
@@ -44,10 +44,10 @@ class CFontInstruction : public CInstruction {
 
 public:
   CFontInstruction(const TToken<CRasterFont>& font) : x4_font(font) {}
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void GetAssets(std::vector<CToken>& assetsOut) const;
-  size_t GetAssetCount() const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void GetAssets(std::vector<CToken>& assetsOut) const override;
+  size_t GetAssetCount() const override;
 };
 
 class CLineExtraSpaceInstruction : public CInstruction {
@@ -55,8 +55,8 @@ class CLineExtraSpaceInstruction : public CInstruction {
 
 public:
   CLineExtraSpaceInstruction(s32 extraSpace) : x4_extraSpace(extraSpace) {}
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 class CLineInstruction : public CInstruction {
@@ -84,8 +84,8 @@ public:
   void TestLargestFont(s32 w, s32 h, s32 b);
   void TestLargestImage(s32 w, s32 h, s32 b);
   void InvokeLTR(CFontRenderState& state) const;
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 
   s32 GetHeight() const {
     if (x10_largestMonoHeight && !x30_imageBaseline)
@@ -107,20 +107,20 @@ class CLineSpacingInstruction : public CInstruction {
 
 public:
   CLineSpacingInstruction(float spacing) : x4_lineSpacing(spacing) {}
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 class CPopStateInstruction : public CInstruction {
 public:
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 class CPushStateInstruction : public CInstruction {
 public:
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 class CRemoveColorOverrideInstruction : public CInstruction {
@@ -128,8 +128,8 @@ class CRemoveColorOverrideInstruction : public CInstruction {
 
 public:
   CRemoveColorOverrideInstruction(int idx) : x4_idx(idx) {}
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 class CImageInstruction : public CInstruction {
@@ -137,16 +137,16 @@ class CImageInstruction : public CInstruction {
 
 public:
   CImageInstruction(const CFontImageDef& image) : x4_image(image) {}
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void GetAssets(std::vector<CToken>& assetsOut) const;
-  size_t GetAssetCount() const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void GetAssets(std::vector<CToken>& assetsOut) const override;
+  size_t GetAssetCount() const override;
 };
 
 class CTextInstruction : public CInstruction {
   std::u16string x4_str; /* used to be a placement-new sized allocation */
 public:
   CTextInstruction(const char16_t* str, int len) : x4_str(str, len) {}
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 class CBlockInstruction : public CInstruction {
@@ -182,15 +182,15 @@ public:
   , x1c_vertJustification(vjust) {}
   void TestLargestFont(s32 monoW, s32 monoH, s32 baseline);
   void SetupPositionLTR(CFontRenderState& state) const;
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 class CWordInstruction : public CInstruction {
 public:
   void InvokeLTR(CFontRenderState& state) const;
-  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
-  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const;
+  void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
+  void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CSplashScreen.hpp
+++ b/Runtime/GuiSys/CSplashScreen.hpp
@@ -23,8 +23,8 @@ private:
 
 public:
   CSplashScreen(ESplashScreen);
-  EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&);
-  void Draw() const;
+  EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
+  void Draw() const override;
 };
 
 } // namespace urde

--- a/Runtime/IOStreams.hpp
+++ b/Runtime/IOStreams.hpp
@@ -46,7 +46,7 @@ public:
 
   void Flush();
 
-  ~CBitStreamWriter() { Flush(); }
+  ~CBitStreamWriter() override { Flush(); }
 };
 
 using CMemoryInStream = athena::io::MemoryReader;
@@ -60,11 +60,11 @@ class CZipInputStream : public CInputStream {
 
 public:
   CZipInputStream(std::unique_ptr<CInputStream>&& strm);
-  ~CZipInputStream();
-  atUint64 readUBytesToBuf(void* buf, atUint64 len);
-  void seek(atInt64, athena::SeekOrigin) {}
-  atUint64 position() const { return 0; }
-  atUint64 length() const { return 0; }
+  ~CZipInputStream() override;
+  atUint64 readUBytesToBuf(void* buf, atUint64 len) override;
+  void seek(atInt64, athena::SeekOrigin) override {}
+  atUint64 position() const override { return 0; }
+  atUint64 length() const override { return 0; }
 };
 #endif
 

--- a/Runtime/IObj.hpp
+++ b/Runtime/IObj.hpp
@@ -25,7 +25,7 @@ public:
   static std::unique_ptr<TObjOwnerDerivedFromIObj<T>> GetNewDerivedObject(std::unique_ptr<T>&& obj) {
     return std::unique_ptr<TObjOwnerDerivedFromIObj<T>>(new TObjOwnerDerivedFromIObj<T>(obj.release()));
   }
-  ~TObjOwnerDerivedFromIObj() { std::default_delete<T>()(static_cast<T*>(m_objPtr)); }
+  ~TObjOwnerDerivedFromIObj() override { std::default_delete<T>()(static_cast<T*>(m_objPtr)); }
   T* GetObj() { return static_cast<T*>(m_objPtr); }
 };
 

--- a/Runtime/IVParamObj.hpp
+++ b/Runtime/IVParamObj.hpp
@@ -7,7 +7,7 @@ namespace urde {
 
 class IVParamObj : public IObj {
 public:
-  virtual ~IVParamObj() {}
+  ~IVParamObj() override = default;
 };
 
 template <class T>

--- a/Runtime/Input/CInputGenerator.hpp
+++ b/Runtime/Input/CInputGenerator.hpp
@@ -34,7 +34,7 @@ public:
   CInputGenerator(float leftDiv, float rightDiv)
   : boo::DeviceFinder({dev_typeid(DolphinSmashAdapter)}), m_leftDiv(leftDiv), m_rightDiv(rightDiv) {}
 
-  ~CInputGenerator() {
+  ~CInputGenerator() override {
     if (smashAdapter)
       smashAdapter->setCallback(nullptr);
   }
@@ -81,17 +81,18 @@ public:
     bool m_connected[4] = {};
     boo::DolphinControllerState m_states[4];
     std::mutex m_stateLock;
-    void controllerConnected(unsigned idx, boo::EDolphinControllerType) {
+    void controllerConnected(unsigned idx, boo::EDolphinControllerType) override {
       /* Controller thread */
       m_statusChanges[idx].store(EStatusChange::Connected);
     }
-    void controllerDisconnected(unsigned idx) {
+    void controllerDisconnected(unsigned idx) override {
       /* Controller thread */
       std::unique_lock<std::mutex> lk(m_stateLock);
       m_statusChanges[idx].store(EStatusChange::Disconnected);
       m_states[idx].reset();
     }
-    void controllerUpdate(unsigned idx, boo::EDolphinControllerType, const boo::DolphinControllerState& state) {
+    void controllerUpdate(unsigned idx, boo::EDolphinControllerType,
+                          const boo::DolphinControllerState& state) override {
       /* Controller thread */
       std::unique_lock<std::mutex> lk(m_stateLock);
       m_states[idx] = state;
@@ -124,7 +125,7 @@ public:
    * received. Device pointers should only be manipulated by this thread using
    * the deviceConnected() and deviceDisconnected() callbacks. */
   std::shared_ptr<boo::DolphinSmashAdapter> smashAdapter;
-  void deviceConnected(boo::DeviceToken& tok) {
+  void deviceConnected(boo::DeviceToken& tok) override {
     /* Device listener thread */
     if (!smashAdapter) {
       auto dev = tok.openAndGetDevice();
@@ -134,7 +135,7 @@ public:
       }
     }
   }
-  void deviceDisconnected(boo::DeviceToken&, boo::DeviceBase* device) {
+  void deviceDisconnected(boo::DeviceToken&, boo::DeviceBase* device) override {
     if (smashAdapter.get() == device)
       smashAdapter.reset();
   }

--- a/Runtime/Particle/CColorElement.hpp
+++ b/Runtime/Particle/CColorElement.hpp
@@ -17,7 +17,7 @@ class CCEKeyframeEmitter : public CColorElement {
 
 public:
   CCEKeyframeEmitter(CInputStream& in);
-  bool GetValue(int frame, zeus::CColor& colorOut) const;
+  bool GetValue(int frame, zeus::CColor& colorOut) const override;
 };
 
 class CCEConstant : public CColorElement {
@@ -30,7 +30,7 @@ public:
   CCEConstant(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b, std::unique_ptr<CRealElement>&& c,
               std::unique_ptr<CRealElement>&& d)
   : x4_r(std::move(a)), x8_g(std::move(b)), xc_b(std::move(c)), x10_a(std::move(d)) {}
-  bool GetValue(int frame, zeus::CColor& colorOut) const;
+  bool GetValue(int frame, zeus::CColor& colorOut) const override;
 };
 
 class CCEFastConstant : public CColorElement {
@@ -38,7 +38,7 @@ class CCEFastConstant : public CColorElement {
 
 public:
   CCEFastConstant(float a, float b, float c, float d) : x4_val(a, b, c, d) {}
-  bool GetValue(int frame, zeus::CColor& colorOut) const;
+  bool GetValue(int frame, zeus::CColor& colorOut) const override;
 };
 
 class CCETimeChain : public CColorElement {
@@ -49,7 +49,7 @@ class CCETimeChain : public CColorElement {
 public:
   CCETimeChain(std::unique_ptr<CColorElement>&& a, std::unique_ptr<CColorElement>&& b, std::unique_ptr<CIntElement>&& c)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_swFrame(std::move(c)) {}
-  bool GetValue(int frame, zeus::CColor& colorOut) const;
+  bool GetValue(int frame, zeus::CColor& colorOut) const override;
 };
 
 class CCEFadeEnd : public CColorElement {
@@ -62,7 +62,7 @@ public:
   CCEFadeEnd(std::unique_ptr<CColorElement>&& a, std::unique_ptr<CColorElement>&& b, std::unique_ptr<CRealElement>&& c,
              std::unique_ptr<CRealElement>&& d)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_startFrame(std::move(c)), x10_endFrame(std::move(d)) {}
-  bool GetValue(int frame, zeus::CColor& colorOut) const;
+  bool GetValue(int frame, zeus::CColor& colorOut) const override;
 };
 
 class CCEFade : public CColorElement {
@@ -73,7 +73,7 @@ class CCEFade : public CColorElement {
 public:
   CCEFade(std::unique_ptr<CColorElement>&& a, std::unique_ptr<CColorElement>&& b, std::unique_ptr<CRealElement>&& c)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_endFrame(std::move(c)) {}
-  bool GetValue(int frame, zeus::CColor& colorOut) const;
+  bool GetValue(int frame, zeus::CColor& colorOut) const override;
 };
 
 class CCEPulse : public CColorElement {
@@ -86,11 +86,11 @@ public:
   CCEPulse(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b, std::unique_ptr<CColorElement>&& c,
            std::unique_ptr<CColorElement>&& d)
   : x4_aDuration(std::move(a)), x8_bDuration(std::move(b)), xc_aVal(std::move(c)), x10_bVal(std::move(d)) {}
-  bool GetValue(int frame, zeus::CColor& colorOut) const;
+  bool GetValue(int frame, zeus::CColor& colorOut) const override;
 };
 
 class CCEParticleColor : public CColorElement {
 public:
-  bool GetValue(int frame, zeus::CColor& colorOut) const;
+  bool GetValue(int frame, zeus::CColor& colorOut) const override;
 };
 } // namespace urde

--- a/Runtime/Particle/CElementGen.hpp
+++ b/Runtime/Particle/CElementGen.hpp
@@ -142,7 +142,7 @@ private:
 public:
   CElementGen(const TToken<CGenDescription>& gen, EModelOrientationType orientType = EModelOrientationType::Normal,
               EOptionalSystemFlags flags = EOptionalSystemFlags::One);
-  ~CElementGen();
+  ~CElementGen() override;
 
   boo::ObjToken<boo::IShaderDataBinding> m_normalDataBind[2];
   boo::ObjToken<boo::IShaderDataBinding> m_normalSubDataBind[2];
@@ -191,34 +191,34 @@ public:
   void RenderParticles();
   void RenderParticlesIndirectTexture();
 
-  bool Update(double);
-  void Render(const CActorLights* = nullptr);
-  void SetOrientation(const zeus::CTransform&);
-  void SetTranslation(const zeus::CVector3f&);
-  void SetGlobalOrientation(const zeus::CTransform&);
-  void SetGlobalTranslation(const zeus::CVector3f&);
-  void SetGlobalScale(const zeus::CVector3f&);
-  void SetLocalScale(const zeus::CVector3f&);
+  bool Update(double) override;
+  void Render(const CActorLights* = nullptr) override;
+  void SetOrientation(const zeus::CTransform&) override;
+  void SetTranslation(const zeus::CVector3f&) override;
+  void SetGlobalOrientation(const zeus::CTransform&) override;
+  void SetGlobalTranslation(const zeus::CVector3f&) override;
+  void SetGlobalScale(const zeus::CVector3f&) override;
+  void SetLocalScale(const zeus::CVector3f&) override;
   void SetGlobalOrientAndTrans(const zeus::CTransform& xf);
-  void SetParticleEmission(bool);
-  void SetModulationColor(const zeus::CColor&);
-  void SetGeneratorRate(float rate);
-  const zeus::CTransform& GetOrientation() const;
-  const zeus::CVector3f& GetTranslation() const;
-  const zeus::CTransform& GetGlobalOrientation() const;
-  const zeus::CVector3f& GetGlobalTranslation() const;
-  const zeus::CVector3f& GetGlobalScale() const;
-  const zeus::CColor& GetModulationColor() const;
-  float GetGeneratorRate() const { return x98_generatorRate; }
-  bool IsSystemDeletable() const;
-  std::optional<zeus::CAABox> GetBounds() const;
-  u32 GetParticleCount() const;
-  bool SystemHasLight() const;
-  CLight GetLight() const;
-  bool GetParticleEmission() const;
-  void DestroyParticles();
-  void Reset();
-  FourCC Get4CharId() const { return FOURCC('PART'); }
+  void SetParticleEmission(bool) override;
+  void SetModulationColor(const zeus::CColor&) override;
+  void SetGeneratorRate(float rate) override;
+  const zeus::CTransform& GetOrientation() const override;
+  const zeus::CVector3f& GetTranslation() const override;
+  const zeus::CTransform& GetGlobalOrientation() const override;
+  const zeus::CVector3f& GetGlobalTranslation() const override;
+  const zeus::CVector3f& GetGlobalScale() const override;
+  const zeus::CColor& GetModulationColor() const override;
+  float GetGeneratorRate() const override { return x98_generatorRate; }
+  bool IsSystemDeletable() const override;
+  std::optional<zeus::CAABox> GetBounds() const override;
+  u32 GetParticleCount() const override;
+  bool SystemHasLight() const override;
+  CLight GetLight() const override;
+  bool GetParticleEmission() const override;
+  void DestroyParticles() override;
+  void Reset() override;
+  FourCC Get4CharId() const override { return FOURCC('PART'); }
   size_t GetNumActiveChildParticles() const { return x290_activePartChildren.size(); }
   CParticleGen& GetActiveChildParticle(size_t idx) const { return *x290_activePartChildren[idx]; }
   bool IsIndirectTextured() const { return x28_loadedGenDesc->x54_x40_TEXR && x28_loadedGenDesc->x58_x44_TIND; }

--- a/Runtime/Particle/CEmitterElement.hpp
+++ b/Runtime/Particle/CEmitterElement.hpp
@@ -13,7 +13,7 @@ class CEESimpleEmitter : public CEmitterElement {
 public:
   CEESimpleEmitter(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CVectorElement>&& b)
   : x4_loc(std::move(a)), x8_vec(std::move(b)) {}
-  bool GetValue(int frame, zeus::CVector3f& pPos, zeus::CVector3f& pVel) const;
+  bool GetValue(int frame, zeus::CVector3f& pPos, zeus::CVector3f& pVel) const override;
 };
 
 class CVESphere : public CEmitterElement {
@@ -24,7 +24,7 @@ class CVESphere : public CEmitterElement {
 public:
   CVESphere(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CRealElement>&& b, std::unique_ptr<CRealElement>&& c)
   : x4_sphereOrigin(std::move(a)), x8_sphereRadius(std::move(b)), xc_velocityMag(std::move(c)) {}
-  bool GetValue(int frame, zeus::CVector3f& pPos, zeus::CVector3f& pVel) const;
+  bool GetValue(int frame, zeus::CVector3f& pPos, zeus::CVector3f& pVel) const override;
 };
 
 class CVEAngleSphere : public CEmitterElement {
@@ -48,7 +48,7 @@ public:
   , x14_angleYBias(std::move(e))
   , x18_angleXRange(std::move(f))
   , x1c_angleYRange(std::move(g)) {}
-  bool GetValue(int frame, zeus::CVector3f& pPos, zeus::CVector3f& pVel) const;
+  bool GetValue(int frame, zeus::CVector3f& pPos, zeus::CVector3f& pVel) const override;
 };
 
 } // namespace urde

--- a/Runtime/Particle/CFlameWarp.hpp
+++ b/Runtime/Particle/CFlameWarp.hpp
@@ -37,12 +37,12 @@ public:
   const zeus::CVector3f& GetFloatingPoint() const { return x80_floatingPoint; }
   void SetMaxDistSq(float d) { x8c_maxDistSq = d; }
   void SetStateManager(CStateManager& mgr) { x9c_stateMgr = &mgr; }
-  bool UpdateWarp() { return xa0_24_activated; }
-  void ModifyParticles(std::vector<CParticle>& particles);
-  void Activate(bool val) { xa0_24_activated = val; }
-  bool IsActivated() { return xa0_24_activated; }
+  bool UpdateWarp() override { return xa0_24_activated; }
+  void ModifyParticles(std::vector<CParticle>& particles) override;
+  void Activate(bool val) override { xa0_24_activated = val; }
+  bool IsActivated() override { return xa0_24_activated; }
   bool IsProcessed() const { return xa0_26_processed; }
-  FourCC Get4CharID() { return FOURCC('FWRP'); }
+  FourCC Get4CharID() override { return FOURCC('FWRP'); }
   void ResetPosition(const zeus::CVector3f& pos) {
     for (auto& vec : x4_collisionPoints) {
       vec = pos;

--- a/Runtime/Particle/CIntElement.hpp
+++ b/Runtime/Particle/CIntElement.hpp
@@ -17,8 +17,8 @@ class CIEKeyframeEmitter : public CIntElement {
 
 public:
   CIEKeyframeEmitter(CInputStream& in);
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEDeath : public CIntElement {
@@ -28,8 +28,8 @@ class CIEDeath : public CIntElement {
 public:
   CIEDeath(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEClamp : public CIntElement {
@@ -40,8 +40,8 @@ class CIEClamp : public CIntElement {
 public:
   CIEClamp(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b, std::unique_ptr<CIntElement>&& c)
   : x4_min(std::move(a)), x8_max(std::move(b)), xc_val(std::move(c)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIETimeChain : public CIntElement {
@@ -52,8 +52,8 @@ class CIETimeChain : public CIntElement {
 public:
   CIETimeChain(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b, std::unique_ptr<CIntElement>&& c)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_swFrame(std::move(c)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEAdd : public CIntElement {
@@ -62,8 +62,8 @@ class CIEAdd : public CIntElement {
 
 public:
   CIEAdd(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b) : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEConstant : public CIntElement {
@@ -71,8 +71,8 @@ class CIEConstant : public CIntElement {
 
 public:
   CIEConstant(int val) : x4_val(val) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEImpulse : public CIntElement {
@@ -80,8 +80,8 @@ class CIEImpulse : public CIntElement {
 
 public:
   CIEImpulse(std::unique_ptr<CIntElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIELifetimePercent : public CIntElement {
@@ -89,8 +89,8 @@ class CIELifetimePercent : public CIntElement {
 
 public:
   CIELifetimePercent(std::unique_ptr<CIntElement>&& a) : x4_percentVal(std::move(a)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEInitialRandom : public CIntElement {
@@ -100,8 +100,8 @@ class CIEInitialRandom : public CIntElement {
 public:
   CIEInitialRandom(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEPulse : public CIntElement {
@@ -114,8 +114,8 @@ public:
   CIEPulse(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b, std::unique_ptr<CIntElement>&& c,
            std::unique_ptr<CIntElement>&& d)
   : x4_aDuration(std::move(a)), x8_bDuration(std::move(b)), xc_aVal(std::move(c)), x10_bVal(std::move(d)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEMultiply : public CIntElement {
@@ -125,8 +125,8 @@ class CIEMultiply : public CIntElement {
 public:
   CIEMultiply(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIESampleAndHold : public CIntElement {
@@ -139,8 +139,8 @@ class CIESampleAndHold : public CIntElement {
 public:
   CIESampleAndHold(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b, std::unique_ptr<CIntElement>&& c)
   : x4_sampleSource(std::move(a)), xc_waitFramesMin(std::move(b)), x10_waitFramesMax(std::move(c)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIERandom : public CIntElement {
@@ -150,8 +150,8 @@ class CIERandom : public CIntElement {
 public:
   CIERandom(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b)
   : x4_min(std::move(a)), x8_max(std::move(b)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIETimeScale : public CIntElement {
@@ -159,26 +159,26 @@ class CIETimeScale : public CIntElement {
 
 public:
   CIETimeScale(std::unique_ptr<CRealElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEGetCumulativeParticleCount : public CIntElement {
 public:
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEGetActiveParticleCount : public CIntElement {
 public:
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEGetEmitterTime : public CIntElement {
 public:
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIEModulo : public CIntElement {
@@ -188,8 +188,8 @@ class CIEModulo : public CIntElement {
 public:
   CIEModulo(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 class CIESubtract : public CIntElement {
@@ -199,8 +199,8 @@ class CIESubtract : public CIntElement {
 public:
   CIESubtract(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, int& valOut) const;
-  int GetMaxValue() const;
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
 };
 
 } // namespace urde

--- a/Runtime/Particle/CModVectorElement.hpp
+++ b/Runtime/Particle/CModVectorElement.hpp
@@ -21,7 +21,7 @@ public:
   , xc_maxMag(std::move(c))
   , x10_minMag(std::move(d))
   , x14_enableMinMag(std::move(e)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVEExponentialImplosion : public CModVectorElement {
@@ -39,7 +39,7 @@ public:
   , xc_maxMag(std::move(c))
   , x10_minMag(std::move(d))
   , x14_enableMinMag(std::move(e)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVELinearImplosion : public CModVectorElement {
@@ -57,7 +57,7 @@ public:
   , xc_maxMag(std::move(c))
   , x10_minMag(std::move(d))
   , x14_enableMinMag(std::move(e)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVETimeChain : public CModVectorElement {
@@ -69,7 +69,7 @@ public:
   CMVETimeChain(std::unique_ptr<CModVectorElement>&& a, std::unique_ptr<CModVectorElement>&& b,
                 std::unique_ptr<CIntElement>&& c)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_swFrame(std::move(c)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVEBounce : public CModVectorElement {
@@ -85,7 +85,7 @@ class CMVEBounce : public CModVectorElement {
 public:
   CMVEBounce(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CVectorElement>&& b,
              std::unique_ptr<CRealElement>&& c, std::unique_ptr<CRealElement>&& d, bool e);
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVEConstant : public CModVectorElement {
@@ -96,7 +96,7 @@ class CMVEConstant : public CModVectorElement {
 public:
   CMVEConstant(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b, std::unique_ptr<CRealElement>&& c)
   : x4_x(std::move(a)), x8_y(std::move(b)), xc_z(std::move(c)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVEFastConstant : public CModVectorElement {
@@ -104,7 +104,7 @@ class CMVEFastConstant : public CModVectorElement {
 
 public:
   CMVEFastConstant(float a, float b, float c) : x4_val(a, b, c) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVEGravity : public CModVectorElement {
@@ -112,7 +112,7 @@ class CMVEGravity : public CModVectorElement {
 
 public:
   CMVEGravity(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVEExplode : public CModVectorElement {
@@ -122,7 +122,7 @@ class CMVEExplode : public CModVectorElement {
 public:
   CMVEExplode(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVESetPosition : public CModVectorElement {
@@ -130,7 +130,7 @@ class CMVESetPosition : public CModVectorElement {
 
 public:
   CMVESetPosition(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVEPulse : public CModVectorElement {
@@ -143,7 +143,7 @@ public:
   CMVEPulse(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b, std::unique_ptr<CModVectorElement>&& c,
             std::unique_ptr<CModVectorElement>&& d)
   : x4_aDuration(std::move(a)), x8_bDuration(std::move(b)), xc_aVal(std::move(c)), x10_bVal(std::move(d)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVEWind : public CModVectorElement {
@@ -153,7 +153,7 @@ class CMVEWind : public CModVectorElement {
 public:
   CMVEWind(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_velocity(std::move(a)), x8_factor(std::move(b)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 class CMVESwirl : public CModVectorElement {
@@ -169,7 +169,7 @@ public:
   , x8_curveBinormal(std::move(b))
   , xc_filterGain(std::move(c))
   , x10_tangentialVelocity(std::move(d)) {}
-  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const;
+  bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
 } // namespace urde

--- a/Runtime/Particle/CParticleElectric.hpp
+++ b/Runtime/Particle/CParticleElectric.hpp
@@ -105,39 +105,39 @@ private:
 public:
   CParticleElectric(const TToken<CElectricDescription>& desc);
 
-  bool Update(double);
-  void Render(const CActorLights* = nullptr);
-  void SetOrientation(const zeus::CTransform&);
-  void SetTranslation(const zeus::CVector3f&);
-  void SetGlobalOrientation(const zeus::CTransform&);
-  void SetGlobalTranslation(const zeus::CVector3f&);
-  void SetGlobalScale(const zeus::CVector3f&);
-  void SetLocalScale(const zeus::CVector3f&);
-  void SetParticleEmission(bool);
-  void SetModulationColor(const zeus::CColor&);
+  bool Update(double) override;
+  void Render(const CActorLights* = nullptr) override;
+  void SetOrientation(const zeus::CTransform&) override;
+  void SetTranslation(const zeus::CVector3f&) override;
+  void SetGlobalOrientation(const zeus::CTransform&) override;
+  void SetGlobalTranslation(const zeus::CVector3f&) override;
+  void SetGlobalScale(const zeus::CVector3f&) override;
+  void SetLocalScale(const zeus::CVector3f&) override;
+  void SetParticleEmission(bool) override;
+  void SetModulationColor(const zeus::CColor&) override;
   void SetOverrideIPos(const zeus::CVector3f& vec) { x178_overrideIPos.emplace(vec); }
   void SetOverrideIVel(const zeus::CVector3f& vec) { x188_overrideIVel.emplace(vec); }
   void SetOverrideFPos(const zeus::CVector3f& vec) { x198_overrideFPos.emplace(vec); }
   void SetOverrideFVel(const zeus::CVector3f& vec) { x1a8_overrideFVel.emplace(vec); }
-  const zeus::CTransform& GetOrientation() const;
-  const zeus::CVector3f& GetTranslation() const;
-  const zeus::CTransform& GetGlobalOrientation() const;
-  const zeus::CVector3f& GetGlobalTranslation() const;
-  const zeus::CVector3f& GetGlobalScale() const;
-  const zeus::CColor& GetModulationColor() const;
-  bool IsSystemDeletable() const;
-  std::optional<zeus::CAABox> GetBounds() const;
-  u32 GetParticleCount() const;
-  bool SystemHasLight() const;
-  CLight GetLight() const;
-  bool GetParticleEmission() const;
-  void DestroyParticles();
-  void Reset() {}
+  const zeus::CTransform& GetOrientation() const override;
+  const zeus::CVector3f& GetTranslation() const override;
+  const zeus::CTransform& GetGlobalOrientation() const override;
+  const zeus::CVector3f& GetGlobalTranslation() const override;
+  const zeus::CVector3f& GetGlobalScale() const override;
+  const zeus::CColor& GetModulationColor() const override;
+  bool IsSystemDeletable() const override;
+  std::optional<zeus::CAABox> GetBounds() const override;
+  u32 GetParticleCount() const override;
+  bool SystemHasLight() const override;
+  CLight GetLight() const override;
+  bool GetParticleEmission() const override;
+  void DestroyParticles() override;
+  void Reset() override {}
   void ForceParticleCreation(s32 count) {
     CGlobalRandom gRnd{x14c_randState};
     CreateNewParticles(count);
   }
-  FourCC Get4CharId() const { return FOURCC('ELSC'); }
+  FourCC Get4CharId() const override { return FOURCC('ELSC'); }
 };
 
 } // namespace urde

--- a/Runtime/Particle/CParticleSwoosh.hpp
+++ b/Runtime/Particle/CParticleSwoosh.hpp
@@ -129,35 +129,35 @@ class CParticleSwoosh : public CParticleGen {
 
 public:
   CParticleSwoosh(const TToken<CSwooshDescription>& desc, int);
-  ~CParticleSwoosh();
+  ~CParticleSwoosh() override;
 
   CSwooshDescription* GetDesc() { return x1c_desc.GetObj(); }
 
-  bool Update(double);
-  void Render(const CActorLights* = nullptr);
-  void SetOrientation(const zeus::CTransform&);
-  void SetTranslation(const zeus::CVector3f&);
-  void SetGlobalOrientation(const zeus::CTransform&);
-  void SetGlobalTranslation(const zeus::CVector3f&);
-  void SetGlobalScale(const zeus::CVector3f&);
-  void SetLocalScale(const zeus::CVector3f&);
-  void SetParticleEmission(bool);
-  void SetModulationColor(const zeus::CColor&);
-  const zeus::CTransform& GetOrientation() const;
-  const zeus::CVector3f& GetTranslation() const;
-  const zeus::CTransform& GetGlobalOrientation() const;
-  const zeus::CVector3f& GetGlobalTranslation() const;
-  const zeus::CVector3f& GetGlobalScale() const;
-  const zeus::CColor& GetModulationColor() const;
-  bool IsSystemDeletable() const;
-  std::optional<zeus::CAABox> GetBounds() const;
-  u32 GetParticleCount() const;
-  bool SystemHasLight() const;
-  CLight GetLight() const;
-  bool GetParticleEmission() const;
-  void DestroyParticles();
-  void Reset() {}
-  FourCC Get4CharId() const { return FOURCC('SWHC'); }
+  bool Update(double) override;
+  void Render(const CActorLights* = nullptr) override;
+  void SetOrientation(const zeus::CTransform&) override;
+  void SetTranslation(const zeus::CVector3f&) override;
+  void SetGlobalOrientation(const zeus::CTransform&) override;
+  void SetGlobalTranslation(const zeus::CVector3f&) override;
+  void SetGlobalScale(const zeus::CVector3f&) override;
+  void SetLocalScale(const zeus::CVector3f&) override;
+  void SetParticleEmission(bool) override;
+  void SetModulationColor(const zeus::CColor&) override;
+  const zeus::CTransform& GetOrientation() const override;
+  const zeus::CVector3f& GetTranslation() const override;
+  const zeus::CTransform& GetGlobalOrientation() const override;
+  const zeus::CVector3f& GetGlobalTranslation() const override;
+  const zeus::CVector3f& GetGlobalScale() const override;
+  const zeus::CColor& GetModulationColor() const override;
+  bool IsSystemDeletable() const override;
+  std::optional<zeus::CAABox> GetBounds() const override;
+  u32 GetParticleCount() const override;
+  bool SystemHasLight() const override;
+  CLight GetLight() const override;
+  bool GetParticleEmission() const override;
+  void DestroyParticles() override;
+  void Reset() override {}
+  FourCC Get4CharId() const override { return FOURCC('SWHC'); }
   void SetRenderGaps(bool r) { x1d0_27_renderGaps = r; }
 
   void DoWarmupUpdate() {

--- a/Runtime/Particle/CRealElement.hpp
+++ b/Runtime/Particle/CRealElement.hpp
@@ -17,7 +17,7 @@ class CREKeyframeEmitter : public CRealElement {
 
 public:
   CREKeyframeEmitter(CInputStream& in);
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CRELifetimeTween : public CRealElement {
@@ -27,7 +27,7 @@ class CRELifetimeTween : public CRealElement {
 public:
   CRELifetimeTween(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREConstant : public CRealElement {
@@ -35,8 +35,8 @@ class CREConstant : public CRealElement {
 
 public:
   CREConstant(float val) : x4_val(val) {}
-  bool GetValue(int frame, float& valOut) const;
-  bool IsConstant() const { return true; }
+  bool GetValue(int frame, float& valOut) const override;
+  bool IsConstant() const override { return true; }
 };
 
 class CRETimeChain : public CRealElement {
@@ -47,7 +47,7 @@ class CRETimeChain : public CRealElement {
 public:
   CRETimeChain(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b, std::unique_ptr<CIntElement>&& c)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_swFrame(std::move(c)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREAdd : public CRealElement {
@@ -57,7 +57,7 @@ class CREAdd : public CRealElement {
 public:
   CREAdd(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREClamp : public CRealElement {
@@ -68,7 +68,7 @@ class CREClamp : public CRealElement {
 public:
   CREClamp(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b, std::unique_ptr<CRealElement>&& c)
   : x4_min(std::move(a)), x8_max(std::move(b)), xc_val(std::move(c)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREInitialRandom : public CRealElement {
@@ -78,8 +78,8 @@ class CREInitialRandom : public CRealElement {
 public:
   CREInitialRandom(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_min(std::move(a)), x8_max(std::move(b)) {}
-  bool GetValue(int frame, float& valOut) const;
-  bool IsConstant() const { return true; }
+  bool GetValue(int frame, float& valOut) const override;
+  bool IsConstant() const override { return true; }
 };
 
 class CRERandom : public CRealElement {
@@ -89,7 +89,7 @@ class CRERandom : public CRealElement {
 public:
   CRERandom(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_min(std::move(a)), x8_max(std::move(b)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREDotProduct : public CRealElement {
@@ -99,7 +99,7 @@ class CREDotProduct : public CRealElement {
 public:
   CREDotProduct(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CVectorElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREMultiply : public CRealElement {
@@ -109,7 +109,7 @@ class CREMultiply : public CRealElement {
 public:
   CREMultiply(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREPulse : public CRealElement {
@@ -122,7 +122,7 @@ public:
   CREPulse(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b, std::unique_ptr<CRealElement>&& c,
            std::unique_ptr<CRealElement>&& d)
   : x4_aDuration(std::move(a)), x8_bDuration(std::move(b)), xc_valA(std::move(c)), x10_valB(std::move(d)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CRETimeScale : public CRealElement {
@@ -130,7 +130,7 @@ class CRETimeScale : public CRealElement {
 
 public:
   CRETimeScale(std::unique_ptr<CRealElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CRELifetimePercent : public CRealElement {
@@ -138,7 +138,7 @@ class CRELifetimePercent : public CRealElement {
 
 public:
   CRELifetimePercent(std::unique_ptr<CRealElement>&& a) : x4_percentVal(std::move(a)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CRESineWave : public CRealElement {
@@ -149,7 +149,7 @@ class CRESineWave : public CRealElement {
 public:
   CRESineWave(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b, std::unique_ptr<CRealElement>&& c)
   : x4_frequency(std::move(a)), x8_amplitude(std::move(b)), xc_phase(std::move(c)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREInitialSwitch : public CRealElement {
@@ -159,7 +159,7 @@ class CREInitialSwitch : public CRealElement {
 public:
   CREInitialSwitch(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CRECompareLessThan : public CRealElement {
@@ -172,7 +172,7 @@ public:
   CRECompareLessThan(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b,
                      std::unique_ptr<CRealElement>&& c, std::unique_ptr<CRealElement>&& d)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_c(std::move(c)), x10_d(std::move(d)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CRECompareEquals : public CRealElement {
@@ -185,57 +185,57 @@ public:
   CRECompareEquals(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b,
                    std::unique_ptr<CRealElement>&& c, std::unique_ptr<CRealElement>&& d)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_c(std::move(c)), x10_d(std::move(d)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleAccessParam1 : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleAccessParam2 : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleAccessParam3 : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleAccessParam4 : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleAccessParam5 : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleAccessParam6 : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleAccessParam7 : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleAccessParam8 : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleSizeOrLineLength : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREParticleRotationOrLineWidth : public CRealElement {
 public:
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CRESubtract : public CRealElement {
@@ -245,7 +245,7 @@ class CRESubtract : public CRealElement {
 public:
   CRESubtract(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREVectorMagnitude : public CRealElement {
@@ -253,7 +253,7 @@ class CREVectorMagnitude : public CRealElement {
 
 public:
   CREVectorMagnitude(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREVectorXToReal : public CRealElement {
@@ -261,7 +261,7 @@ class CREVectorXToReal : public CRealElement {
 
 public:
   CREVectorXToReal(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREVectorYToReal : public CRealElement {
@@ -269,7 +269,7 @@ class CREVectorYToReal : public CRealElement {
 
 public:
   CREVectorYToReal(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREVectorZToReal : public CRealElement {
@@ -277,7 +277,7 @@ class CREVectorZToReal : public CRealElement {
 
 public:
   CREVectorZToReal(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CRECEXT : public CRealElement {
@@ -285,7 +285,7 @@ class CRECEXT : public CRealElement {
 
 public:
   CRECEXT(std::unique_ptr<CIntElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREIntTimesReal : public CRealElement {
@@ -295,7 +295,7 @@ class CREIntTimesReal : public CRealElement {
 public:
   CREIntTimesReal(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CRealElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREConstantRange : public CRealElement {
@@ -315,7 +315,7 @@ public:
   , x10_inRange(std::move(d))
   , x14_outOfRange(std::move(e)) {}
 
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREGetComponentRed : public CRealElement {
@@ -324,7 +324,7 @@ class CREGetComponentRed : public CRealElement {
 public:
   CREGetComponentRed(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREGetComponentGreen : public CRealElement {
@@ -333,7 +333,7 @@ class CREGetComponentGreen : public CRealElement {
 public:
   CREGetComponentGreen(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREGetComponentBlue : public CRealElement {
@@ -342,7 +342,7 @@ class CREGetComponentBlue : public CRealElement {
 public:
   CREGetComponentBlue(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 
 class CREGetComponentAlpha : public CRealElement {
@@ -351,6 +351,6 @@ class CREGetComponentAlpha : public CRealElement {
 public:
   CREGetComponentAlpha(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
-  bool GetValue(int frame, float& valOut) const;
+  bool GetValue(int frame, float& valOut) const override;
 };
 } // namespace urde

--- a/Runtime/Particle/CUVElement.hpp
+++ b/Runtime/Particle/CUVElement.hpp
@@ -26,10 +26,10 @@ struct CUVEConstant : public CUVElement {
 
 public:
   CUVEConstant(TToken<CTexture>&& tex) : x4_tex(std::move(tex)) {}
-  TLockedToken<CTexture> GetValueTexture(int frame) const { return TLockedToken<CTexture>(x4_tex); }
-  void GetValueUV(int frame, SUVElementSet& valOut) const { valOut = {0.f, 0.f, 1.f, 1.f}; }
-  bool HasConstantTexture() const { return true; }
-  bool HasConstantUV() const { return true; }
+  TLockedToken<CTexture> GetValueTexture(int frame) const override { return TLockedToken<CTexture>(x4_tex); }
+  void GetValueUV(int frame, SUVElementSet& valOut) const override { valOut = {0.f, 0.f, 1.f, 1.f}; }
+  bool HasConstantTexture() const override { return true; }
+  bool HasConstantUV() const override { return true; }
 };
 
 struct CUVEAnimTexture : public CUVElement {
@@ -44,10 +44,10 @@ public:
   CUVEAnimTexture(TToken<CTexture>&& tex, std::unique_ptr<CIntElement>&& tileW, std::unique_ptr<CIntElement>&& tileH,
                   std::unique_ptr<CIntElement>&& strideW, std::unique_ptr<CIntElement>&& strideH,
                   std::unique_ptr<CIntElement>&& cycleFrames, bool loop);
-  TLockedToken<CTexture> GetValueTexture(int frame) const { return TLockedToken<CTexture>(x4_tex); }
-  void GetValueUV(int frame, SUVElementSet& valOut) const;
-  bool HasConstantTexture() const { return true; }
-  bool HasConstantUV() const { return false; }
+  TLockedToken<CTexture> GetValueTexture(int frame) const override { return TLockedToken<CTexture>(x4_tex); }
+  void GetValueUV(int frame, SUVElementSet& valOut) const override;
+  bool HasConstantTexture() const override { return true; }
+  bool HasConstantUV() const override { return false; }
 };
 
 } // namespace urde

--- a/Runtime/Particle/CVectorElement.hpp
+++ b/Runtime/Particle/CVectorElement.hpp
@@ -17,7 +17,7 @@ class CVEKeyframeEmitter : public CVectorElement {
 
 public:
   CVEKeyframeEmitter(CInputStream& in);
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVECone : public CVectorElement {
@@ -28,7 +28,7 @@ class CVECone : public CVectorElement {
 
 public:
   CVECone(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CRealElement>&& b);
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVETimeChain : public CVectorElement {
@@ -40,7 +40,7 @@ public:
   CVETimeChain(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CVectorElement>&& b,
                std::unique_ptr<CIntElement>&& c)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_swFrame(std::move(c)) {}
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEAngleCone : public CVectorElement {
@@ -58,7 +58,7 @@ public:
   , xc_angleXRange(std::move(c))
   , x10_angleYRange(std::move(d))
   , x14_magnitude(std::move(e)) {}
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEAdd : public CVectorElement {
@@ -68,7 +68,7 @@ class CVEAdd : public CVectorElement {
 public:
   CVEAdd(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CVectorElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVECircleCluster : public CVectorElement {
@@ -81,7 +81,7 @@ class CVECircleCluster : public CVectorElement {
 public:
   CVECircleCluster(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CVectorElement>&& b,
                    std::unique_ptr<CIntElement>&& c, std::unique_ptr<CRealElement>&& d);
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEConstant : public CVectorElement {
@@ -92,7 +92,7 @@ class CVEConstant : public CVectorElement {
 public:
   CVEConstant(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b, std::unique_ptr<CRealElement>&& c)
   : x4_a(std::move(a)), x8_b(std::move(b)), xc_c(std::move(c)) {}
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEFastConstant : public CVectorElement {
@@ -100,8 +100,8 @@ class CVEFastConstant : public CVectorElement {
 
 public:
   CVEFastConstant(float a, float b, float c) : x4_val(a, b, c) {}
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
-  bool IsFastConstant() const { return true; }
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
+  bool IsFastConstant() const override { return true; }
 };
 
 class CVECircle : public CVectorElement {
@@ -115,7 +115,7 @@ class CVECircle : public CVectorElement {
 public:
   CVECircle(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CVectorElement>&& b, std::unique_ptr<CRealElement>&& c,
             std::unique_ptr<CRealElement>&& d, std::unique_ptr<CRealElement>&& e);
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEMultiply : public CVectorElement {
@@ -125,7 +125,7 @@ class CVEMultiply : public CVectorElement {
 public:
   CVEMultiply(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CVectorElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVERealToVector : public CVectorElement {
@@ -133,7 +133,7 @@ class CVERealToVector : public CVectorElement {
 
 public:
   CVERealToVector(std::unique_ptr<CRealElement>&& a) : x4_a(std::move(a)) {}
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEPulse : public CVectorElement {
@@ -146,42 +146,42 @@ public:
   CVEPulse(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b, std::unique_ptr<CVectorElement>&& c,
            std::unique_ptr<CVectorElement>&& d)
   : x4_aDuration(std::move(a)), x8_bDuration(std::move(b)), xc_aVal(std::move(c)), x10_bVal(std::move(d)) {}
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEParticleVelocity : public CVectorElement {
 public:
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEParticleColor : public CVectorElement {
 public:
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEParticleLocation : public CVectorElement {
 public:
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEParticleSystemOrientationFront : public CVectorElement {
 public:
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEParticleSystemOrientationUp : public CVectorElement {
 public:
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEParticleSystemOrientationRight : public CVectorElement {
 public:
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEParticleSystemTranslation : public CVectorElement {
 public:
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVESubtract : public CVectorElement {
@@ -191,7 +191,7 @@ class CVESubtract : public CVectorElement {
 public:
   CVESubtract(std::unique_ptr<CVectorElement>&& a, std::unique_ptr<CVectorElement>&& b)
   : x4_a(std::move(a)), x8_b(std::move(b)) {}
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 class CVEColorToVector : public CVectorElement {
@@ -200,7 +200,7 @@ class CVEColorToVector : public CVectorElement {
 public:
   CVEColorToVector(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
-  bool GetValue(int frame, zeus::CVector3f& valOut) const;
+  bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
 } // namespace urde

--- a/Runtime/Weapon/CBeamProjectile.hpp
+++ b/Runtime/Weapon/CBeamProjectile.hpp
@@ -39,7 +39,7 @@ public:
                   EMaterialTypes matType, const CDamageInfo& dInfo, TUniqueId uid, TAreaId aid, TUniqueId owner,
                   EProjectileAttrib attribs, bool growingBeam);
 
-  void Accept(IVisitor& visitor);
+  void Accept(IVisitor& visitor) override;
   float GetMaxRadius() const { return x2f4_beamRadius; }
   const zeus::CVector3f& GetSurfaceNormal() const { return x30c_collisionNormal; }
   EDamageType GetDamageType() const { return x2f8_damageType; }
@@ -54,8 +54,8 @@ public:
   s32 GetIntMaxLength() const { return x2e8_intMaxLength; }
   TUniqueId GetCollisionActorId() const { return x2fe_collisionActorId; }
 
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void CalculateRenderBounds();
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void CalculateRenderBounds() override;
   virtual void ResetBeam(CStateManager&, bool);
   virtual void UpdateFx(const zeus::CTransform&, float, CStateManager&);
   virtual void Fire(const zeus::CTransform&, CStateManager&, bool) = 0;

--- a/Runtime/Weapon/CBomb.hpp
+++ b/Runtime/Weapon/CBomb.hpp
@@ -24,15 +24,15 @@ public:
   CBomb(const TCachedToken<CGenDescription>& particle1, const TCachedToken<CGenDescription>& particle2, TUniqueId uid,
         TAreaId aid, TUniqueId playerId, float f1, const zeus::CTransform& xf, const CDamageInfo& dInfo);
 
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const {}
-  void Touch(CActor&, CStateManager&);
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override {}
+  void Touch(CActor&, CStateManager&) override;
   void Explode(const zeus::CVector3f&, CStateManager&);
   void UpdateLight(float, CStateManager&);
-  std::optional<zeus::CAABox> GetTouchBounds() const;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
   void SetVelocityWR(const zeus::CVector3f& vel) { x158_velocity = vel; }
   void SetConstantAccelerationWR(const zeus::CVector3f& acc) { x164_acceleration = acc; }
   void SetFuseDisabled(bool b) { x190_26_disableFuse = false; }

--- a/Runtime/Weapon/CElectricBeamProjectile.hpp
+++ b/Runtime/Weapon/CElectricBeamProjectile.hpp
@@ -27,12 +27,12 @@ public:
                           const zeus::CTransform&, EMaterialTypes, const CDamageInfo&, TUniqueId, TAreaId, TUniqueId,
                           EProjectileAttrib);
 
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void Touch(CActor&, CStateManager&){};
-  void UpdateFx(const zeus::CTransform&, float, CStateManager&);
-  void ResetBeam(CStateManager&, bool);
-  void Fire(const zeus::CTransform&, CStateManager&, bool);
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void Touch(CActor&, CStateManager&) override {}
+  void UpdateFx(const zeus::CTransform&, float, CStateManager&) override;
+  void ResetBeam(CStateManager&, bool) override;
+  void Fire(const zeus::CTransform&, CStateManager&, bool) override;
 };
 } // namespace urde

--- a/Runtime/Weapon/CFlameThrower.hpp
+++ b/Runtime/Weapon/CFlameThrower.hpp
@@ -51,10 +51,10 @@ public:
                 const CDamageInfo& dInfo, TUniqueId uid, TAreaId aId, TUniqueId owner, EProjectileAttrib attribs,
                 CAssetId playerSteamTxtr, s16 playerHitSfx, CAssetId playerIceTxtr);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
   void SetTransform(const zeus::CTransform& xf, float);
   void Reset(CStateManager&, bool);
   void Fire(const zeus::CTransform&, CStateManager&, bool);

--- a/Runtime/Weapon/CGameProjectile.hpp
+++ b/Runtime/Weapon/CGameProjectile.hpp
@@ -61,9 +61,9 @@ public:
                   const std::optional<TLockedToken<CGenDescription>>& visorParticle, u16 visorSfx,
                   bool sendCollideMsg);
 
-  virtual void Accept(IVisitor& visitor);
+  void Accept(IVisitor& visitor) override;
   virtual void ResolveCollisionWithActor(const CRayCastResult& res, CActor& act, CStateManager& mgr);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   static EProjectileAttrib GetBeamAttribType(EWeaponType wType);
   void DeleteProjectileLight(CStateManager&);
   void CreateProjectileLight(std::string_view, const CLight&, CStateManager&);
@@ -81,7 +81,7 @@ public:
   CProjectileTouchResult CanCollideWithGameObject(CActor& act, CStateManager& mgr) const;
   CProjectileTouchResult CanCollideWithTrigger(CActor& act, CStateManager& mgr) const;
   zeus::CAABox GetProjectileBounds() const;
-  std::optional<zeus::CAABox> GetTouchBounds() const;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
   CProjectileWeapon& ProjectileWeapon() { return x170_projectile; }
   const CProjectileWeapon& GetProjectileWeapon() const { return x170_projectile; }
   TUniqueId GetHomingTargetId() const { return x2c0_homingTargetId; }

--- a/Runtime/Weapon/CIceBeam.hpp
+++ b/Runtime/Weapon/CIceBeam.hpp
@@ -18,17 +18,17 @@ public:
   CIceBeam(CAssetId characterId, EWeaponType type, TUniqueId playerId, EMaterialTypes playerMaterial,
            const zeus::CVector3f& scale);
 
-  void PreRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf);
-  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf);
-  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf);
+  void PreRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf) override;
+  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf) override;
+  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf) override;
   void Fire(bool underwater, float dt, EChargeState chargeState, const zeus::CTransform& xf, CStateManager& mgr,
-            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2);
-  void EnableFx(bool enable);
-  void EnableSecondaryFx(ESecondaryFxType type);
-  void Update(float dt, CStateManager& mgr);
-  void Load(CStateManager& mgr, bool subtypeBasePose);
-  void Unload(CStateManager& mgr);
-  bool IsLoaded() const;
+            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2) override;
+  void EnableFx(bool enable) override;
+  void EnableSecondaryFx(ESecondaryFxType type) override;
+  void Update(float dt, CStateManager& mgr) override;
+  void Load(CStateManager& mgr, bool subtypeBasePose) override;
+  void Unload(CStateManager& mgr) override;
+  bool IsLoaded() const override;
 };
 
 } // namespace urde

--- a/Runtime/Weapon/CPhazonBeam.hpp
+++ b/Runtime/Weapon/CPhazonBeam.hpp
@@ -37,18 +37,18 @@ public:
   void UpdateBeam(float dt, const zeus::CTransform& targetXf, const zeus::CVector3f& localBeamPos, CStateManager& mgr);
   void CreateBeam(CStateManager& mgr);
 
-  void PreRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf);
-  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf);
-  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf);
+  void PreRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf) override;
+  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf) override;
+  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf) override;
   void Fire(bool underwater, float dt, EChargeState chargeState, const zeus::CTransform& xf, CStateManager& mgr,
-            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2);
-  void Update(float dt, CStateManager& mgr);
-  void Load(CStateManager& mgr, bool subtypeBasePose);
-  void Unload(CStateManager& mgr);
-  bool IsLoaded() const;
+            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2) override;
+  void Update(float dt, CStateManager& mgr) override;
+  void Load(CStateManager& mgr, bool subtypeBasePose) override;
+  void Unload(CStateManager& mgr) override;
+  bool IsLoaded() const override;
   void Draw(bool drawSuitArm, const CStateManager& mgr, const zeus::CTransform& xf, const CModelFlags& flags,
-            const CActorLights* lights) const;
-  void DrawMuzzleFx(const CStateManager& mgr) const;
+            const CActorLights* lights) const override;
+  void DrawMuzzleFx(const CStateManager& mgr) const override;
 };
 
 } // namespace urde

--- a/Runtime/Weapon/CPlasmaBeam.hpp
+++ b/Runtime/Weapon/CPlasmaBeam.hpp
@@ -30,15 +30,15 @@ public:
   }
   void DeleteBeam(CStateManager& mgr);
 
-  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf);
-  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf);
+  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf) override;
+  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf) override;
   void Fire(bool underwater, float dt, EChargeState chargeState, const zeus::CTransform& xf, CStateManager& mgr,
-            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2);
-  void EnableSecondaryFx(ESecondaryFxType type);
-  void Update(float dt, CStateManager& mgr);
-  void Load(CStateManager& mgr, bool subtypeBasePose);
-  void Unload(CStateManager& mgr);
-  bool IsLoaded() const;
+            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2) override;
+  void EnableSecondaryFx(ESecondaryFxType type) override;
+  void Update(float dt, CStateManager& mgr) override;
+  void Load(CStateManager& mgr, bool subtypeBasePose) override;
+  void Unload(CStateManager& mgr) override;
+  bool IsLoaded() const override;
 };
 
 } // namespace urde

--- a/Runtime/Weapon/CPlasmaProjectile.hpp
+++ b/Runtime/Weapon/CPlasmaProjectile.hpp
@@ -104,14 +104,14 @@ public:
                     const CDamageInfo& dInfo, TUniqueId uid, TAreaId aid, TUniqueId owner,
                     const PlayerEffectResoures& res, bool growingBeam, EProjectileAttrib attribs);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr);
-  void ResetBeam(CStateManager& mgr, bool fullReset);
-  void UpdateFx(const zeus::CTransform& xf, float dt, CStateManager& mgr);
-  void Fire(const zeus::CTransform& xf, CStateManager& mgr, bool b);
-  void Touch(CActor& other, CStateManager& mgr);
-  bool CanRenderUnsorted(const CStateManager& mgr) const;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const;
-  void Render(const CStateManager& mgr) const;
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
+  void ResetBeam(CStateManager& mgr, bool fullReset) override;
+  void UpdateFx(const zeus::CTransform& xf, float dt, CStateManager& mgr) override;
+  void Fire(const zeus::CTransform& xf, CStateManager& mgr, bool b) override;
+  void Touch(CActor& other, CStateManager& mgr) override;
+  bool CanRenderUnsorted(const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void Render(const CStateManager& mgr) const override;
 };
 } // namespace urde

--- a/Runtime/Weapon/CPowerBeam.hpp
+++ b/Runtime/Weapon/CPowerBeam.hpp
@@ -20,16 +20,16 @@ public:
   CPowerBeam(CAssetId characterId, EWeaponType type, TUniqueId playerId, EMaterialTypes playerMaterial,
              const zeus::CVector3f& scale);
 
-  void PreRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf);
-  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf);
-  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf);
+  void PreRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf) override;
+  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf) override;
+  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf) override;
   void Fire(bool underwater, float dt, EChargeState chargeState, const zeus::CTransform& xf, CStateManager& mgr,
-            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2);
-  void EnableSecondaryFx(ESecondaryFxType type);
-  void Update(float dt, CStateManager& mgr);
-  void Load(CStateManager& mgr, bool subtypeBasePose);
-  void Unload(CStateManager& mgr);
-  bool IsLoaded() const;
+            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2) override;
+  void EnableSecondaryFx(ESecondaryFxType type) override;
+  void Update(float dt, CStateManager& mgr) override;
+  void Load(CStateManager& mgr, bool subtypeBasePose) override;
+  void Unload(CStateManager& mgr) override;
+  bool IsLoaded() const override;
 };
 
 } // namespace urde

--- a/Runtime/Weapon/CPowerBomb.hpp
+++ b/Runtime/Weapon/CPowerBomb.hpp
@@ -20,13 +20,13 @@ public:
   CPowerBomb(const TToken<CGenDescription>& particle, TUniqueId uid, TAreaId aid, TUniqueId playerId,
              const zeus::CTransform& xf, const CDamageInfo& dInfo);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const {}
-  std::optional<zeus::CAABox> GetTouchBounds() const { return {}; }
-  void Touch(CActor&, CStateManager&) { /*x158_24_canStartFilter; */
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override {}
+  std::optional<zeus::CAABox> GetTouchBounds() const override { return {}; }
+  void Touch(CActor&, CStateManager&) override { /*x158_24_canStartFilter; */
   }
   float GetCurTime() const { return x15c_curTime; }
   void ApplyDynamicDamage(const zeus::CVector3f&, CStateManager&);

--- a/Runtime/Weapon/CTargetableProjectile.hpp
+++ b/Runtime/Weapon/CTargetableProjectile.hpp
@@ -16,10 +16,10 @@ public:
                         const std::optional<TLockedToken<CGenDescription>>& visorParticle, u16 visorSfx,
                         bool sendCollideMsg);
 
-  void Accept(IVisitor&);
-  zeus::CVector3f GetAimPosition(const CStateManager&, float) const;
+  void Accept(IVisitor&) override;
+  zeus::CVector3f GetAimPosition(const CStateManager&, float) const override;
   bool Explode(const zeus::CVector3f& pos, const zeus::CVector3f& normal, EWeaponCollisionResponseTypes type,
-               CStateManager& mgr, const CDamageVulnerability& dVuln, TUniqueId hitActor);
+               CStateManager& mgr, const CDamageVulnerability& dVuln, TUniqueId hitActor) override;
 };
 
 } // namespace urde

--- a/Runtime/Weapon/CWaveBeam.hpp
+++ b/Runtime/Weapon/CWaveBeam.hpp
@@ -20,15 +20,15 @@ public:
   CWaveBeam(CAssetId characterId, EWeaponType type, TUniqueId playerId, EMaterialTypes playerMaterial,
             const zeus::CVector3f& scale);
 
-  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf);
-  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf);
+  void PostRenderGunFx(const CStateManager& mgr, const zeus::CTransform& xf) override;
+  void UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, const zeus::CTransform& xf) override;
   void Fire(bool underwater, float dt, EChargeState chargeState, const zeus::CTransform& xf, CStateManager& mgr,
-            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2);
-  void EnableSecondaryFx(ESecondaryFxType type);
-  void Update(float dt, CStateManager& mgr);
-  void Load(CStateManager& mgr, bool subtypeBasePose);
-  void Unload(CStateManager& mgr);
-  bool IsLoaded() const;
+            TUniqueId homingTarget, float chargeFactor1, float chargeFactor2) override;
+  void EnableSecondaryFx(ESecondaryFxType type) override;
+  void Update(float dt, CStateManager& mgr) override;
+  void Load(CStateManager& mgr, bool subtypeBasePose) override;
+  void Unload(CStateManager& mgr) override;
+  bool IsLoaded() const override;
 };
 
 } // namespace urde

--- a/Runtime/Weapon/CWeapon.hpp
+++ b/Runtime/Weapon/CWeapon.hpp
@@ -24,7 +24,7 @@ public:
           const zeus::CTransform& xf, const CMaterialFilter& filter, const CMaterialList& mList, const CDamageInfo&,
           EProjectileAttrib attribs, CModelData&& mData);
 
-  virtual void Accept(IVisitor& visitor);
+  void Accept(IVisitor& visitor) override;
   bool HasAttrib(EProjectileAttrib attrib) const { return (int(xe8_projectileAttribs) & int(attrib)) == int(attrib); }
   EProjectileAttrib GetAttribField() const { return xe8_projectileAttribs; }
   const CMaterialFilter& GetFilter() const { return xf8_filter; }
@@ -38,10 +38,10 @@ public:
   float GetDamageDuration() const { return x150_damageDuration; }
   float GetInterferenceDuration() const { return x154_interferenceDuration; }
 
-  void Think(float, CStateManager&);
-  void Render(const CStateManager&) const;
+  void Think(float, CStateManager&) override;
+  void Render(const CStateManager&) const override;
   EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
-                                                         const CWeaponMode&, EProjectileAttrib) const;
-  void FluidFXThink(EFluidState state, CScriptWater& water, CStateManager& mgr);
+                                                         const CWeaponMode&, EProjectileAttrib) const override;
+  void FluidFXThink(EFluidState state, CScriptWater& water, CStateManager& mgr) override;
 };
 } // namespace urde

--- a/Runtime/World/CActor.hpp
+++ b/Runtime/World/CActor.hpp
@@ -98,8 +98,8 @@ public:
   CActor(TUniqueId uid, bool active, std::string_view name, const CEntityInfo& info, const zeus::CTransform&,
          CModelData&& mData, const CMaterialList& list, const CActorParameters& params, TUniqueId otherUid);
 
-  virtual void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  virtual void SetActive(bool active) {
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void SetActive(bool active) override {
     xe4_27_notInSortedLists = true;
     xe4_28_transformDirty = true;
     xe4_29_actorLightsDirty = true;

--- a/Runtime/World/CAi.hpp
+++ b/Runtime/World/CAi.hpp
@@ -39,19 +39,21 @@ public:
 
   const CStateMachine* GetStateMachine() const;
 
-  virtual void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  virtual CHealthInfo* HealthInfo(CStateManager&) { return &x258_healthInfo; }
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  CHealthInfo* HealthInfo(CStateManager&) override { return &x258_healthInfo; }
+  const CDamageVulnerability* GetDamageVulnerability() const override { return &x260_damageVulnerability; }
+  EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
+                                                         const CWeaponMode&, EProjectileAttrib) const override;
+  void FluidFXThink(EFluidState, CScriptWater&, CStateManager&) override;
+
   virtual void Death(CStateManager& mgr, const zeus::CVector3f& direction, EScriptObjectState state) = 0;
   virtual void KnockBack(const zeus::CVector3f&, CStateManager&, const CDamageInfo& info, EKnockBackType type,
                          bool inDeferred, float magnitude) = 0;
-  virtual const CDamageVulnerability* GetDamageVulnerability() const { return &x260_damageVulnerability; }
+
   virtual void TakeDamage(const zeus::CVector3f& direction, float magnitude) {}
   virtual bool CanBeShot(const CStateManager&, int) { return true; }
   virtual bool IsListening() const { return false; }
   virtual bool Listen(const zeus::CVector3f&, EListenNoiseType) { return 0; }
-  virtual EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
-                                                                 const CWeaponMode&, EProjectileAttrib) const;
-  void FluidFXThink(EFluidState, CScriptWater&, CStateManager&);
 
   virtual zeus::CVector3f GetOrigin(const CStateManager& mgr, const CTeamAiRole& role,
                                     const zeus::CVector3f& aimPos) const {

--- a/Runtime/World/CAmbientAI.hpp
+++ b/Runtime/World/CAmbientAI.hpp
@@ -29,13 +29,13 @@ public:
              const zeus::CAABox&, const CMaterialList&, float, const CHealthInfo&, const CDamageVulnerability&,
              const CActorParameters&, float, float, s32, s32, bool);
 
-  void Accept(IVisitor&);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  CHealthInfo* HealthInfo(CStateManager&) { return &x260_healthInfo; }
-  const CDamageVulnerability* GetDamageVulnerability() const { return &x268_dVuln; }
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor&, CStateManager&) {}
+  void Accept(IVisitor&) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  CHealthInfo* HealthInfo(CStateManager&) override{ return &x260_healthInfo; }
+  const CDamageVulnerability* GetDamageVulnerability() const override{ return &x268_dVuln; }
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor&, CStateManager&) override{}
   void RandomizePlaybackRate(CStateManager&);
 };
 

--- a/Runtime/World/CEffect.hpp
+++ b/Runtime/World/CEffect.hpp
@@ -8,8 +8,8 @@ class CEffect : public CActor {
 public:
   CEffect(TUniqueId uid, const CEntityInfo& info, bool active, std::string_view name, const zeus::CTransform& xf);
 
-  virtual void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {}
-  virtual void Render(const CStateManager&) const {}
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override{}
+  void Render(const CStateManager&) const override{}
 };
 
 } // namespace urde

--- a/Runtime/World/CExplosion.hpp
+++ b/Runtime/World/CExplosion.hpp
@@ -26,13 +26,13 @@ public:
              std::string_view name, const zeus::CTransform& xf, u32, const zeus::CVector3f& scale,
              const zeus::CColor& color);
 
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const;
-  bool CanRenderUnsorted(const CStateManager&) const;
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override;
+  bool CanRenderUnsorted(const CStateManager&) const override;
 };
 
 } // namespace urde

--- a/Runtime/World/CFire.hpp
+++ b/Runtime/World/CFire.hpp
@@ -28,17 +28,17 @@ public:
   CFire(TToken<CGenDescription>, TUniqueId, TAreaId, bool, TUniqueId, const zeus::CTransform&, const CDamageInfo&,
         const zeus::CAABox&, const zeus::CVector3f&, bool, CAssetId, bool, bool, bool, float, float, float, float);
 
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  std::optional<zeus::CAABox> GetTouchBounds() const {
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override {
     if (GetActive())
       return x128_;
 
     return {};
   }
 
-  void Touch(CActor&, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
+  void Touch(CActor&, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
 };
 } // namespace urde

--- a/Runtime/World/CFishCloud.hpp
+++ b/Runtime/World/CFishCloud.hpp
@@ -135,14 +135,14 @@ public:
              CAssetId part1, u32 partCount1, CAssetId part2, u32 partCount2, CAssetId part3, u32 partCount3,
              CAssetId part4, u32 partCount4, u32 deathSfx, bool repelFromThreats, bool hotInThermal);
 
-  void Accept(IVisitor& visitor);
-  void Think(float dt, CStateManager& mgr);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr);
-  void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum);
-  void Render(const CStateManager& mgr) const;
-  void CalculateRenderBounds();
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor& other, CStateManager& mgr);
+  void Accept(IVisitor& visitor) override;
+  void Think(float dt, CStateManager& mgr) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
+  void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
+  void Render(const CStateManager& mgr) const override;
+  void CalculateRenderBounds() override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor& other, CStateManager& mgr) override;
   void RemoveRepulsor(TUniqueId source);
   void RemoveAttractor(TUniqueId source);
   bool AddRepulsor(TUniqueId source, bool swirl, float radius, float priority);

--- a/Runtime/World/CFishCloudModifier.hpp
+++ b/Runtime/World/CFishCloudModifier.hpp
@@ -13,8 +13,8 @@ public:
   CFishCloudModifier(TUniqueId uid, bool active, std::string_view name, const CEntityInfo& eInfo,
                      const zeus::CVector3f& pos, bool isRepulsor, bool swirl, float radius,
                      float priority);
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
 
   void AddSelf(CStateManager&);
   void RemoveSelf(CStateManager&);

--- a/Runtime/World/CFluidPlaneCPU.hpp
+++ b/Runtime/World/CFluidPlaneCPU.hpp
@@ -94,8 +94,8 @@ public:
                                                  const CScriptWater* water) const;
   void Render(const CStateManager& mgr, float alpha, const zeus::CAABox& aabb, const zeus::CTransform& xf,
               const zeus::CTransform& areaXf, bool noNormals, const zeus::CFrustum& frustum,
-              const std::optional<CRippleManager>& rippleManager, TUniqueId waterId,
-              const bool* gridFlags, u32 gridDimX, u32 gridDimY, const zeus::CVector3f& areaCenter) const;
+              const std::optional<CRippleManager>& rippleManager, TUniqueId waterId, const bool* gridFlags,
+              u32 gridDimX, u32 gridDimY, const zeus::CVector3f& areaCenter) const override;
   float GetReflectionBlend() const { return x114_reflectionBlend; }
   float GetSpecularMax() const { return x110_specularMax; }
   float GetSpecularMin() const { return x10c_specularMin; }

--- a/Runtime/World/CFluidPlaneDoor.hpp
+++ b/Runtime/World/CFluidPlaneDoor.hpp
@@ -15,16 +15,16 @@ class CFluidPlaneDoor final : public CFluidPlane {
 public:
   CFluidPlaneDoor(CAssetId patternTex1, CAssetId patternTex2, CAssetId colorTex, float tileSize, u32 tileSubdivisions,
                   EFluidType fluidType, float alpha, const CFluidUVMotion& uvMotion);
-  void AddRipple(float mag, TUniqueId rippler, const zeus::CVector3f& center, CScriptWater& water, CStateManager& mgr) {
-  }
+  void AddRipple(float mag, TUniqueId rippler, const zeus::CVector3f& center, CScriptWater& water,
+                 CStateManager& mgr) override {}
   void AddRipple(float intensity, TUniqueId rippler, const zeus::CVector3f& center, const zeus::CVector3f& velocity,
-                 const CScriptWater& water, CStateManager& mgr, const zeus::CVector3f& upVec) {}
-  void AddRipple(const CRipple& ripple, const CScriptWater& water, CStateManager& mgr) {}
+                 const CScriptWater& water, CStateManager& mgr, const zeus::CVector3f& upVec) override {}
+  void AddRipple(const CRipple& ripple, const CScriptWater& water, CStateManager& mgr) override {}
 
   void Render(const CStateManager& mgr, float alpha, const zeus::CAABox& aabb, const zeus::CTransform& xf,
               const zeus::CTransform& areaXf, bool noNormals, const zeus::CFrustum& frustum,
-              const std::optional<CRippleManager>& rippleManager, TUniqueId waterId,
-              const bool* gridFlags, u32 gridDimX, u32 gridDimY, const zeus::CVector3f& areaCenter) const;
+              const std::optional<CRippleManager>& rippleManager, TUniqueId waterId, const bool* gridFlags,
+              u32 gridDimX, u32 gridDimY, const zeus::CVector3f& areaCenter) const override;
 };
 
 } // namespace urde

--- a/Runtime/World/CFluidPlaneGPU.hpp
+++ b/Runtime/World/CFluidPlaneGPU.hpp
@@ -17,7 +17,7 @@ public:
   void RenderStripWithRipples(float curY, const CFluidPlaneRender::SHFieldSample (&heights)[46][46],
                               const u8 (&flags)[9][9], int startYDiv, const CFluidPlaneRender::SPatchInfo& info,
                               std::vector<CFluidPlaneShader::Vertex>& vOut,
-                              std::vector<CFluidPlaneShader::PatchVertex>& pvOut) const;
+                              std::vector<CFluidPlaneShader::PatchVertex>& pvOut) const override;
 };
 
 } // namespace urde

--- a/Runtime/World/CGameArea.hpp
+++ b/Runtime/World/CGameArea.hpp
@@ -50,14 +50,14 @@ class CDummyGameArea final : public IGameArea {
 public:
   CDummyGameArea(CInputStream& in, int idx, int mlvlVersion);
 
-  std::pair<std::unique_ptr<u8[]>, s32> IGetScriptingMemoryAlways() const;
-  TAreaId IGetAreaId() const;
-  CAssetId IGetAreaAssetId() const;
-  bool IIsActive() const;
-  TAreaId IGetAttachedAreaId(int) const;
-  u32 IGetNumAttachedAreas() const;
-  CAssetId IGetStringTableAssetId() const;
-  const zeus::CTransform& IGetTM() const;
+  std::pair<std::unique_ptr<u8[]>, s32> IGetScriptingMemoryAlways() const override;
+  TAreaId IGetAreaId() const override;
+  CAssetId IGetAreaAssetId() const override;
+  bool IIsActive() const override;
+  TAreaId IGetAttachedAreaId(int) const override;
+  u32 IGetNumAttachedAreas() const override;
+  CAssetId IGetStringTableAssetId() const override;
+  const zeus::CTransform& IGetTM() const override;
 };
 
 struct CAreaRenderOctTree {
@@ -164,7 +164,7 @@ public:
   public:
     CAreaObjectList(TAreaId areaIdx) : CObjectList(EGameObjectList::Invalid), x200c_areaIdx(areaIdx) {}
 
-    bool IsQualified(const CEntity& ent);
+    bool IsQualified(const CEntity& ent) override;
   };
 
   enum class EOcclusionState { Occluded, Visible };
@@ -272,15 +272,15 @@ public:
   void ReadDependencyList();
   void SetLoadPauseState(bool paused);
 
-  std::pair<std::unique_ptr<u8[]>, s32> IGetScriptingMemoryAlways() const;
+  std::pair<std::unique_ptr<u8[]>, s32> IGetScriptingMemoryAlways() const override;
   TAreaId GetAreaId() const { return x4_selfIdx; }
-  TAreaId IGetAreaId() const { return x4_selfIdx; }
-  CAssetId IGetAreaAssetId() const { return x84_mrea; }
-  bool IIsActive() const;
-  TAreaId IGetAttachedAreaId(int) const;
-  u32 IGetNumAttachedAreas() const;
-  CAssetId IGetStringTableAssetId() const;
-  const zeus::CTransform& IGetTM() const;
+  TAreaId IGetAreaId() const override { return x4_selfIdx; }
+  CAssetId IGetAreaAssetId() const override { return x84_mrea; }
+  bool IIsActive() const override;
+  TAreaId IGetAttachedAreaId(int) const override;
+  u32 IGetNumAttachedAreas() const override;
+  CAssetId IGetStringTableAssetId() const override;
+  const zeus::CTransform& IGetTM() const override;
 
   void SetXRaySpeedAndTarget(float speed, float target);
   void SetThermalSpeedAndTarget(float speed, float target);

--- a/Runtime/World/CGameLight.hpp
+++ b/Runtime/World/CGameLight.hpp
@@ -14,8 +14,8 @@ public:
   CGameLight(TUniqueId, TAreaId, bool, std::string_view, const zeus::CTransform&, TUniqueId, const CLight&,
              u32 sourceId, u32, float);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
   void SetLightPriorityAndId();
   void SetLight(const CLight&);
   CLight GetLight() const;

--- a/Runtime/World/CHUDBillboardEffect.hpp
+++ b/Runtime/World/CHUDBillboardEffect.hpp
@@ -29,12 +29,12 @@ public:
                       const std::optional<TToken<CElectricDescription>>& electric, TUniqueId uid,
                       bool active, std::string_view name, float dist, const zeus::CVector3f& scale0,
                       const zeus::CColor& color, const zeus::CVector3f& scale1, const zeus::CVector3f& translation);
-  ~CHUDBillboardEffect();
-  void Accept(IVisitor& visitor);
-  void Think(float dt, CStateManager& mgr);
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const;
-  void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum);
-  void Render(const CStateManager& mgr) const;
+  ~CHUDBillboardEffect() override;
+  void Accept(IVisitor& visitor) override;
+  void Think(float dt, CStateManager& mgr) override;
+  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
+  void Render(const CStateManager& mgr) const override;
   bool IsElementGen() const { return x104_26_isElementGen; }
   void SetRunIndefinitely(bool b) { x104_27_runIndefinitely = b; }
   CParticleGen* GetParticleGen() const { return xe8_generator.get(); }

--- a/Runtime/World/CIceImpact.hpp
+++ b/Runtime/World/CIceImpact.hpp
@@ -9,7 +9,7 @@ public:
   CIceImpact(const TLockedToken<CGenDescription>& particle, TUniqueId uid, TAreaId aid, bool active,
              std::string_view name, const zeus::CTransform& xf, u32 flags, const zeus::CVector3f& scale,
              const zeus::CColor& color);
-  void Accept(IVisitor& visitor);
+  void Accept(IVisitor& visitor) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CPatterned.hpp
+++ b/Runtime/World/CPatterned.hpp
@@ -256,67 +256,70 @@ public:
              CPatterned::EMovementType movement, EColliderType collider, EBodyType body, const CActorParameters& params,
              EKnockBackVariant kbVariant);
 
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void PreThink(float dt, CStateManager& mgr) { x500_preThinkDt = dt; CEntity::Think(x500_preThinkDt, mgr); }
-  void Think(float, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager& mgr) const;
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void PreThink(float dt, CStateManager& mgr) override {
+    x500_preThinkDt = dt;
+    CEntity::Think(x500_preThinkDt, mgr);
+  }
+  void Think(float, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager& mgr) const override;
 
-  void CollidedWith(TUniqueId, const CCollisionInfoList&, CStateManager& mgr);
-  void Touch(CActor& act, CStateManager& mgr);
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  bool CanRenderUnsorted(const CStateManager& mgr) const;
-  zeus::CVector3f GetOrbitPosition(const CStateManager& mgr) const { return GetAimPosition(mgr, 0.f); }
-  zeus::CVector3f GetAimPosition(const CStateManager& mgr, float) const;
+  void CollidedWith(TUniqueId, const CCollisionInfoList&, CStateManager& mgr) override;
+  void Touch(CActor& act, CStateManager& mgr) override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  bool CanRenderUnsorted(const CStateManager& mgr) const override;
+  zeus::CVector3f GetOrbitPosition(const CStateManager& mgr) const override { return GetAimPosition(mgr, 0.f); }
+  zeus::CVector3f GetAimPosition(const CStateManager& mgr, float) const override;
   zeus::CTransform GetLctrTransform(std::string_view name) const;
   zeus::CTransform GetLctrTransform(CSegId id) const;
 
   bool ApplyBoneTracking() const;
 
   void DeathDelete(CStateManager& mgr);
-  void Death(CStateManager& mgr, const zeus::CVector3f& direction, EScriptObjectState state);
+  void Death(CStateManager& mgr, const zeus::CVector3f& direction, EScriptObjectState state) override;
   void KnockBack(const zeus::CVector3f&, CStateManager&, const CDamageInfo& info, EKnockBackType type, bool inDeferred,
-                 float magnitude);
-  void TakeDamage(const zeus::CVector3f&, float arg);
-  bool FixedRandom(CStateManager&, float arg);
-  bool Random(CStateManager&, float arg);
-  bool CodeTrigger(CStateManager&, float arg);
-  bool FixedDelay(CStateManager&, float arg);
-  bool RandomDelay(CStateManager&, float arg);
-  bool Delay(CStateManager&, float arg);
-  bool PatrolPathOver(CStateManager&, float arg);
-  bool Stuck(CStateManager&, float arg);
-  bool AnimOver(CStateManager&, float arg);
-  bool InPosition(CStateManager&, float arg);
-  bool HasPatrolPath(CStateManager& mgr, float arg);
-  bool Attacked(CStateManager&, float arg);
-  bool PatternShagged(CStateManager&, float arg);
-  bool PatternOver(CStateManager&, float arg);
-  bool HasRetreatPattern(CStateManager& mgr, float arg);
-  bool HasAttackPattern(CStateManager& mgr, float arg);
-  bool NoPathNodes(CStateManager&, float arg);
-  bool PathShagged(CStateManager&, float arg);
-  bool PathFound(CStateManager&, float arg);
-  bool PathOver(CStateManager&, float arg);
-  bool Landed(CStateManager&, float arg);
-  bool PlayerSpot(CStateManager&, float arg);
-  bool SpotPlayer(CStateManager&, float arg);
-  bool Leash(CStateManager&, float arg);
-  bool InDetectionRange(CStateManager&, float arg);
-  bool InMaxRange(CStateManager&, float arg);
-  bool TooClose(CStateManager&, float arg);
-  bool InRange(CStateManager&, float arg);
-  bool OffLine(CStateManager&, float arg);
-  bool Default(CStateManager&, float arg) { return true; }
-  void PathFind(CStateManager&, EStateMsg msg, float dt);
-  void Dead(CStateManager&, EStateMsg msg, float dt);
-  void TargetPlayer(CStateManager&, EStateMsg msg, float dt);
-  void TargetPatrol(CStateManager&, EStateMsg msg, float dt);
-  void FollowPattern(CStateManager&, EStateMsg msg, float dt);
-  void Patrol(CStateManager&, EStateMsg msg, float dt);
-  void Start(CStateManager&, EStateMsg msg, float dt) {}
+                 float magnitude) override;
+  void TakeDamage(const zeus::CVector3f&, float arg) override;
+  bool FixedRandom(CStateManager&, float arg) override;
+  bool Random(CStateManager&, float arg) override;
+  bool CodeTrigger(CStateManager&, float arg) override;
+  bool FixedDelay(CStateManager&, float arg) override;
+  bool RandomDelay(CStateManager&, float arg) override;
+  bool Delay(CStateManager&, float arg) override;
+  bool PatrolPathOver(CStateManager&, float arg) override;
+  bool Stuck(CStateManager&, float arg) override;
+  bool AnimOver(CStateManager&, float arg) override;
+  bool InPosition(CStateManager&, float arg) override;
+  bool HasPatrolPath(CStateManager& mgr, float arg) override;
+  bool Attacked(CStateManager&, float arg) override;
+  bool PatternShagged(CStateManager&, float arg) override;
+  bool PatternOver(CStateManager&, float arg) override;
+  bool HasRetreatPattern(CStateManager& mgr, float arg) override;
+  bool HasAttackPattern(CStateManager& mgr, float arg) override;
+  bool NoPathNodes(CStateManager&, float arg) override;
+  bool PathShagged(CStateManager&, float arg) override;
+  bool PathFound(CStateManager&, float arg) override;
+  bool PathOver(CStateManager&, float arg) override;
+  bool Landed(CStateManager&, float arg) override;
+  bool PlayerSpot(CStateManager&, float arg) override;
+  bool SpotPlayer(CStateManager&, float arg) override;
+  bool Leash(CStateManager&, float arg) override;
+  bool InDetectionRange(CStateManager&, float arg) override;
+  bool InMaxRange(CStateManager&, float arg) override;
+  bool TooClose(CStateManager&, float arg) override;
+  bool InRange(CStateManager&, float arg) override;
+  bool OffLine(CStateManager&, float arg) override;
+  bool Default(CStateManager&, float arg) override { return true; }
+  void PathFind(CStateManager&, EStateMsg msg, float dt) override;
+  void Dead(CStateManager&, EStateMsg msg, float dt) override;
+  void TargetPlayer(CStateManager&, EStateMsg msg, float dt) override;
+  void TargetPatrol(CStateManager&, EStateMsg msg, float dt) override;
+  void FollowPattern(CStateManager&, EStateMsg msg, float dt) override;
+  void Patrol(CStateManager&, EStateMsg msg, float dt) override;
+  void Start(CStateManager&, EStateMsg msg, float dt) override {}
 
   void TryCommand(CStateManager& mgr, pas::EAnimationState state, CPatternedTryFunc func, int arg);
   void TryLoopReaction(CStateManager& mgr, int arg);
@@ -364,7 +367,7 @@ public:
   void LaunchProjectile(const zeus::CTransform& gunXf, CStateManager& mgr, int maxAllowed, EProjectileAttrib attrib,
                         bool playerHoming, const std::optional<TLockedToken<CGenDescription>>& visorParticle,
                         u16 visorSfx, bool sendCollideMsg, const zeus::CVector3f& scale);
-  void DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node, EUserEventType type, float dt);
+  void DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node, EUserEventType type, float dt) override;
 
   void SetDestPos(const zeus::CVector3f& pos) { x2e0_destPos = pos; }
   void UpdateAlphaDelta(float dt, CStateManager& mgr);

--- a/Runtime/World/CPhysicsActor.hpp
+++ b/Runtime/World/CPhysicsActor.hpp
@@ -112,9 +112,9 @@ public:
   CPhysicsActor(TUniqueId, bool, std::string_view, const CEntityInfo&, const zeus::CTransform&, CModelData&&,
                 const CMaterialList&, const zeus::CAABox&, const SMoverData&, const CActorParameters&, float, float);
 
-  void Render(const CStateManager& mgr) const;
-  zeus::CVector3f GetOrbitPosition(const CStateManager&) const;
-  zeus::CVector3f GetAimPosition(const CStateManager&, float val) const;
+  void Render(const CStateManager& mgr) const override;
+  zeus::CVector3f GetOrbitPosition(const CStateManager&) const override;
+  zeus::CVector3f GetAimPosition(const CStateManager&, float val) const override;
   virtual const CCollisionPrimitive* GetCollisionPrimitive() const;
   virtual zeus::CTransform GetPrimitiveTransform() const;
   virtual void CollidedWith(TUniqueId, const CCollisionInfoList&, CStateManager&);

--- a/Runtime/World/CPlayer.hpp
+++ b/Runtime/World/CPlayer.hpp
@@ -367,23 +367,23 @@ public:
   void AsyncLoadSuit(CStateManager& mgr);
   void LoadAnimationTokens();
   bool HasTransitionBeamModel() const;
-  bool CanRenderUnsorted(const CStateManager& mgr) const;
+  bool CanRenderUnsorted(const CStateManager& mgr) const override;
   const CDamageVulnerability* GetDamageVulnerability(const zeus::CVector3f& v1, const zeus::CVector3f& v2,
-                                                     const CDamageInfo& info) const;
-  const CDamageVulnerability* GetDamageVulnerability() const;
-  zeus::CVector3f GetHomingPosition(const CStateManager& mgr, float) const;
-  zeus::CVector3f GetAimPosition(const CStateManager& mgr, float) const;
-  void FluidFXThink(CActor::EFluidState, CScriptWater& water, CStateManager& mgr);
+                                                     const CDamageInfo& info) const override;
+  const CDamageVulnerability* GetDamageVulnerability() const override;
+  zeus::CVector3f GetHomingPosition(const CStateManager& mgr, float) const override;
+  zeus::CVector3f GetAimPosition(const CStateManager& mgr, float) const override;
+  void FluidFXThink(CActor::EFluidState, CScriptWater& water, CStateManager& mgr) override;
   zeus::CVector3f GetDamageLocationWR() const { return x564_damageLocation; }
   float GetPrevDamageAmount() const { return x560_prevDamageAmt; }
   float GetDamageAmount() const { return x55c_damageAmt; }
   bool WasDamaged() const { return x558_wasDamaged; }
   void TakeDamage(bool, const zeus::CVector3f&, float, EWeaponType, CStateManager& mgr);
-  void Accept(IVisitor& visitor);
-  CHealthInfo* HealthInfo(CStateManager& mgr);
+  void Accept(IVisitor& visitor) override;
+  CHealthInfo* HealthInfo(CStateManager& mgr) override;
   bool IsUnderBetaMetroidAttack(CStateManager& mgr) const;
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor& actor, CStateManager& mgr);
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor& actor, CStateManager& mgr) override;
   void DoPreThink(float dt, CStateManager& mgr);
   void DoThink(float dt, CStateManager& mgr);
   void UpdateScanningState(const CFinalInput& input, CStateManager& mgr, float);
@@ -394,11 +394,11 @@ public:
   bool GetExplorationMode() const;
   bool GetCombatMode() const;
   void RenderGun(const CStateManager& mgr, const zeus::CVector3f&) const;
-  void Render(const CStateManager& mgr) const;
+  void Render(const CStateManager& mgr) const override;
   void RenderReflectedPlayer(CStateManager& mgr);
-  void PreRender(CStateManager& mgr, const zeus::CFrustum&);
-  void CalculateRenderBounds();
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
+  void PreRender(CStateManager& mgr, const zeus::CFrustum&) override;
+  void CalculateRenderBounds() override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
   void ComputeFreeLook(const CFinalInput& input);
   void UpdateFreeLookState(const CFinalInput&, float dt, CStateManager&);
   void UpdateFreeLook(float dt);
@@ -427,9 +427,9 @@ public:
   void ResetControlDirectionInterpolation();
   void SetControlDirectionInterpolation(float time);
   void UpdatePlayerControlDirection(float dt, CStateManager& mgr);
-  void Think(float, CStateManager&);
-  void PreThink(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Think(float, CStateManager&) override;
+  void PreThink(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void SetVisorSteam(float, float, float, CAssetId, bool);
   void UpdateFootstepSounds(const CFinalInput& input, CStateManager&, float);
   u16 GetMaterialSoundUnderPlayer(CStateManager& mgr, const u16*, u32, u16);
@@ -514,15 +514,15 @@ public:
   zeus::CVector3f GetEyePosition() const;
   float GetEyeHeight() const;
   float GetUnbiasedEyeHeight() const;
-  float GetStepUpHeight() const;
-  float GetStepDownHeight() const;
+  float GetStepUpHeight() const override;
+  float GetStepDownHeight() const override;
   void Teleport(const zeus::CTransform& xf, CStateManager& mgr, bool resetBallCam);
   void BombJump(const zeus::CVector3f& pos, CStateManager& mgr);
   zeus::CTransform CreateTransformFromMovementDirection() const;
-  const CCollisionPrimitive* GetCollisionPrimitive() const;
+  const CCollisionPrimitive* GetCollisionPrimitive() const override;
   const CCollidableSphere* GetCollidableSphere() const;
-  zeus::CTransform GetPrimitiveTransform() const;
-  void CollidedWith(TUniqueId, const CCollisionInfoList&, CStateManager& mgr);
+  zeus::CTransform GetPrimitiveTransform() const override;
+  void CollidedWith(TUniqueId, const CCollisionInfoList&, CStateManager& mgr) override;
   float GetBallMaxVelocity() const;
   float GetActualBallMaxVelocity(float dt) const;
   float GetActualFirstPersonMaxVelocity(float dt) const;
@@ -536,7 +536,7 @@ public:
   void FinishSidewaysDash();
   void ComputeDash(const CFinalInput& input, float dt, CStateManager& mgr);
   void ComputeMovement(const CFinalInput& input, CStateManager& mgr, float dt);
-  float GetWeight() const;
+  float GetWeight() const override;
   zeus::CVector3f GetDampedClampedVelocityWR() const;
   const CVisorSteam& GetVisorSteam() const { return x7a0_visorSteam; }
   float GetVisorStaticAlpha() const { return x74c_visorStaticAlpha; }

--- a/Runtime/World/CRepulsor.hpp
+++ b/Runtime/World/CRepulsor.hpp
@@ -8,8 +8,8 @@ class CRepulsor : public CActor {
 public:
   CRepulsor(TUniqueId, bool, std::string_view, const CEntityInfo&, const zeus::CVector3f&, float);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
 
   float GetAffectRadius() const { return xe8_affectRadius; }
 };

--- a/Runtime/World/CScriptActor.hpp
+++ b/Runtime/World/CScriptActor.hpp
@@ -32,17 +32,17 @@ public:
                const CHealthInfo& hInfo, const CDamageVulnerability& dVuln, const CActorParameters& actParms,
                bool looping, bool active, s32 shaderIdx, float xrayAlpha, bool noThermalHotZ, bool castsShadow,
                bool scaleAdvancementDelta, bool materialFlag54);
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  zeus::CAABox GetSortingBounds(const CStateManager&) const;
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  zeus::CAABox GetSortingBounds(const CStateManager&) const override;
   EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
-                                                         const CWeaponMode&, EProjectileAttrib) const;
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor&, CStateManager&);
-  const CDamageVulnerability* GetDamageVulnerability() const { return &x268_damageVulnerability; }
-  CHealthInfo* HealthInfo(CStateManager&) { return &x260_currentHealth; }
+                                                         const CWeaponMode&, EProjectileAttrib) const override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor&, CStateManager&) override;
+  const CDamageVulnerability* GetDamageVulnerability() const override { return &x268_damageVulnerability; }
+  CHealthInfo* HealthInfo(CStateManager&) override { return &x260_currentHealth; }
   bool IsPlayerActor() const { return x2e3_24_isPlayerActor; }
 };
 }; // namespace urde

--- a/Runtime/World/CScriptActorKeyframe.hpp
+++ b/Runtime/World/CScriptActorKeyframe.hpp
@@ -25,9 +25,9 @@ public:
   CScriptActorKeyframe(TUniqueId uid, std::string_view name, const CEntityInfo& info, s32 animId, bool looping,
                        float lifetime, bool isPassive, u32 fadeOut, bool active, float totalPlayback);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
-  void Think(float, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
+  void Think(float, CStateManager&) override;
   void UpdateEntity(TUniqueId, CStateManager&);
   bool IsPassive() const { return x44_25_isPassive; }
   void SetIsPassive(bool b) { x44_25_isPassive = b; }

--- a/Runtime/World/CScriptActorRotate.hpp
+++ b/Runtime/World/CScriptActorRotate.hpp
@@ -30,9 +30,9 @@ class CScriptActorRotate : public CEntity {
 public:
   CScriptActorRotate(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CVector3f&, float, bool, bool, bool);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptAiJumpPoint.hpp
+++ b/Runtime/World/CScriptAiJumpPoint.hpp
@@ -21,12 +21,12 @@ private:
 public:
   CScriptAiJumpPoint(TUniqueId, std::string_view, const CEntityInfo&, zeus::CTransform&, bool, float);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {}
-  void Render(const CStateManager&) const {}
-  std::optional<zeus::CAABox> GetTouchBounds() const;
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void Render(const CStateManager&) const override {}
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
   bool GetInUse(TUniqueId uid) const;
   TUniqueId GetJumpPoint() const { return x10c_currentWaypoint; }
   TUniqueId GetJumpTarget() const { return x10e_nextWaypoint; }

--- a/Runtime/World/CScriptAreaAttributes.hpp
+++ b/Runtime/World/CScriptAreaAttributes.hpp
@@ -19,8 +19,8 @@ public:
                         float thermalHeat, float xrayFogDistance, float worldLightingLevel, CAssetId skybox,
                         EPhazonType phazonType);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 
   bool GetNeedsSky() const { return x34_24_showSkybox; }
   bool GetNeedsEnvFx() const { return x38_envFx != EEnvFxType::None; }

--- a/Runtime/World/CScriptBallTrigger.hpp
+++ b/Runtime/World/CScriptBallTrigger.hpp
@@ -15,10 +15,10 @@ public:
   CScriptBallTrigger(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CVector3f&, const zeus::CVector3f&,
                      bool, float, float, float, const zeus::CVector3f&, bool);
 
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager& mgr);
-  void InhabitantAdded(CActor&, CStateManager&);
-  void InhabitantExited(CActor&, CStateManager&);
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager& mgr) override;
+  void InhabitantAdded(CActor&, CStateManager&) override;
+  void InhabitantExited(CActor&, CStateManager&) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptBeam.hpp
+++ b/Runtime/World/CScriptBeam.hpp
@@ -16,8 +16,8 @@ public:
   CScriptBeam(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CTransform&, bool,
               const TToken<CWeaponDescription>&, const CBeamInfo&, const CDamageInfo&);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptCameraBlurKeyframe.hpp
+++ b/Runtime/World/CScriptCameraBlurKeyframe.hpp
@@ -15,7 +15,7 @@ public:
   CScriptCameraBlurKeyframe(TUniqueId uid, std::string_view name, const CEntityInfo& info, EBlurType type, float amount,
                             u32 unk, float timeIn, float timeOut, bool active);
 
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
-  void Accept(IVisitor& visitor);
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
+  void Accept(IVisitor& visitor) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptCameraFilterKeyframe.hpp
+++ b/Runtime/World/CScriptCameraFilterKeyframe.hpp
@@ -20,7 +20,7 @@ public:
                               EFilterShape shape, u32 filterIdx, u32 unk, const zeus::CColor& color, float timeIn,
                               float timeOut, CAssetId txtr, bool active);
 
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
-  void Accept(IVisitor& visitor);
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
+  void Accept(IVisitor& visitor) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptCameraHint.hpp
+++ b/Runtime/World/CScriptCameraHint.hpp
@@ -90,8 +90,8 @@ public:
                     float clampRotRange, float elevation, float interpolateTime, float clampVelTime,
                     float controlInterpDur);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
 
   void ClearIdList() { x150_helpers.clear(); }
   void SetInactive(bool inactive) { x166_inactive = inactive; }

--- a/Runtime/World/CScriptCameraHintTrigger.hpp
+++ b/Runtime/World/CScriptCameraHintTrigger.hpp
@@ -23,9 +23,9 @@ public:
                            const zeus::CTransform& xf, bool deactivateOnEnter,
                            bool deactivateOnExit);
 
-  void Accept(IVisitor& visitor);
-  void Think(float dt, CStateManager& mgr);
-  void Touch(CActor& other, CStateManager& mgr);
-  std::optional<zeus::CAABox> GetTouchBounds() const;
+  void Accept(IVisitor& visitor) override;
+  void Think(float dt, CStateManager& mgr) override;
+  void Touch(CActor& other, CStateManager& mgr) override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptCameraPitchVolume.hpp
+++ b/Runtime/World/CScriptCameraPitchVolume.hpp
@@ -25,10 +25,10 @@ public:
   CScriptCameraPitchVolume(TUniqueId, bool, std::string_view, const CEntityInfo&, const zeus::CVector3f&,
                            const zeus::CTransform&, const zeus::CRelAngle&, const zeus::CRelAngle&, float);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor&, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor&, CStateManager&) override;
   float GetUpPitch() const { return x124_upPitch; }
   float GetDownPitch() const { return x128_downPitch; }
   const zeus::CVector3f& GetScale() const { return x12c_scale; }

--- a/Runtime/World/CScriptCameraShaker.hpp
+++ b/Runtime/World/CScriptCameraShaker.hpp
@@ -11,8 +11,8 @@ class CScriptCameraShaker : public CEntity {
 public:
   CScriptCameraShaker(TUniqueId uid, std::string_view name, const CEntityInfo& info, bool active,
                       const CCameraShakeData& shakeData);
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptCameraWaypoint.hpp
+++ b/Runtime/World/CScriptCameraWaypoint.hpp
@@ -12,10 +12,10 @@ public:
   CScriptCameraWaypoint(TUniqueId uid, std::string_view name, const CEntityInfo& info, const zeus::CTransform& xf,
                         bool active, float hfov, u32);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {}
-  void Render(const CStateManager&) const {}
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void Render(const CStateManager&) const override {}
   TUniqueId GetRandomNextWaypointId(CStateManager& mgr) const;
   float GetHFov() const { return xe8_hfov; }
 };

--- a/Runtime/World/CScriptColorModulate.hpp
+++ b/Runtime/World/CScriptColorModulate.hpp
@@ -45,9 +45,9 @@ public:
                        const zeus::CColor& colorB, EBlendMode blendMode, float timeA2B, float timeB2A, bool doReverse,
                        bool resetTargetWhenDone, bool depthCompare, bool depthUpdate, bool depthBackwards, bool active);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
-  void Think(float, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
+  void Think(float, CStateManager&) override;
   CModelFlags CalculateFlags(const zeus::CColor&) const;
   void SetTargetFlags(CStateManager&, const CModelFlags&);
   static TUniqueId FadeOutHelper(CStateManager& mgr, TUniqueId obj, float fadetime);

--- a/Runtime/World/CScriptControllerAction.hpp
+++ b/Runtime/World/CScriptControllerAction.hpp
@@ -20,8 +20,8 @@ class CScriptControllerAction : public CEntity {
 public:
   CScriptControllerAction(TUniqueId uid, std::string_view name, const CEntityInfo& info, bool active,
                           ControlMapper::ECommands command, bool b1, u32 w1, bool b2);
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptCounter.hpp
+++ b/Runtime/World/CScriptCounter.hpp
@@ -13,8 +13,8 @@ class CScriptCounter : public CEntity {
 public:
   CScriptCounter(TUniqueId, std::string_view name, const CEntityInfo& info, s32, s32, bool, bool);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptCoverPoint.hpp
+++ b/Runtime/World/CScriptCoverPoint.hpp
@@ -32,12 +32,12 @@ public:
   CScriptCoverPoint(TUniqueId uid, std::string_view name, const CEntityInfo& info, zeus::CTransform xf, bool active,
                     u32 flags, bool crouch, float horizontalAngle, float verticalAngle, float coverTime);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {}
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Render(const CStateManager&) const {}
-  std::optional<zeus::CAABox> GetTouchBounds() const;
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Render(const CStateManager&) const override {}
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
   void SetInUse(bool inUse);
   bool GetInUse(TUniqueId uid) const;
   bool ShouldLandHere() const { return xe8_26_landHere; }

--- a/Runtime/World/CScriptDamageableTrigger.hpp
+++ b/Runtime/World/CScriptDamageableTrigger.hpp
@@ -45,16 +45,16 @@ public:
                            const CDamageVulnerability& dVuln, u32 faceFlag, CAssetId patternTex1, CAssetId patternTex2,
                            CAssetId colorTex, ECanOrbit canOrbit, bool active, const CVisorParameters& vParams);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
-                                                         const CWeaponMode&, EProjectileAttrib) const;
-  void Render(const CStateManager& mgr) const;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const;
-  void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum);
-  const CDamageVulnerability* GetDamageVulnerability() const { return &x174_dVuln; }
-  CHealthInfo* HealthInfo(CStateManager&) { return &x16c_hInfo; }
-  void Think(float, CStateManager&);
-  std::optional<zeus::CAABox> GetTouchBounds() const;
+                                                         const CWeaponMode&, EProjectileAttrib) const override;
+  void Render(const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
+  const CDamageVulnerability* GetDamageVulnerability() const override { return &x174_dVuln; }
+  CHealthInfo* HealthInfo(CStateManager&) override { return &x16c_hInfo; }
+  void Think(float, CStateManager&) override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptDebris.hpp
+++ b/Runtime/World/CScriptDebris.hpp
@@ -70,15 +70,15 @@ public:
                 const zeus::CVector3f& particle3Scale, EOrientationType particle3Or, bool solid, bool dieOnProjectile,
                 bool noBounce, bool active);
 
-  void Accept(IVisitor& visitor);
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const;
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr);
-  void Think(float dt, CStateManager& mgr);
-  void Touch(CActor& other, CStateManager& mgr);
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum);
-  void Render(const CStateManager& mgr) const;
+  void Accept(IVisitor& visitor) override;
+  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
+  void Think(float dt, CStateManager& mgr) override;
+  void Touch(CActor& other, CStateManager& mgr) override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
+  void Render(const CStateManager& mgr) const override;
 
-  void CollidedWith(TUniqueId uid, const CCollisionInfoList&, CStateManager&);
+  void CollidedWith(TUniqueId uid, const CCollisionInfoList&, CStateManager&) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptDebugCameraWaypoint.hpp
+++ b/Runtime/World/CScriptDebugCameraWaypoint.hpp
@@ -11,7 +11,7 @@ public:
   CScriptDebugCameraWaypoint(TUniqueId uid, std::string_view name, const CEntityInfo& info, const zeus::CTransform& xf,
                              u32 w1);
 
-  void Accept(IVisitor&);
+  void Accept(IVisitor&) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptDistanceFog.hpp
+++ b/Runtime/World/CScriptDistanceFog.hpp
@@ -21,7 +21,7 @@ public:
   CScriptDistanceFog(TUniqueId, std::string_view, const CEntityInfo&, ERglFogMode, const zeus::CColor&,
                      const zeus::CVector2f&, float, const zeus::CVector2f&, bool, bool, float, float, float, float);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptDock.hpp
+++ b/Runtime/World/CScriptDock.hpp
@@ -26,11 +26,11 @@ public:
               const zeus::CVector3f& extent, s32 dock, TAreaId area, bool active, s32 dockReferenceCount,
               bool loadConnected);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor&, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor&, CStateManager&) override;
   void CleanUp() {}
   zeus::CPlane GetPlane(const CStateManager&) const;
   TAreaId GetAreaId() const { return x260_area; }

--- a/Runtime/World/CScriptDockAreaChange.hpp
+++ b/Runtime/World/CScriptDockAreaChange.hpp
@@ -9,7 +9,7 @@ class CScriptDockAreaChange : public CEntity {
 public:
   CScriptDockAreaChange(TUniqueId, std::string_view, const CEntityInfo&, s32, bool);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptDoor.hpp
+++ b/Runtime/World/CScriptDoor.hpp
@@ -42,18 +42,18 @@ public:
               const CActorParameters&, const zeus::CVector3f&, const zeus::CAABox&, bool active, bool open, bool, float,
               bool ballDoor);
 
-  zeus::CVector3f GetOrbitPosition(const CStateManager& mgr) const;
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr);
-  void Think(float, CStateManager& mgr);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager& mgr) const;
-  void Render(const CStateManager&) const {}
+  zeus::CVector3f GetOrbitPosition(const CStateManager& mgr) const override;
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
+  void Think(float, CStateManager& mgr) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager& mgr) const override;
+  void Render(const CStateManager&) const override {}
   void ForceClosed(CStateManager&);
   bool IsConnectedToArea(const CStateManager& mgr, TAreaId area);
   void OpenDoor(TUniqueId, CStateManager&);
   EDoorOpenCondition GetDoorOpenCondition(CStateManager& mgr);
   void SetDoorAnimation(EDoorAnimType);
-  std::optional<zeus::CAABox> GetTouchBounds() const;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
   std::optional<zeus::CAABox> GetProjectileBounds() const;
   bool IsOpen() const { return x2a8_26_isOpen; }
 };

--- a/Runtime/World/CScriptEMPulse.hpp
+++ b/Runtime/World/CScriptEMPulse.hpp
@@ -23,13 +23,13 @@ public:
   CScriptEMPulse(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CTransform&, bool, float, float, float,
                  float, float, float, float, CAssetId);
 
-  void Accept(IVisitor&);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void CalculateRenderBounds();
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor&, CStateManager&);
+  void Accept(IVisitor&) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void CalculateRenderBounds() override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor&, CStateManager&) override;
 };
 } // namespace urde
 #endif // __URDE_CSCRIPTEMPULSE_HPP__

--- a/Runtime/World/CScriptEffect.hpp
+++ b/Runtime/World/CScriptEffect.hpp
@@ -52,19 +52,19 @@ public:
                 float rateCamDistRangeFarRate, bool combatVisorVisible, bool thermalVisorVisible, bool xrayVisorVisible,
                 const CLightParameters& lParms, bool dieWhenSystemsDone);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const;
-  void Think(float, CStateManager&);
-  bool CanRenderUnsorted(const CStateManager&) const { return false; }
-  void SetActive(bool active) {
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override;
+  void Think(float, CStateManager&) override;
+  bool CanRenderUnsorted(const CStateManager&) const override { return false; }
+  void SetActive(bool active) override {
     CActor::SetActive(active);
     xe7_29_drawEnabled = true;
   }
-  void CalculateRenderBounds();
-  zeus::CAABox GetSortingBounds(const CStateManager&) const;
+  void CalculateRenderBounds() override;
+  zeus::CAABox GetSortingBounds(const CStateManager&) const override;
   bool AreBothSystemsDeleteable();
   static void ResetParticleCounts() {
     g_NumParticlesUpdating = 0;

--- a/Runtime/World/CScriptGenerator.hpp
+++ b/Runtime/World/CScriptGenerator.hpp
@@ -22,7 +22,7 @@ public:
   CScriptGenerator(TUniqueId uid, std::string_view name, const CEntityInfo& info, u32 spawnCount, bool noReuseFollowers,
                    const zeus::CVector3f& vec1, bool noInheritXf, bool active, float minScale, float maxScale);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptGrapplePoint.hpp
+++ b/Runtime/World/CScriptGrapplePoint.hpp
@@ -12,12 +12,12 @@ public:
   CScriptGrapplePoint(TUniqueId uid, std::string_view name, const CEntityInfo& info, const zeus::CTransform& transform,
                       bool active, const CGrappleParameters& params);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void Render(const CStateManager&) const;
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void Render(const CStateManager&) const override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
   const CGrappleParameters& GetGrappleParameters() const { return x100_parameters; }
 };
 } // namespace urde

--- a/Runtime/World/CScriptGunTurret.hpp
+++ b/Runtime/World/CScriptGunTurret.hpp
@@ -221,17 +221,17 @@ public:
                    const CDamageVulnerability& dVuln, const CActorParameters& aParms,
                    const CScriptGunTurretData& turretData);
 
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void Touch(CActor&, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const;
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  zeus::CVector3f GetOrbitPosition(const CStateManager&) const;
-  zeus::CVector3f GetAimPosition(const CStateManager&, float) const;
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void Touch(CActor&, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  zeus::CVector3f GetOrbitPosition(const CStateManager&) const override;
+  zeus::CVector3f GetAimPosition(const CStateManager&, float) const override;
 
-  CHealthInfo* HealthInfo(CStateManager&) { return &x264_healthInfo; }
-  const CDamageVulnerability* GetDamageVulnerability() const { return &x26c_damageVuln; }
+  CHealthInfo* HealthInfo(CStateManager&) override { return &x264_healthInfo; }
+  const CDamageVulnerability* GetDamageVulnerability() const override { return &x26c_damageVuln; }
 };
 } // namespace urde

--- a/Runtime/World/CScriptHUDMemo.hpp
+++ b/Runtime/World/CScriptHUDMemo.hpp
@@ -21,7 +21,7 @@ public:
   CScriptHUDMemo(TUniqueId, std::string_view, const CEntityInfo&, const CHUDMemoParms&, CScriptHUDMemo::EDisplayType,
                  CAssetId, bool);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptMazeNode.hpp
+++ b/Runtime/World/CScriptMazeNode.hpp
@@ -32,7 +32,7 @@ public:
   CScriptMazeNode(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CTransform&, bool, s32, s32, s32,
                   const zeus::CVector3f&, const zeus::CVector3f&, const zeus::CVector3f&);
 
-  void Accept(IVisitor& visitor);
+  void Accept(IVisitor& visitor) override;
   static void LoadMazeSeeds();
 };
 } // namespace urde

--- a/Runtime/World/CScriptMemoryRelay.hpp
+++ b/Runtime/World/CScriptMemoryRelay.hpp
@@ -15,7 +15,7 @@ class CScriptMemoryRelay : public CEntity {
 
 public:
   CScriptMemoryRelay(TUniqueId, std::string_view name, const CEntityInfo&, bool, bool, bool);
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptMidi.hpp
+++ b/Runtime/World/CScriptMidi.hpp
@@ -21,8 +21,8 @@ public:
 
   void Stop(CStateManager& mgr, float fadeTime);
   void Play(CStateManager& mgr, float fadeTime);
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptPickup.hpp
+++ b/Runtime/World/CScriptPickup.hpp
@@ -26,10 +26,10 @@ public:
                 CPlayerState::EItemType itemType, s32 amount, s32 capacity, CAssetId pickupEffect,
                 float possibility, float lifeTime, float fadeInTime, float startDelay, bool active);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void Touch(CActor&, CStateManager&);
-  std::optional<zeus::CAABox> GetTouchBounds() const { return CPhysicsActor::GetBoundingBox(); }
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void Touch(CActor&, CStateManager&) override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override { return CPhysicsActor::GetBoundingBox(); }
   float GetPossibility() const { return x264_possibility; }
   CPlayerState::EItemType GetItem() const { return x258_itemType; }
   void SetGenerated() { x28c_24_generated = true; }

--- a/Runtime/World/CScriptPickupGenerator.hpp
+++ b/Runtime/World/CScriptPickupGenerator.hpp
@@ -16,7 +16,7 @@ class CScriptPickupGenerator : public CEntity {
 public:
   CScriptPickupGenerator(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CVector3f&, float, bool);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& stateMgr) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptPlatform.hpp
+++ b/Runtime/World/CScriptPlatform.hpp
@@ -76,18 +76,18 @@ public:
                   const std::optional<TLockedToken<CCollidableOBBTreeGroupContainer>>& dcln,
                   bool rainSplashes, u32 maxRainSplashes, u32 rainGenRate);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void PreThink(float, CStateManager&);
-  void Think(float, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void Render(const CStateManager&) const;
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  zeus::CTransform GetPrimitiveTransform() const;
-  const CCollisionPrimitive* GetCollisionPrimitive() const;
-  zeus::CVector3f GetOrbitPosition(const CStateManager& mgr) const;
-  zeus::CVector3f GetAimPosition(const CStateManager& mgr, float dt) const;
-  zeus::CAABox GetSortingBounds(const CStateManager& mgr) const;
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void PreThink(float, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void Render(const CStateManager&) const override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  zeus::CTransform GetPrimitiveTransform() const override;
+  const CCollisionPrimitive* GetCollisionPrimitive() const override;
+  zeus::CVector3f GetOrbitPosition(const CStateManager& mgr) const override;
+  zeus::CVector3f GetAimPosition(const CStateManager& mgr, float dt) const override;
+  zeus::CAABox GetSortingBounds(const CStateManager& mgr) const override;
   bool IsRider(TUniqueId id) const;
   bool IsSlave(TUniqueId id) const;
   std::vector<SRiders>& GetStaticSlaves() { return x328_slavesStatic; }
@@ -101,8 +101,8 @@ public:
   TUniqueId GetNext(TUniqueId, CStateManager&);
   TUniqueId GetWaypoint(CStateManager&);
 
-  const CDamageVulnerability* GetDamageVulnerability() const { return &x29c_damageVuln; }
-  CHealthInfo* HealthInfo(CStateManager&) { return &x294_health; }
+  const CDamageVulnerability* GetDamageVulnerability() const override { return &x29c_damageVuln; }
+  CHealthInfo* HealthInfo(CStateManager&) override { return &x294_health; }
   void SetControlledAnimation(bool controlled) { x356_25_controlledAnimation = controlled; }
 
   virtual void SplashThink(const zeus::CAABox&, const CFluidPlane&, float, CStateManager&) const;

--- a/Runtime/World/CScriptPlayerActor.hpp
+++ b/Runtime/World/CScriptPlayerActor.hpp
@@ -59,12 +59,12 @@ public:
                      const CDamageVulnerability& dVuln, const CActorParameters& aParams, bool loop, bool active,
                      u32 flags, CPlayerState::EBeamId beam);
 
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void SetActive(bool active);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager& mgr) const;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void SetActive(bool active) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager& mgr) const override;
   void TouchModels(const CStateManager& mgr) const;
 };
 } // namespace urde

--- a/Runtime/World/CScriptPlayerHint.hpp
+++ b/Runtime/World/CScriptPlayerHint.hpp
@@ -16,8 +16,8 @@ class CScriptPlayerHint : public CActor {
 public:
   CScriptPlayerHint(TUniqueId uid, std::string_view name, const CEntityInfo& info, const zeus::CTransform& xf,
                     bool active, u32 priority, u32 overrideFlags);
-  void Accept(IVisitor& visit);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor& visit) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   u32 GetPriority() const { return x100_priority; }
   u32 GetOverrideFlags() const { return x104_overrideFlags; }
   TUniqueId GetActorId() const { return x108_mpId; }

--- a/Runtime/World/CScriptPlayerStateChange.hpp
+++ b/Runtime/World/CScriptPlayerStateChange.hpp
@@ -18,7 +18,7 @@ private:
 public:
   CScriptPlayerStateChange(TUniqueId, std::string_view, const CEntityInfo&, bool, u32, u32, u32, EControl,
                            EControlCommandOption);
-  void Accept(IVisitor& visit);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor& visit) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptPointOfInterest.hpp
+++ b/Runtime/World/CScriptPointOfInterest.hpp
@@ -12,12 +12,12 @@ public:
   CScriptPointOfInterest(TUniqueId, std::string_view, const CEntityInfo, const zeus::CTransform&, bool,
                          const CScannableParameters&, float);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const;
-  void CalculateRenderBounds();
-  std::optional<zeus::CAABox> GetTouchBounds() const;
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override;
+  void CalculateRenderBounds() override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptRandomRelay.hpp
+++ b/Runtime/World/CScriptRandomRelay.hpp
@@ -12,8 +12,8 @@ public:
   CScriptRandomRelay(TUniqueId uid, std::string_view name, const CEntityInfo& info, s32 sendSetSize,
                      s32 sendSetVariance, bool percentSize, bool active);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
   void SendLocalScriptMsgs(EScriptObjectState state, CStateManager& stateMgr);
 };
 } // namespace urde

--- a/Runtime/World/CScriptRelay.hpp
+++ b/Runtime/World/CScriptRelay.hpp
@@ -10,9 +10,9 @@ class CScriptRelay : public CEntity {
 public:
   CScriptRelay(TUniqueId, std::string_view, const CEntityInfo&, bool);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
-  void Think(float, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
+  void Think(float, CStateManager& stateMgr) override;
   void UpdateObjectRef(CStateManager& stateMgr);
 };
 } // namespace urde

--- a/Runtime/World/CScriptRipple.hpp
+++ b/Runtime/World/CScriptRipple.hpp
@@ -11,8 +11,8 @@ class CScriptRipple : public CEntity {
 public:
   CScriptRipple(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CVector3f&, bool, float);
 
-  void Accept(IVisitor&);
-  void Think(float, CStateManager&) {}
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor&) override;
+  void Think(float, CStateManager&) override {}
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptRoomAcoustics.hpp
+++ b/Runtime/World/CScriptRoomAcoustics.hpp
@@ -30,9 +30,9 @@ public:
                        float revStdMix, float revStdTime, float revStdDamping, float revStdPreDelay, bool delay,
                        u32 delayL, u32 delayR, u32 delayS, u32 feedbackL, u32 feedbackR, u32 feedbackS, u32 outputL,
                        u32 outputR, u32 outputS);
-  void Think(float dt, CStateManager& stateMgr);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
-  void Accept(IVisitor& visitor);
+  void Think(float dt, CStateManager& stateMgr) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
+  void Accept(IVisitor& visitor) override;
   void EnableAuxCallbacks();
 
   static void DisableAuxCallbacks();

--- a/Runtime/World/CScriptShadowProjector.hpp
+++ b/Runtime/World/CScriptShadowProjector.hpp
@@ -26,11 +26,11 @@ public:
   CScriptShadowProjector(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CTransform&, bool,
                          const zeus::CVector3f&, bool, float, float, float, float, s32);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {}
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
   void CreateProjectedShadow();
 };
 } // namespace urde

--- a/Runtime/World/CScriptSound.hpp
+++ b/Runtime/World/CScriptSound.hpp
@@ -48,11 +48,11 @@ public:
                u32 pan, u32 w6, bool looped, bool nonEmitter, bool autoStart, bool occlusionTest, bool acoustics,
                bool worldSfx, bool allowDuplicates, s32 pitch);
 
-  void Accept(IVisitor& visitor);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {}
-  void PreThink(float, CStateManager&);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void PreThink(float, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PlaySound(CStateManager&);
   void StopSound(CStateManager&);
 };

--- a/Runtime/World/CScriptSpawnPoint.hpp
+++ b/Runtime/World/CScriptSpawnPoint.hpp
@@ -21,8 +21,8 @@ public:
   CScriptSpawnPoint(TUniqueId, std::string_view name, const CEntityInfo& info, const zeus::CTransform& xf,
                     const rstl::reserved_vector<u32, int(CPlayerState::EItemType::Max)>& itemCounts, bool, bool, bool);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
   bool FirstSpawn() const { return x10c_24_firstSpawn; }
   const zeus::CTransform& GetTransform() const { return x34_xf; }
   u32 GetPowerup(CPlayerState::EItemType item) const;

--- a/Runtime/World/CScriptSpecialFunction.hpp
+++ b/Runtime/World/CScriptSpecialFunction.hpp
@@ -119,12 +119,12 @@ public:
                          std::string_view, float, float, float, float, const zeus::CVector3f&, const zeus::CColor&,
                          bool, const CDamageInfo&, s32, s32, CPlayerState::EItemType, s16, s16, s16);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const;
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override;
 
   void SkipCinematic(CStateManager&);
   void RingScramble(CStateManager&);

--- a/Runtime/World/CScriptSpiderBallAttractionSurface.hpp
+++ b/Runtime/World/CScriptSpiderBallAttractionSurface.hpp
@@ -11,11 +11,11 @@ class CScriptSpiderBallAttractionSurface : public CActor {
 public:
   CScriptSpiderBallAttractionSurface(TUniqueId uid, std::string_view name, const CEntityInfo& info,
                                      const zeus::CTransform& xf, const zeus::CVector3f& scale, bool active);
-  void Accept(IVisitor& visitor);
-  void Think(float dt, CStateManager& mgr);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr);
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor& actor, CStateManager& mgr);
+  void Accept(IVisitor& visitor) override;
+  void Think(float dt, CStateManager& mgr) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor& actor, CStateManager& mgr) override;
   const zeus::CVector3f& GetScale() const { return xe8_scale; }
 };
 

--- a/Runtime/World/CScriptSpiderBallWaypoint.hpp
+++ b/Runtime/World/CScriptSpiderBallWaypoint.hpp
@@ -11,11 +11,11 @@ class CScriptSpiderBallWaypoint : public CActor {
 
 public:
   CScriptSpiderBallWaypoint(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CTransform&, bool, u32);
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Render(const CStateManager& mgr) const { CActor::Render(mgr); }
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {}
-  std::optional<zeus::CAABox> GetTouchBounds() const { return xfc_aabox; }
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Render(const CStateManager& mgr) const override { CActor::Render(mgr); }
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  std::optional<zeus::CAABox> GetTouchBounds() const override { return xfc_aabox; }
   void AccumulateBounds(const zeus::CVector3f& v);
   void BuildWaypointListAndBounds(CStateManager& mgr);
   void AddPreviousWaypoint(TUniqueId uid);

--- a/Runtime/World/CScriptSpindleCamera.hpp
+++ b/Runtime/World/CScriptSpindleCamera.hpp
@@ -96,12 +96,12 @@ public:
                        const SSpindleProperty& deleteHintBallDist,
                        const SSpindleProperty& recoverClampedAzimuthFromHintDir);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void Render(const CStateManager&) const;
-  void Reset(const zeus::CTransform& xf, CStateManager& mgr);
-  void ProcessInput(const CFinalInput& input, CStateManager& mgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void Render(const CStateManager&) const override;
+  void Reset(const zeus::CTransform& xf, CStateManager& mgr) override;
+  void ProcessInput(const CFinalInput& input, CStateManager& mgr) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptSteam.hpp
+++ b/Runtime/World/CScriptSteam.hpp
@@ -18,9 +18,9 @@ public:
                const zeus::CAABox&, const CDamageInfo& dInfo, const zeus::CVector3f& orientedForce, ETriggerFlags flags,
                bool active, CAssetId, float, float, float, float, bool);
 
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptStreamedMusic.hpp
+++ b/Runtime/World/CScriptStreamedMusic.hpp
@@ -25,8 +25,8 @@ public:
 
   void Stop(CStateManager& mgr);
   void Play(CStateManager& mgr);
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptSwitch.hpp
+++ b/Runtime/World/CScriptSwitch.hpp
@@ -10,7 +10,7 @@ class CScriptSwitch : public CEntity {
 public:
   CScriptSwitch(TUniqueId, std::string_view, const CEntityInfo&, bool, bool, bool);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
 };
 } // namespace urde

--- a/Runtime/World/CScriptTargetingPoint.hpp
+++ b/Runtime/World/CScriptTargetingPoint.hpp
@@ -17,10 +17,10 @@ private:
 public:
   CScriptTargetingPoint(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CTransform&, bool);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void Render(const CStateManager&) const {}
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void Render(const CStateManager&) const override {}
 
   bool GetLocked() const;
 };

--- a/Runtime/World/CScriptTimer.hpp
+++ b/Runtime/World/CScriptTimer.hpp
@@ -15,9 +15,9 @@ class CScriptTimer : public CEntity {
 public:
   CScriptTimer(TUniqueId, std::string_view name, const CEntityInfo& info, float, float, bool, bool, bool);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
   bool IsTiming() const;
   void StartTiming(bool isTiming);
   void Reset(CStateManager&);

--- a/Runtime/World/CScriptTrigger.hpp
+++ b/Runtime/World/CScriptTrigger.hpp
@@ -66,9 +66,9 @@ public:
                  const zeus::CAABox&, const CDamageInfo& dInfo, const zeus::CVector3f& orientedForce,
                  ETriggerFlags triggerFlags, bool, bool, bool);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   virtual void InhabitantRejected(CActor&, CStateManager&) {}
   virtual void InhabitantExited(CActor&, CStateManager&) {}
   virtual void InhabitantIdle(CActor&, CStateManager&) {}
@@ -76,8 +76,8 @@ public:
   CObjectTracker* FindObject(TUniqueId);
   void UpdateInhabitants(float, CStateManager&);
   std::list<CObjectTracker>& GetInhabitants();
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor&, CStateManager&);
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor&, CStateManager&) override;
   const zeus::CAABox& GetTriggerBoundsOR() const { return x130_bounds; }
   zeus::CAABox GetTriggerBoundsWR() const;
   const CDamageInfo& GetDamageInfo() const { return x100_damageInfo; }

--- a/Runtime/World/CScriptVisorFlare.hpp
+++ b/Runtime/World/CScriptVisorFlare.hpp
@@ -14,12 +14,12 @@ public:
                     CVisorFlare::EBlendMode blendMode, bool, float, float, float, u32, u32,
                     const std::vector<CVisorFlare::CFlareDef>& flares);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager& stateMgr);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const;
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager& stateMgr) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptVisorGoo.hpp
+++ b/Runtime/World/CScriptVisorGoo.hpp
@@ -22,13 +22,13 @@ public:
                   CAssetId particle, CAssetId electric, float minDist, float maxDist, float nearProb, float farProb,
                   const zeus::CColor& color, int sfx, bool forceShow, bool active);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager& stateMgr);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const;
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor&, CStateManager&);
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager& stateMgr) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor&, CStateManager&) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptWater.hpp
+++ b/Runtime/World/CScriptWater.hpp
@@ -89,17 +89,17 @@ public:
                float unitsPerLightmapTexel, float alphaInTime, float alphaOutTime, u32, u32, bool, s32, s32,
                std::unique_ptr<u32[]>&& u32Arr);
 
-  void Accept(IVisitor& visitor);
-  void Think(float, CStateManager&);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const;
-  void Touch(CActor&, CStateManager&);
-  void CalculateRenderBounds();
-  zeus::CAABox GetSortingBounds(const CStateManager&) const;
+  void Accept(IVisitor& visitor) override;
+  void Think(float, CStateManager&) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override;
+  void Touch(CActor&, CStateManager&) override;
+  void CalculateRenderBounds() override;
+  zeus::CAABox GetSortingBounds(const CStateManager&) const override;
   EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
-                                                         const CWeaponMode&, EProjectileAttrib) const;
+                                                         const CWeaponMode&, EProjectileAttrib) const override;
 
   u16 GetSplashSound(float) const;
   const std::optional<TLockedToken<CGenDescription>>& GetSplashEffect(float) const;

--- a/Runtime/World/CScriptWaypoint.hpp
+++ b/Runtime/World/CScriptWaypoint.hpp
@@ -20,9 +20,9 @@ public:
                   bool active, float speed, float pause, u32 patternTranslate, u32 patternOrient, u32 patternFit,
                   u32 behaviour, u32 behaviourOrient, u32 behaviourModifiers, u32 animation);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
   TUniqueId FollowWaypoint(CStateManager& mgr) const;
   TUniqueId NextWaypoint(CStateManager& mgr) const;
   float GetSpeed() const { return xe8_speed; }

--- a/Runtime/World/CScriptWorldTeleporter.hpp
+++ b/Runtime/World/CScriptWorldTeleporter.hpp
@@ -44,8 +44,8 @@ public:
                          const zeus::CVector3f&, CAssetId, const zeus::CVector3f&, CAssetId, const zeus::CVector3f&,
                          bool, u16, u8, u8);
 
-  void Accept(IVisitor&);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr);
+  void Accept(IVisitor&) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
   void StartTransition(CStateManager&);
 };
 } // namespace urde

--- a/Runtime/World/CSnakeWeedSwarm.hpp
+++ b/Runtime/World/CSnakeWeedSwarm.hpp
@@ -12,7 +12,7 @@ public:
                   float, float, float, float, float, float, float, const CDamageInfo&, float, u32, u32, u32, u32, u32,
                   u32, float);
 
-  void Accept(IVisitor&);
+  void Accept(IVisitor&) override;
   void ApplyRadiusDamage(const zeus::CVector3f& pos, const CDamageInfo& info, CStateManager& stateMgr) {}
 };
 } // namespace urde

--- a/Runtime/World/CTeamAiMgr.hpp
+++ b/Runtime/World/CTeamAiMgr.hpp
@@ -78,9 +78,9 @@ private:
 public:
   CTeamAiMgr(TUniqueId uid, std::string_view name, const CEntityInfo& info, const CTeamAiData& data);
 
-  void Accept(IVisitor&);
-  void Think(float dt, CStateManager& mgr);
-  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& mgr);
+  void Accept(IVisitor&) override;
+  void Think(float dt, CStateManager& mgr) override;
+  void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& mgr) override;
   CTeamAiRole* GetTeamAiRole(TUniqueId aiId);
   bool IsPartOfTeam(TUniqueId aiId) const;
   bool HasTeamAiRole(TUniqueId aiId) const;

--- a/Runtime/World/CWallCrawlerSwarm.hpp
+++ b/Runtime/World/CWallCrawlerSwarm.hpp
@@ -180,18 +180,18 @@ public:
                     const CDamageVulnerability& dVuln, s32 launchSfx,
                     s32 scatterSfx, const CActorParameters& aParams);
 
-  void Accept(IVisitor& visitor);
-  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&);
-  void Think(float, CStateManager&);
-  void PreRender(CStateManager&, const zeus::CFrustum&);
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
-  void Render(const CStateManager&) const;
-  bool CanRenderUnsorted(const CStateManager&) const;
-  void CalculateRenderBounds();
-  std::optional<zeus::CAABox> GetTouchBounds() const;
-  void Touch(CActor& other, CStateManager&);
-  zeus::CVector3f GetOrbitPosition(const CStateManager&) const;
-  zeus::CVector3f GetAimPosition(const CStateManager&, float) const;
+  void Accept(IVisitor& visitor) override;
+  void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void PreRender(CStateManager&, const zeus::CFrustum&) override;
+  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager&) const override;
+  bool CanRenderUnsorted(const CStateManager&) const override;
+  void CalculateRenderBounds() override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor& other, CStateManager&) override;
+  zeus::CVector3f GetOrbitPosition(const CStateManager&) const override;
+  zeus::CVector3f GetAimPosition(const CStateManager&, float) const override;
   const zeus::CVector3f& GetLastKilledOffset() const { return x130_lastKilledOffset; }
   void ApplyRadiusDamage(const zeus::CVector3f& pos, const CDamageInfo& info, CStateManager& stateMgr) {}
   const std::vector<CBoid>& GetBoids() const { return x108_boids; }

--- a/Runtime/World/CWallWalker.hpp
+++ b/Runtime/World/CWallWalker.hpp
@@ -48,10 +48,10 @@ public:
               float alignAngVel, EKnockBackVariant kbVariant, float advanceWpRadius, EWalkerType wType,
               float playerObstructionMinDist, bool disableMove);
 
-  void PreThink(float, CStateManager&);
-  void Think(float, CStateManager&);
-  void Render(const CStateManager&) const;
-  const CCollisionPrimitive* GetCollisionPrimitive() const { return &x590_colSphere; }
+  void PreThink(float, CStateManager&) override;
+  void Think(float, CStateManager&) override;
+  void Render(const CStateManager&) const override;
+  const CCollisionPrimitive* GetCollisionPrimitive() const override { return &x590_colSphere; }
   void UpdateWPDestination(CStateManager&);
 };
 } // namespace urde

--- a/Runtime/World/CWorld.hpp
+++ b/Runtime/World/CWorld.hpp
@@ -52,18 +52,18 @@ class CDummyWorld : public IWorld {
 
 public:
   CDummyWorld(CAssetId mlvlId, bool loadMap);
-  ~CDummyWorld();
-  CAssetId IGetWorldAssetId() const;
-  CAssetId IGetStringTableAssetId() const;
-  CAssetId IGetSaveWorldAssetId() const;
-  const CMapWorld* IGetMapWorld() const;
-  CMapWorld* IMapWorld();
-  const IGameArea* IGetAreaAlways(TAreaId id) const;
-  TAreaId IGetCurrentAreaId() const;
-  TAreaId IGetAreaId(CAssetId id) const;
-  bool ICheckWorldComplete();
-  std::string IGetDefaultAudioTrack() const;
-  int IGetAreaCount() const;
+  ~CDummyWorld() override;
+  CAssetId IGetWorldAssetId() const override;
+  CAssetId IGetStringTableAssetId() const override;
+  CAssetId IGetSaveWorldAssetId() const override;
+  const CMapWorld* IGetMapWorld() const override;
+  CMapWorld* IMapWorld() override;
+  const IGameArea* IGetAreaAlways(TAreaId id) const override;
+  TAreaId IGetCurrentAreaId() const override;
+  TAreaId IGetAreaId(CAssetId id) const override;
+  bool ICheckWorldComplete() override;
+  std::string IGetDefaultAudioTrack() const override;
+  int IGetAreaCount() const override;
 };
 
 class CWorld : public IWorld {
@@ -173,21 +173,21 @@ public:
   u32 GetRelayCount() const { return x2c_relays.size(); }
   CRelay GetRelay(u32 idx) const { return x2c_relays[idx]; }
 
-  CAssetId IGetWorldAssetId() const;
-  CAssetId IGetStringTableAssetId() const;
-  CAssetId IGetSaveWorldAssetId() const;
-  const CMapWorld* IGetMapWorld() const;
-  CMapWorld* IMapWorld();
+  CAssetId IGetWorldAssetId() const override;
+  CAssetId IGetStringTableAssetId() const override;
+  CAssetId IGetSaveWorldAssetId() const override;
+  const CMapWorld* IGetMapWorld() const override;
+  CMapWorld* IMapWorld() override;
   const CGameArea* GetAreaAlways(TAreaId) const;
   CGameArea* GetArea(TAreaId);
   s32 GetNumAreas() const { return x18_areas.size(); }
-  const IGameArea* IGetAreaAlways(TAreaId id) const;
-  TAreaId IGetCurrentAreaId() const;
+  const IGameArea* IGetAreaAlways(TAreaId id) const override;
+  TAreaId IGetCurrentAreaId() const override;
   TAreaId GetCurrentAreaId() const { return x68_curAreaId; }
-  TAreaId IGetAreaId(CAssetId id) const;
-  bool ICheckWorldComplete();
-  std::string IGetDefaultAudioTrack() const;
-  int IGetAreaCount() const;
+  TAreaId IGetAreaId(CAssetId id) const override;
+  bool ICheckWorldComplete() override;
+  std::string IGetDefaultAudioTrack() const override;
+  int IGetAreaCount() const override;
 
   static void PropogateAreaChain(CGameArea::EOcclusionState, CGameArea*, CWorld*);
   static CGameArea::CConstChainIterator GetAliveAreasEnd() { return {skGlobalEnd}; }


### PR DESCRIPTION
Applies the override keyword where applicable to indicate visually where member function overriding is occurring. This only targets the RuntimeCommonB target as a starting point, which resolves around 900+ cases where the keyword could be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/31)
<!-- Reviewable:end -->
