### PR TITLE
Runtime/Weapon/CGameProjectile: Fix misnamed virtual function

### DIFF
--- a/Runtime/Weapon/CGameProjectile.cpp
+++ b/Runtime/Weapon/CGameProjectile.cpp
@@ -229,7 +229,7 @@ void CGameProjectile::ApplyDamageToActors(CStateManager& mgr, const CDamageInfo&
   x2d0_touchResults.clear();
 }
 
-void CGameProjectile::FluidFxThink(EFluidState state, CScriptWater& water, CStateManager& mgr) {
+void CGameProjectile::FluidFXThink(EFluidState state, CScriptWater& water, CStateManager& mgr) {
   if (x170_projectile.GetWeaponDescription()->xa6_SWTR)
     CWeapon::FluidFXThink(state, water, mgr);
 }

--- a/Runtime/Weapon/CGameProjectile.hpp
+++ b/Runtime/Weapon/CGameProjectile.hpp
@@ -72,7 +72,7 @@ public:
   void UpdateProjectileMovement(float dt, CStateManager& mgr);
   CRayCastResult DoCollisionCheck(TUniqueId& idOut, CStateManager& mgr);
   void ApplyDamageToActors(CStateManager& mgr, const CDamageInfo& dInfo);
-  void FluidFxThink(EFluidState state, CScriptWater& water, CStateManager& mgr);
+  void FluidFXThink(EFluidState state, CScriptWater& water, CStateManager& mgr) override;
   CRayCastResult RayCollisionCheckWithWorld(TUniqueId& idOut, const zeus::CVector3f& start, const zeus::CVector3f& end,
                                             float mag, const rstl::reserved_vector<TUniqueId, 1024>& nearList,
                                             CStateManager& mgr);


### PR DESCRIPTION
This has a slightly similar name to FluidFXThink (which has an uppercase X). Given this function isn't explicitly called anywhere directly, this is assumed to be a typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/36)
<!-- Reviewable:end -->
