### PR TITLE
Runtime/Input/CFinalInput: Correct return value of AKey, ASpecialKey and AMouseButton

### DIFF
--- a/Runtime/Input/CFinalInput.hpp
+++ b/Runtime/Input/CFinalInput.hpp
@@ -159,9 +159,9 @@ struct CFinalInput {
   bool DKey(char k) const { return m_kbm && m_kbm->m_charKeys[int(k)]; }
   bool DSpecialKey(boo::ESpecialKey k) const { return m_kbm && m_kbm->m_specialKeys[int(k)]; }
   bool DMouseButton(boo::EMouseButton k) const { return m_kbm && m_kbm->m_mouseButtons[int(k)]; }
-  bool AKey(char k) const { return DKey(k) ? 1.f : 0.f; }
-  bool ASpecialKey(boo::ESpecialKey k) const { return DSpecialKey(k) ? 1.f : 0.f; }
-  bool AMouseButton(boo::EMouseButton k) const { return DMouseButton(k) ? 1.f : 0.f; }
+  float AKey(char k) const { return DKey(k) ? 1.f : 0.f; }
+  float ASpecialKey(boo::ESpecialKey k) const { return DSpecialKey(k) ? 1.f : 0.f; }
+  float AMouseButton(boo::EMouseButton k) const { return DMouseButton(k) ? 1.f : 0.f; }
 
   const std::optional<CKeyboardMouseControllerData>& GetKBM() const { return m_kbm; }
 };

--- a/Runtime/Input/CFinalInput.hpp
+++ b/Runtime/Input/CFinalInput.hpp
@@ -72,8 +72,12 @@ struct CFinalInput {
   CFinalInput(int cIdx, float dt, const boo::DolphinControllerState& data, const CFinalInput& prevInput, float leftDiv,
               float rightDiv);
   CFinalInput(int cIdx, float dt, const CKeyboardMouseControllerData& data, const CFinalInput& prevInput);
+
   CFinalInput& operator|=(const CFinalInput& other);
-  bool operator==(const CFinalInput& other) { return memcmp(this, &other, sizeof(CFinalInput)) == 0; }
+
+  bool operator==(const CFinalInput& other) const { return memcmp(this, &other, sizeof(CFinalInput)) == 0; }
+  bool operator!=(const CFinalInput& other) const { return !operator==(other); }
+
   float DeltaTime() const { return x0_dt; }
   u32 ControllerIdx() const { return x4_controllerIdx; }
 


### PR DESCRIPTION
The other A-prefixed functions all return a float value, however these are truncating float values to bool. We can amend this to prevent potential compilation warnings.

While I was in the area, I noticed the equality operator wasn't const qualified, so I applied the qualifier to it (and provided the trivial inequality operator for logical symmetry).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/37)
<!-- Reviewable:end -->
