### PR TITLE
MP1: Migrate from std::bind to lambdas

### DIFF
--- a/Runtime/MP1/CFrontEndUI.cpp
+++ b/Runtime/MP1/CFrontEndUI.cpp
@@ -97,19 +97,15 @@ void CFrontEndUI::SNewFileSelectFrame::FinishedLoading() {
   worker->SetIsSelectable(false);
   worker->SetVisibility(false, ETraversalMode::Children);
 
-  x20_tablegroup_fileselect->SetMenuAdvanceCallback(
-      std::bind(&SNewFileSelectFrame::DoFileMenuAdvance, this, std::placeholders::_1));
+  x20_tablegroup_fileselect->SetMenuAdvanceCallback([this](CGuiTableGroup* caller) { DoFileMenuAdvance(caller); });
   x20_tablegroup_fileselect->SetMenuSelectionChangeCallback(
-      std::bind(&SNewFileSelectFrame::DoSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
-  x20_tablegroup_fileselect->SetMenuCancelCallback(
-      std::bind(&SNewFileSelectFrame::DoFileMenuCancel, this, std::placeholders::_1));
+      [this](CGuiTableGroup* caller, int oldSel) { DoSelectionChange(caller, oldSel); });
+  x20_tablegroup_fileselect->SetMenuCancelCallback([this](CGuiTableGroup* caller) { DoFileMenuCancel(caller); });
 
-  x40_tablegroup_popup->SetMenuAdvanceCallback(
-      std::bind(&SNewFileSelectFrame::DoPopupAdvance, this, std::placeholders::_1));
+  x40_tablegroup_popup->SetMenuAdvanceCallback([this](CGuiTableGroup* caller) { DoPopupAdvance(caller); });
   x40_tablegroup_popup->SetMenuSelectionChangeCallback(
-      std::bind(&SNewFileSelectFrame::DoSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
-  x40_tablegroup_popup->SetMenuCancelCallback(
-      std::bind(&SNewFileSelectFrame::DoPopupCancel, this, std::placeholders::_1));
+      [this](CGuiTableGroup* caller, int oldSel) { DoSelectionChange(caller, oldSel); });
+  x40_tablegroup_popup->SetMenuCancelCallback([this](CGuiTableGroup* caller) { DoPopupCancel(caller); });
 
   for (int i = 0; i < 3; ++i)
     x64_fileSelections[i] = FindFileSelectOption(x1c_loadedFrame, i);
@@ -868,12 +864,12 @@ void CFrontEndUI::SFusionBonusFrame::FinishedLoading() {
   SetTableColors(x28_tablegroup_options);
   SetTableColors(x2c_tablegroup_fusionsuit);
 
-  x28_tablegroup_options->SetMenuAdvanceCallback(std::bind(&SFusionBonusFrame::DoAdvance, this, std::placeholders::_1));
+  x28_tablegroup_options->SetMenuAdvanceCallback([this](CGuiTableGroup* caller) { DoAdvance(caller); });
   x28_tablegroup_options->SetMenuSelectionChangeCallback(
-      std::bind(&SFusionBonusFrame::DoSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
-  x28_tablegroup_options->SetMenuCancelCallback(std::bind(&SFusionBonusFrame::DoCancel, this, std::placeholders::_1));
+      [this](CGuiTableGroup* caller, int oldSel) { DoSelectionChange(caller, oldSel); });
+  x28_tablegroup_options->SetMenuCancelCallback([this](CGuiTableGroup* caller) { DoCancel(caller); });
   x2c_tablegroup_fusionsuit->SetMenuSelectionChangeCallback(
-      std::bind(&SFusionBonusFrame::DoSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
+      [this](CGuiTableGroup* caller, int oldSel) { DoSelectionChange(caller, oldSel); });
 }
 
 bool CFrontEndUI::SFusionBonusFrame::PumpLoad() {
@@ -1112,10 +1108,10 @@ void CFrontEndUI::SFrontEndFrame::FinishedLoading() {
   if (proceed)
     proceed->TextSupport().SetText(g_MainStringTable->GetString(85));
 
-  x18_tablegroup_mainmenu->SetMenuAdvanceCallback(std::bind(&SFrontEndFrame::DoAdvance, this, std::placeholders::_1));
+  x18_tablegroup_mainmenu->SetMenuAdvanceCallback([this](CGuiTableGroup* caller) { DoAdvance(caller); });
   x18_tablegroup_mainmenu->SetMenuSelectionChangeCallback(
-      std::bind(&SFrontEndFrame::DoSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
-  x18_tablegroup_mainmenu->SetMenuCancelCallback(std::bind(&SFrontEndFrame::DoCancel, this, std::placeholders::_1));
+      [this](CGuiTableGroup* caller, int oldSel) { DoSelectionChange(caller, oldSel); });
+  x18_tablegroup_mainmenu->SetMenuCancelCallback([this](CGuiTableGroup* caller) { DoCancel(caller); });
 
   HandleActiveChange(x18_tablegroup_mainmenu);
 }
@@ -1531,31 +1527,27 @@ void CFrontEndUI::SOptionsFrontEndFrame::FinishedLoading() {
   x30_tablegroup_triple = static_cast<CGuiTableGroup*>(x1c_loadedFrame->FindWidget("tablegroup_triple"));
   x34_slidergroup_slider = static_cast<CGuiSliderGroup*>(x1c_loadedFrame->FindWidget("slidergroup_slider"));
 
-  x24_tablegroup_leftmenu->SetMenuAdvanceCallback(
-      std::bind(&SOptionsFrontEndFrame::DoLeftMenuAdvance, this, std::placeholders::_1));
+  x24_tablegroup_leftmenu->SetMenuAdvanceCallback([this](CGuiTableGroup* caller) { DoLeftMenuAdvance(caller); });
   x24_tablegroup_leftmenu->SetMenuSelectionChangeCallback(
-      std::bind(&SOptionsFrontEndFrame::DoMenuSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
+      [this](CGuiTableGroup* caller, int oldSel) { DoMenuSelectionChange(caller, oldSel); });
 
   x38_rowPitch = x24_tablegroup_leftmenu->GetWorkerWidget(1)->GetIdlePosition().z() -
                  x24_tablegroup_leftmenu->GetWorkerWidget(0)->GetIdlePosition().z();
 
   x28_tablegroup_rightmenu->SetMenuSelectionChangeCallback(
-      std::bind(&SOptionsFrontEndFrame::DoMenuSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
-  x28_tablegroup_rightmenu->SetMenuCancelCallback(
-      std::bind(&SOptionsFrontEndFrame::DoMenuCancel, this, std::placeholders::_1));
+      [this](CGuiTableGroup* caller, int oldSel) { DoMenuSelectionChange(caller, oldSel); });
+  x28_tablegroup_rightmenu->SetMenuCancelCallback([this](CGuiTableGroup* caller) { DoMenuCancel(caller); });
 
   x2c_tablegroup_double->SetMenuSelectionChangeCallback(
-      std::bind(&SOptionsFrontEndFrame::DoMenuSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
-  x2c_tablegroup_double->SetMenuCancelCallback(
-      std::bind(&SOptionsFrontEndFrame::DoMenuCancel, this, std::placeholders::_1));
+      [this](CGuiTableGroup* caller, int oldSel) { DoMenuSelectionChange(caller, oldSel); });
+  x2c_tablegroup_double->SetMenuCancelCallback([this](CGuiTableGroup* caller) { DoMenuCancel(caller); });
 
   x30_tablegroup_triple->SetMenuSelectionChangeCallback(
-      std::bind(&SOptionsFrontEndFrame::DoMenuSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
-  x30_tablegroup_triple->SetMenuCancelCallback(
-      std::bind(&SOptionsFrontEndFrame::DoMenuCancel, this, std::placeholders::_1));
+      [this](CGuiTableGroup* caller, int oldSel) { DoMenuSelectionChange(caller, oldSel); });
+  x30_tablegroup_triple->SetMenuCancelCallback([this](CGuiTableGroup* caller) { DoMenuCancel(caller); });
 
   x34_slidergroup_slider->SetSelectionChangedCallback(
-      std::bind(&SOptionsFrontEndFrame::DoSliderChange, this, std::placeholders::_1, std::placeholders::_2));
+      [this](CGuiSliderGroup* caller, float value) { DoSliderChange(caller, value); });
 
   FindTextPanePair(x1c_loadedFrame, "textpane_double0").SetPairText(x20_loadedPauseStrg->GetString(95)); // Off
   FindTextPanePair(x1c_loadedFrame, "textpane_double1").SetPairText(x20_loadedPauseStrg->GetString(94)); // On

--- a/Runtime/MP1/CGBASupport.cpp
+++ b/Runtime/MP1/CGBASupport.cpp
@@ -141,10 +141,10 @@ void CGBASupport::Update(float dt) {
 
   case EPhase::StartJoyBusBoot:
     x34_phase = EPhase::PollJoyBusBoot;
-    if (!g_JbusEndpoint || g_JbusEndpoint->GBAJoyBootAsync(
-                               x40_siChan * 2, 2, x2c_buffer.get(), x28_fileSize, &x3c_status,
-                               std::bind(JoyBootDone, std::placeholders::_1, std::placeholders::_2)) != jbus::GBA_READY)
+    if (!g_JbusEndpoint || g_JbusEndpoint->GBAJoyBootAsync(x40_siChan * 2, 2, x2c_buffer.get(), x28_fileSize,
+                                                           &x3c_status, JoyBootDone) != jbus::GBA_READY) {
       x34_phase = EPhase::Failed;
+    }
     break;
 
   case EPhase::PollJoyBusBoot:

--- a/Runtime/MP1/COptionsScreen.cpp
+++ b/Runtime/MP1/COptionsScreen.cpp
@@ -207,11 +207,11 @@ void COptionsScreen::VActivate() {
       .SetText(xc_pauseStrg.GetString(98));
 
   x18c_slidergroup_slider->SetSelectionChangedCallback(
-      std::bind(&COptionsScreen::OnSliderChanged, this, std::placeholders::_1, std::placeholders::_2));
+      [this](CGuiSliderGroup* caller, float value) { OnSliderChanged(caller, value); });
   x190_tablegroup_double->SetMenuSelectionChangeCallback(
-      std::bind(&COptionsScreen::OnEnumChanged, this, std::placeholders::_1, std::placeholders::_2));
+      [this](CGuiTableGroup* caller, int oldSel) { OnEnumChanged(caller, oldSel); });
   x194_tablegroup_triple->SetMenuSelectionChangeCallback(
-      std::bind(&COptionsScreen::OnEnumChanged, this, std::placeholders::_1, std::placeholders::_2));
+      [this](CGuiTableGroup* caller, int oldSel) { OnEnumChanged(caller, oldSel); });
 }
 
 void COptionsScreen::RightTableSelectionChanged(int oldSel, int newSel) { UpdateOptionView(); }

--- a/Runtime/MP1/CPauseScreen.cpp
+++ b/Runtime/MP1/CPauseScreen.cpp
@@ -79,10 +79,10 @@ void CPauseScreen::InitializeFrameGlue() {
     deco->SetColor(color);
   }
 
-  x34_loadedPauseScreenInstructions->SetMouseDownCallback(std::bind(&CPauseScreen::OnWidgetMouseDown, this,
-                                                          std::placeholders::_1, std::placeholders::_2));
-  x34_loadedPauseScreenInstructions->SetMouseUpCallback(std::bind(&CPauseScreen::OnWidgetMouseUp, this,
-                                                        std::placeholders::_1, std::placeholders::_2));
+  x34_loadedPauseScreenInstructions->SetMouseDownCallback(
+      [this](CGuiWidget* caller, bool resume) { OnWidgetMouseDown(caller, resume); });
+  x34_loadedPauseScreenInstructions->SetMouseUpCallback(
+      [this](CGuiWidget* caller, bool cancel) { OnWidgetMouseUp(caller, cancel); });
 }
 
 bool CPauseScreen::CheckLoadComplete(const CStateManager& mgr) {

--- a/Runtime/MP1/CPauseScreenBase.cpp
+++ b/Runtime/MP1/CPauseScreenBase.cpp
@@ -151,25 +151,21 @@ void CPauseScreenBase::InitializeFrameGlue() {
   x190_tablegroup_double->SetWorkersMouseActive(false);
   x194_tablegroup_triple->SetWorkersMouseActive(false);
 
-  x70_tablegroup_leftlog->SetMenuAdvanceCallback(
-      std::bind(&CPauseScreenBase::OnLeftTableAdvance, this, std::placeholders::_1));
+  x70_tablegroup_leftlog->SetMenuAdvanceCallback([this](CGuiTableGroup* caller) { OnLeftTableAdvance(caller); });
   x70_tablegroup_leftlog->SetMenuSelectionChangeCallback(
-      std::bind(&CPauseScreenBase::OnTableSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
-  x84_tablegroup_rightlog->SetMenuAdvanceCallback(
-      std::bind(&CPauseScreenBase::OnRightTableAdvance, this, std::placeholders::_1));
+      [this](CGuiTableGroup* caller, int oldSel) { OnTableSelectionChange(caller, oldSel); });
+  x84_tablegroup_rightlog->SetMenuAdvanceCallback([this](CGuiTableGroup* caller) { OnRightTableAdvance(caller); });
   x84_tablegroup_rightlog->SetMenuSelectionChangeCallback(
-      std::bind(&CPauseScreenBase::OnTableSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
-  x84_tablegroup_rightlog->SetMenuCancelCallback(
-      std::bind(&CPauseScreenBase::OnRightTableCancel, this, std::placeholders::_1));
+      [this](CGuiTableGroup* caller, int oldSel) { OnTableSelectionChange(caller, oldSel); });
+  x84_tablegroup_rightlog->SetMenuCancelCallback([this](CGuiTableGroup* caller) { OnRightTableCancel(caller); });
   x18c_slidergroup_slider->SetSelectionChangedCallback({});
   x190_tablegroup_double->SetMenuSelectionChangeCallback({});
   x194_tablegroup_triple->SetMenuSelectionChangeCallback({});
 
-  x8_frame.SetMouseUpCallback(std::bind(&CPauseScreenBase::OnWidgetMouseUp, this,
-                                        std::placeholders::_1, std::placeholders::_2));
-  x8_frame.SetMouseScrollCallback(std::bind(&CPauseScreenBase::OnWidgetScroll, this,
-                                            std::placeholders::_1, std::placeholders::_2,
-                                            std::placeholders::_3, std::placeholders::_4));
+  x8_frame.SetMouseUpCallback([this](CGuiWidget* widget, bool cancel) { OnWidgetMouseUp(widget, cancel); });
+  x8_frame.SetMouseScrollCallback([this](CGuiWidget* widget, const boo::SScrollDelta& delta, int accumX, int accumY) {
+    OnWidgetScroll(widget, delta, accumX, accumY);
+  });
 }
 
 bool CPauseScreenBase::IsReady() {

--- a/Runtime/MP1/CQuitGameScreen.cpp
+++ b/Runtime/MP1/CQuitGameScreen.cpp
@@ -29,9 +29,9 @@ void CQuitGameScreen::FinishedLoading() {
 
   x14_tablegroup_quitgame = static_cast<CGuiTableGroup*>(x10_loadedFrame->FindWidget("tablegroup_quitgame"));
   x14_tablegroup_quitgame->SetVertical(false);
-  x14_tablegroup_quitgame->SetMenuAdvanceCallback(std::bind(&CQuitGameScreen::DoAdvance, this, std::placeholders::_1));
+  x14_tablegroup_quitgame->SetMenuAdvanceCallback([this](CGuiTableGroup* caller) { DoAdvance(caller); });
   x14_tablegroup_quitgame->SetMenuSelectionChangeCallback(
-      std::bind(&CQuitGameScreen::DoSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
+      [this](CGuiTableGroup* caller, int oldSel) { DoSelectionChange(caller, oldSel); });
 
   static_cast<CGuiTextPane*>(x10_loadedFrame->FindWidget("textpane_title"))
       ->TextSupport()
@@ -46,8 +46,7 @@ void CQuitGameScreen::FinishedLoading() {
 
   x14_tablegroup_quitgame->SetUserSelection(DefaultSelections[int(x0_type)]);
   x14_tablegroup_quitgame->SetWorkersMouseActive(true);
-  x10_loadedFrame->SetMouseUpCallback(std::bind(&CQuitGameScreen::OnWidgetMouseUp, this,
-                                      std::placeholders::_1, std::placeholders::_2));
+  x10_loadedFrame->SetMouseUpCallback([this](CGuiWidget* widget, bool cancel) { OnWidgetMouseUp(widget, cancel); });
   SetColors();
 }
 

--- a/Runtime/MP1/CSaveGameScreen.cpp
+++ b/Runtime/MP1/CSaveGameScreen.cpp
@@ -101,9 +101,9 @@ bool CSaveGameScreen::PumpLoad() {
   x64_textpane_choice2 = static_cast<CGuiTextPane*>(x50_loadedFrame->FindWidget("textpane_choice2"));
   x68_textpane_choice3 = static_cast<CGuiTextPane*>(x50_loadedFrame->FindWidget("textpane_choice3"));
 
-  x58_tablegroup_choices->SetMenuAdvanceCallback(std::bind(&CSaveGameScreen::DoAdvance, this, std::placeholders::_1));
+  x58_tablegroup_choices->SetMenuAdvanceCallback([this](CGuiTableGroup* caller) { DoAdvance(caller); });
   x58_tablegroup_choices->SetMenuSelectionChangeCallback(
-      std::bind(&CSaveGameScreen::DoSelectionChange, this, std::placeholders::_1, std::placeholders::_2));
+      [this](CGuiTableGroup* caller, int oldSel) { DoSelectionChange(caller, oldSel); });
 
   if (x0_saveCtx == ESaveContext::InGame)
     x6c_cardDriver->StartCardProbe();

--- a/Runtime/MP1/MP1.cpp
+++ b/Runtime/MP1/MP1.cpp
@@ -648,27 +648,33 @@ void CMain::Init(const hecl::Runtime::FileStoreManager& storeMgr, hecl::CVarMana
   m_cvarMgr = cvarMgr;
   m_console = std::make_unique<hecl::Console>(m_cvarMgr);
   m_console->init(window);
-  m_console->registerCommand("Quit"sv, "Quits the game immediately"sv, ""sv,
-                             std::bind(&CMain::quit, this, std::placeholders::_1, std::placeholders::_2));
-  m_console->registerCommand("Give"sv, "Gives the player the specified item, maxing it out"sv, ""sv,
-                             std::bind(&CMain::Give, this, std::placeholders::_1, std::placeholders::_2),
-                             hecl::SConsoleCommand::ECommandFlags::Cheat);
-  m_console->registerCommand("Remove"sv, "Removes the specified item from the player"sv, ""sv,
-                             std::bind(&CMain::Remove, this, std::placeholders::_1, std::placeholders::_2),
-                             hecl::SConsoleCommand::ECommandFlags::Cheat);
+  m_console->registerCommand(
+      "Quit"sv, "Quits the game immediately"sv, ""sv,
+      [this](hecl::Console* console, const std::vector<std::string>& args) { quit(console, args); });
+  m_console->registerCommand(
+      "Give"sv, "Gives the player the specified item, maxing it out"sv, ""sv,
+      [this](hecl::Console* console, const std::vector<std::string>& args) { Give(console, args); },
+      hecl::SConsoleCommand::ECommandFlags::Cheat);
+  m_console->registerCommand(
+      "Remove"sv, "Removes the specified item from the player"sv, ""sv,
+      [this](hecl::Console* console, const std::vector<std::string>& args) { Remove(console, args); },
+      hecl::SConsoleCommand::ECommandFlags::Cheat);
   m_console->registerCommand(
       "Teleport"sv, "Teleports the player to the specified coordinates in worldspace"sv, "x y z [dX dY dZ]"sv,
-      std::bind(&CMain::Teleport, this, std::placeholders::_1, std::placeholders::_2),
+      [this](hecl::Console* console, const std::vector<std::string>& args) { Teleport(console, args); },
       (hecl::SConsoleCommand::ECommandFlags::Cheat | hecl::SConsoleCommand::ECommandFlags::Developer));
-  m_console->registerCommand("God"sv, "Disables damage given by enemies and objects"sv, ""sv,
-                             std::bind(&CMain::God, this, std::placeholders::_1, std::placeholders::_2),
-                             hecl::SConsoleCommand::ECommandFlags::Cheat);
-  m_console->registerCommand("ListWorlds"sv, "Lists loaded worlds"sv, ""sv,
-                             std::bind(&CMain::ListWorlds, this, std::placeholders::_1, std::placeholders::_2),
-                             hecl::SConsoleCommand::ECommandFlags::Normal);
-  m_console->registerCommand("Warp"sv, "Warps to a given area and world"sv, "[worldname] areaId"sv,
-                             std::bind(&CMain::Warp, this, std::placeholders::_1, std::placeholders::_2),
-                             hecl::SConsoleCommand::ECommandFlags::Normal);
+  m_console->registerCommand(
+      "God"sv, "Disables damage given by enemies and objects"sv, ""sv,
+      [this](hecl::Console* console, const std::vector<std::string>& args) { God(console, args); },
+      hecl::SConsoleCommand::ECommandFlags::Cheat);
+  m_console->registerCommand(
+      "ListWorlds"sv, "Lists loaded worlds"sv, ""sv,
+      [this](hecl::Console* console, const std::vector<std::string>& args) { ListWorlds(console, args); },
+      hecl::SConsoleCommand::ECommandFlags::Normal);
+  m_console->registerCommand(
+      "Warp"sv, "Warps to a given area and world"sv, "[worldname] areaId"sv,
+      [this](hecl::Console* console, const std::vector<std::string>& args) { Warp(console, args); },
+      hecl::SConsoleCommand::ECommandFlags::Normal);
 
   InitializeSubsystems();
   x128_globalObjects.PostInitialize();


### PR DESCRIPTION
Provides a more straightforward means of supplying custom behavior in place. Lambdas also typically optimize better compared to std::bind objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/39)
<!-- Reviewable:end -->
