### PR TITLE
Runtime: Make const/non-const getters have the same name

### DIFF
--- a/Editor/ViewManager.cpp
+++ b/Editor/ViewManager.cpp
@@ -102,8 +102,8 @@ void ViewManager::TestGameView::think() {
     }
 
     const urde::TAreaId aId = g_GameState->CurrentWorldState().GetCurrentAreaId();
-    if (areaInfo && areaInfo->toBoolean() && g_StateManager->WorldNC() &&
-        g_StateManager->WorldNC()->DoesAreaExist(aId)) {
+    if (areaInfo && areaInfo->toBoolean() && g_StateManager->GetWorld() &&
+        g_StateManager->GetWorld()->DoesAreaExist(aId)) {
       const auto& layerStates = g_GameState->CurrentWorldState().GetLayerState();
       std::string layerBits;
       u32 totalActive = 0;
@@ -117,7 +117,7 @@ void ViewManager::TestGameView::think() {
       overlayText += fmt::format(fmt(
           "Area AssetId: 0x{}, Total Objects: {}\n"
           "Active Layer bits: {}\n"),
-          g_StateManager->WorldNC()->GetArea(aId)->GetAreaAssetId(),
+          g_StateManager->GetWorld()->GetArea(aId)->GetAreaAssetId(),
           g_StateManager->GetAllObjectList().size(), layerBits);
     }
 

--- a/Runtime/AutoMapper/CMapWorld.cpp
+++ b/Runtime/AutoMapper/CMapWorld.cpp
@@ -42,7 +42,7 @@ void CMapWorld::SetWhichMapAreasLoaded(const IWorld& wld, int start, int count) 
 
   for (int i = 0; i < 2; ++i) {
     for (CMapAreaData* data = x10_listHeads[i]; data;) {
-      CMapAreaData* nextData = data->NextMapAreaData();
+      CMapAreaData* nextData = data->GetNextMapAreaData();
       if (!IsMapAreaInBFSInfoVector(data, bfsInfos)) {
         data->Unlock();
         MoveMapAreaToList(data, EMapAreaList::Unloaded);
@@ -64,11 +64,11 @@ bool CMapWorld::IsMapAreasStreaming() const {
   CMapAreaData* data = x10_listHeads[1];
   while (data != nullptr) {
     if (data->IsLoaded()) {
-      CMapAreaData* next = data->NextMapAreaData();
+      CMapAreaData* next = data->GetNextMapAreaData();
       const_cast<CMapWorld*>(this)->MoveMapAreaToList(data, EMapAreaList::Loaded);
       data = next;
     } else {
-      data = data->NextMapAreaData();
+      data = data->GetNextMapAreaData();
       ret = true;
     }
   }
@@ -78,13 +78,13 @@ bool CMapWorld::IsMapAreasStreaming() const {
 void CMapWorld::MoveMapAreaToList(CMapWorld::CMapAreaData* data, CMapWorld::EMapAreaList list) {
   CMapAreaData* last = nullptr;
   for (CMapAreaData* head = x10_listHeads[int(data->GetContainingList())];;
-       last = head, head = head->NextMapAreaData()) {
+       last = head, head = head->GetNextMapAreaData()) {
     if (head != data)
       continue;
     if (!last)
-      x10_listHeads[int(data->GetContainingList())] = head->NextMapAreaData();
+      x10_listHeads[int(data->GetContainingList())] = head->GetNextMapAreaData();
     else
-      last->SetNextMapArea(head->NextMapAreaData());
+      last->SetNextMapArea(head->GetNextMapAreaData());
     break;
   }
   data->SetNextMapArea(x10_listHeads[int(list)]);

--- a/Runtime/AutoMapper/CMapWorld.hpp
+++ b/Runtime/AutoMapper/CMapWorld.hpp
@@ -67,9 +67,9 @@ public:
     void Unlock() { x0_area.Unlock(); }
     bool IsLoaded() const { return x0_area.IsLoaded(); }
     const CMapArea* GetMapArea() const { return x0_area.GetObj(); }
+    CMapAreaData* GetNextMapAreaData() { return x14_next; }
     const CMapAreaData* GetNextMapAreaData() const { return x14_next; }
     EMapAreaList GetContainingList() const { return x10_list; }
-    CMapAreaData* NextMapAreaData() { return x14_next; }
     void SetContainingList(EMapAreaList list) { x10_list = list; }
     void SetNextMapArea(CMapAreaData* next) { x14_next = next; }
   };

--- a/Runtime/CRelayTracker.cpp
+++ b/Runtime/CRelayTracker.cpp
@@ -36,7 +36,7 @@ void CRelayTracker::RemoveRelay(TEditorId id) {
 }
 
 void CRelayTracker::SendMsgs(TAreaId areaId, CStateManager& stateMgr) {
-  const CWorld* world = stateMgr.WorldNC();
+  const CWorld* world = stateMgr.GetWorld();
   u32 relayCount = world->GetRelayCount();
 
   bool hasActiveRelays = false;

--- a/Runtime/CStateManager.hpp
+++ b/Runtime/CStateManager.hpp
@@ -381,7 +381,7 @@ public:
 
   CEnvFxManager* GetEnvFxManager() { return x880_envFxManager; }
   const CEnvFxManager* GetEnvFxManager() const { return x880_envFxManager; }
-  CWorld* WorldNC() { return x850_world.get(); }
+  CWorld* GetWorld() { return x850_world.get(); }
   const CWorld* GetWorld() const { return x850_world.get(); }
   CRelayTracker* GetRelayTracker() { return x8bc_relayTracker.get(); }
   const CRelayTracker* GetRelayTracker() const { return x8bc_relayTracker.get(); }
@@ -391,7 +391,8 @@ public:
 
   const std::shared_ptr<CMapWorldInfo>& MapWorldInfo() const { return x8c0_mapWorldInfo; }
   const std::shared_ptr<CWorldTransManager>& WorldTransManager() const { return x8c4_worldTransManager; }
-  const std::shared_ptr<CWorldLayerState>& LayerState() const { return x8c8_worldLayerState; }
+  const std::shared_ptr<CWorldLayerState>& WorldLayerState() const { return x8c8_worldLayerState; }
+  std::shared_ptr<CWorldLayerState>& WorldLayerState() { return x8c8_worldLayerState; }
 
   CPlayer& GetPlayer() const { return *x84c_player; }
   CPlayer* Player() const { return x84c_player.get(); }
@@ -442,7 +443,6 @@ public:
   void SetPlayerActorHead(TUniqueId id) { xf6c_playerActorHead = id; }
   std::list<TUniqueId>& GetActiveFlickerBats() { return xf3c_activeFlickerBats; }
   std::list<TUniqueId>& GetActiveParasites() { return xf54_activeParasites; }
-  std::shared_ptr<CWorldLayerState>& WorldLayerStateNC() { return x8c8_worldLayerState; }
   static float g_EscapeShakeCountdown;
   static bool g_EscapeShakeCountdownInit;
 

--- a/Runtime/Character/CAdditiveBodyState.cpp
+++ b/Runtime/Character/CAdditiveBodyState.cpp
@@ -46,7 +46,7 @@ pas::EAnimationState CABSAim::UpdateBody(float dt, CBodyController& bc, CStateMa
   if (st == pas::EAnimationState::Invalid) {
     const zeus::CVector3f& target = bc.GetCommandMgr().GetAdditiveTargetVector();
     if (target.canBeNormalized()) {
-      CAnimData& animData = *bc.GetOwner().ModelData()->AnimationData();
+      CAnimData& animData = *bc.GetOwner().GetModelData()->GetAnimationData();
 
       float hAngle = zeus::clamp(-x18_angles[0], std::atan2(target.x(), target.y()), x18_angles[1]);
       hAngle *= 0.63661975f;
@@ -85,7 +85,7 @@ pas::EAnimationState CABSAim::UpdateBody(float dt, CBodyController& bc, CStateMa
 }
 
 void CABSAim::Shutdown(CBodyController& bc) {
-  CAnimData& animData = *bc.GetOwner().ModelData()->AnimationData();
+  CAnimData& animData = *bc.GetOwner().GetModelData()->GetAnimationData();
 
   if (x28_hWeight != 0.f)
     animData.DelAdditiveAnimation(x8_anims[x28_hWeight < 0.f ? 0 : 1]);
@@ -102,7 +102,7 @@ void CABSFlinch::Start(CBodyController& bc, CStateManager& mgr) {
   std::pair<float, s32> best = bc.GetPASDatabase().FindBestAnimation(parms, *mgr.GetActiveRandom(), -1);
   x8_anim = best.second;
 
-  CAnimData& animData = *bc.GetOwner().ModelData()->AnimationData();
+  CAnimData& animData = *bc.GetOwner().GetModelData()->GetAnimationData();
   animData.AddAdditiveAnimation(x8_anim, x4_weight, false, true);
 }
 
@@ -115,7 +115,7 @@ pas::EAnimationState CABSFlinch::GetBodyStateTransition(float dt, CBodyControlle
 pas::EAnimationState CABSFlinch::UpdateBody(float dt, CBodyController& bc, CStateManager& mgr) {
   const pas::EAnimationState st = GetBodyStateTransition(dt, bc);
   if (st == pas::EAnimationState::Invalid) {
-    CAnimData& animData = *bc.GetOwner().ModelData()->AnimationData();
+    CAnimData& animData = *bc.GetOwner().GetModelData()->GetAnimationData();
     CCharAnimTime rem = animData.GetAdditiveAnimationTree(x8_anim)->VGetTimeRemaining();
     if (std::fabs(rem.GetSeconds()) < 0.00001f)
       return pas::EAnimationState::AdditiveIdle;
@@ -149,7 +149,7 @@ void CABSReaction::Start(CBodyController& bc, CStateManager& mgr) {
   x8_anim = best.second;
 
   if (x8_anim != -1) {
-    CAnimData& animData = *bc.GetOwner().ModelData()->AnimationData();
+    CAnimData& animData = *bc.GetOwner().GetModelData()->GetAnimationData();
     animData.AddAdditiveAnimation(x8_anim, x4_weight, x10_active, false);
   }
 }
@@ -166,7 +166,7 @@ pas::EAnimationState CABSReaction::UpdateBody(float dt, CBodyController& bc, CSt
     if (x8_anim == -1)
       return pas::EAnimationState::AdditiveIdle;
 
-    CAnimData& animData = *bc.GetOwner().ModelData()->AnimationData();
+    CAnimData& animData = *bc.GetOwner().GetModelData()->GetAnimationData();
     if (x10_active) {
       if (bc.GetCommandMgr().GetCmd(EBodyStateCmd::StopReaction)) {
         StopAnimation(bc);
@@ -190,7 +190,7 @@ pas::EAnimationState CABSReaction::UpdateBody(float dt, CBodyController& bc, CSt
 
 void CABSReaction::StopAnimation(CBodyController& bc) {
   if (x8_anim != -1) {
-    CAnimData& animData = *bc.GetOwner().ModelData()->AnimationData();
+    CAnimData& animData = *bc.GetOwner().GetModelData()->GetAnimationData();
     animData.DelAdditiveAnimation(x8_anim);
     x8_anim = -1;
   }

--- a/Runtime/Character/CBodyController.cpp
+++ b/Runtime/Character/CBodyController.cpp
@@ -15,7 +15,7 @@ CBodyController::CBodyController(CActor& actor, float turnSpeed, EBodyType bodyT
   x2a4_bodyStateInfo.x18_bodyController = this;
 }
 
-void CBodyController::EnableAnimation(bool e) { x0_actor.ModelData()->AnimationData()->EnableAnimation(e); }
+void CBodyController::EnableAnimation(bool e) { x0_actor.GetModelData()->GetAnimationData()->EnableAnimation(e); }
 
 void CBodyController::Activate(CStateManager& mgr) {
   x300_25_active = true;
@@ -77,8 +77,8 @@ void CBodyController::Update(float dt, CStateManager& mgr) {
 bool CBodyController::HasBodyState(pas::EAnimationState s) const { return GetPASDatabase().HasState(s32(s)); }
 
 void CBodyController::SetCurrentAnimation(const CAnimPlaybackParms& parms, bool loop, bool noTrans) {
-  x0_actor.ModelData()->AnimationData()->SetAnimation(parms, noTrans);
-  x0_actor.ModelData()->EnableLooping(loop);
+  x0_actor.GetModelData()->GetAnimationData()->SetAnimation(parms, noTrans);
+  x0_actor.GetModelData()->EnableLooping(loop);
   x2f8_curAnim = parms.GetAnimationId();
 }
 
@@ -86,13 +86,13 @@ float CBodyController::GetAnimTimeRemaining() const {
   return x0_actor.GetModelData()->GetAnimationData()->GetAnimTimeRemaining("Whole Body");
 }
 
-void CBodyController::SetPlaybackRate(float r) { x0_actor.ModelData()->AnimationData()->SetPlaybackRate(r); }
+void CBodyController::SetPlaybackRate(float r) { x0_actor.GetModelData()->GetAnimationData()->SetPlaybackRate(r); }
 
 const CPASDatabase& CBodyController::GetPASDatabase() const {
   return x0_actor.GetModelData()->GetAnimationData()->GetCharacterInfo().GetPASDatabase();
 }
 
-void CBodyController::MultiplyPlaybackRate(float r) { x0_actor.ModelData()->AnimationData()->MultiplyPlaybackRate(r); }
+void CBodyController::MultiplyPlaybackRate(float r) { x0_actor.GetModelData()->GetAnimationData()->MultiplyPlaybackRate(r); }
 
 void CBodyController::FaceDirection(const zeus::CVector3f& v0, float dt) {
   if (x300_26_frozen)

--- a/Runtime/Character/CModelData.hpp
+++ b/Runtime/Character/CModelData.hpp
@@ -133,7 +133,7 @@ public:
   void DisintegrateDraw(EWhichModel which, const zeus::CTransform& xf, const CTexture& tex,
                         const zeus::CColor& addColor, float t);
 
-  CAnimData* AnimationData() { return x10_animData.get(); }
+  CAnimData* GetAnimationData() { return x10_animData.get(); }
   const CAnimData* GetAnimationData() const { return x10_animData.get(); }
   const TLockedToken<CModel>& GetNormalModel() const { return x1c_normalModel; }
   const TLockedToken<CModel>& GetXRayModel() const { return x2c_xrayModel; }

--- a/Runtime/Character/CRagDoll.cpp
+++ b/Runtime/Character/CRagDoll.cpp
@@ -305,7 +305,7 @@ void CRagDoll::Update(CStateManager& mgr, float dt, float waterTop) {
 
 void CRagDoll::Prime(CStateManager& mgr, const zeus::CTransform& xf, CModelData& mData) {
   zeus::CVector3f scale = mData.GetScale();
-  CAnimData* aData = mData.AnimationData();
+  CAnimData* aData = mData.GetAnimationData();
   aData->BuildPose();
   for (auto& particle : x4_particles)
     if (particle.x0_id != 0xff)

--- a/Runtime/MP1/CMFGame.cpp
+++ b/Runtime/MP1/CMFGame.cpp
@@ -186,7 +186,7 @@ void CMFGame::Touch() {
   if (gunVisible)
     player.GetPlayerGun()->TouchModel(*x14_stateManager);
   if (samusVisible)
-    player.ModelData()->Touch(*x14_stateManager, 0);
+    player.GetModelData()->Touch(*x14_stateManager, 0);
   if (ballVisible)
     player.GetMorphBall()->TouchModel(*x14_stateManager);
 }

--- a/Runtime/MP1/CSamusDoll.cpp
+++ b/Runtime/MP1/CSamusDoll.cpp
@@ -107,7 +107,7 @@ CModelData CSamusDoll::BuildSuitModelData1(CPlayerState::EPlayerSuit suit) {
   CModelData ret(CAnimRes(g_ResFactory->GetResourceIdByName("ANCS_ItemScreenSamus")->id, Character1Idxs[int(suit)],
                           zeus::skOne3f, 2, true));
   CAnimPlaybackParms parms(2, -1, 1.f, true);
-  ret.AnimationData()->SetAnimation(parms, false);
+  ret.GetAnimationData()->SetAnimation(parms, false);
   return ret;
 }
 
@@ -115,7 +115,7 @@ CModelData CSamusDoll::BuildSuitModelDataBoots(CPlayerState::EPlayerSuit suit) {
   CModelData ret(CAnimRes(g_ResFactory->GetResourceIdByName("ANCS_ItemScreenSamus")->id, CharacterBootsIdxs[int(suit)],
                           zeus::skOne3f, 2, true));
   CAnimPlaybackParms parms(2, -1, 1.f, true);
-  ret.AnimationData()->SetAnimation(parms, false);
+  ret.GetAnimationData()->SetAnimation(parms, false);
   return ret;
 }
 
@@ -177,8 +177,8 @@ void CSamusDoll::Update(float dt, CRandom16& rand) {
     if (x54_remTransitionTime == 0.f) {
       x4c_completedMorphball = x4d_selectedMorphball;
       if (!x4d_selectedMorphball) {
-        xc8_suitModel0->AnimationData()->SetAnimation(CAnimPlaybackParms(2, -1, 1.f, true), false);
-        x134_suitModelBoots->AnimationData()->SetAnimation(CAnimPlaybackParms(2, -1, 1.f, true), false);
+        xc8_suitModel0->GetAnimationData()->SetAnimation(CAnimPlaybackParms(2, -1, 1.f, true), false);
+        x134_suitModelBoots->GetAnimationData()->SetAnimation(CAnimPlaybackParms(2, -1, 1.f, true), false);
       }
     }
   }
@@ -293,10 +293,10 @@ void CSamusDoll::Draw(const CStateManager& mgr, float alpha) {
     for (size_t i = 0; i <= x118_suitModel1and2.size(); ++i) {
       TCachedToken<CSkinnedModel> backupModelData = xc8_suitModel0->GetAnimationData()->GetModelData();
       if (i < x118_suitModel1and2.size())
-        xc8_suitModel0->AnimationData()->SubstituteModelData(x118_suitModel1and2[i]);
+        xc8_suitModel0->GetAnimationData()->SubstituteModelData(x118_suitModel1and2[i]);
       xc8_suitModel0->InvSuitDraw(CModelData::EWhichModel::Normal, zeus::CTransform(), x24c_actorLights.get(),
                                   zeus::CColor(1.f, alpha), zeus::CColor(1.f, alpha * suitPulse));
-      xc8_suitModel0->AnimationData()->SubstituteModelData(backupModelData);
+      xc8_suitModel0->GetAnimationData()->SubstituteModelData(backupModelData);
     }
 
     x134_suitModelBoots->InvSuitDraw(CModelData::EWhichModel::Normal, zeus::CTransform(),
@@ -522,9 +522,9 @@ void CSamusDoll::Draw(const CStateManager& mgr, float alpha) {
 void CSamusDoll::Touch() {
   if (!CheckLoadComplete())
     return;
-  xc8_suitModel0->AnimationData()->PreRender();
-  x134_suitModelBoots->AnimationData()->PreRender();
-  x184_ballModelData->AnimationData()->PreRender();
+  xc8_suitModel0->GetAnimationData()->PreRender();
+  x134_suitModelBoots->GetAnimationData()->PreRender();
+  x184_ballModelData->GetAnimationData()->PreRender();
   xc8_suitModel0->Touch(CModelData::EWhichModel::Normal, 0);
   x134_suitModelBoots->Touch(CModelData::EWhichModel::Normal, 0);
   x184_ballModelData->Touch(CModelData::EWhichModel::Normal, 0);
@@ -547,13 +547,13 @@ void CSamusDoll::SetInMorphball(bool morphball) {
 void CSamusDoll::SetTransitionAnimation() {
   if (!x4c_completedMorphball) {
     /* Into morphball */
-    xc8_suitModel0->AnimationData()->SetAnimation(CAnimPlaybackParms{0, -1, 1.f, true}, false);
-    x134_suitModelBoots->AnimationData()->SetAnimation(CAnimPlaybackParms{0, -1, 1.f, true}, false);
+    xc8_suitModel0->GetAnimationData()->SetAnimation(CAnimPlaybackParms{0, -1, 1.f, true}, false);
+    x134_suitModelBoots->GetAnimationData()->SetAnimation(CAnimPlaybackParms{0, -1, 1.f, true}, false);
     x50_totalTransitionTime = x54_remTransitionTime = xc8_suitModel0->GetAnimationData()->GetAnimationDuration(0);
   } else if (!x4d_selectedMorphball) {
     /* Outta morphball */
-    xc8_suitModel0->AnimationData()->SetAnimation(CAnimPlaybackParms{1, -1, 1.f, true}, false);
-    x134_suitModelBoots->AnimationData()->SetAnimation(CAnimPlaybackParms{1, -1, 1.f, true}, false);
+    xc8_suitModel0->GetAnimationData()->SetAnimation(CAnimPlaybackParms{1, -1, 1.f, true}, false);
+    x134_suitModelBoots->GetAnimationData()->SetAnimation(CAnimPlaybackParms{1, -1, 1.f, true}, false);
     x50_totalTransitionTime = x54_remTransitionTime = xc8_suitModel0->GetAnimationData()->GetAnimationDuration(1);
   }
 }

--- a/Runtime/MP1/CSamusFaceReflection.cpp
+++ b/Runtime/MP1/CSamusFaceReflection.cpp
@@ -15,7 +15,7 @@ CSamusFaceReflection::CSamusFaceReflection(CStateManager& stateMgr)
 , x4c_lights(std::make_unique<CActorLights>(8, zeus::skZero3f, 4, 4, false, false, false, 0.1f)) {
   x60_lookDir = zeus::skForward;
   CAnimPlaybackParms parms(0, -1, 1.f, true);
-  x0_modelData.AnimationData()->SetAnimation(parms, false);
+  x0_modelData.GetAnimationData()->SetAnimation(parms, false);
 }
 
 void CSamusFaceReflection::PreDraw(const CStateManager& mgr) {
@@ -24,7 +24,7 @@ void CSamusFaceReflection::PreDraw(const CStateManager& mgr) {
       x70_hidden = true;
     } else {
       x70_hidden = false;
-      x0_modelData.AnimationData()->PreRender();
+      x0_modelData.GetAnimationData()->PreRender();
     }
   }
 }

--- a/Runtime/MP1/World/CBabygoth.cpp
+++ b/Runtime/MP1/World/CBabygoth.cpp
@@ -59,7 +59,7 @@ CBabygoth::CBabygoth(TUniqueId uid, std::string_view name, const CEntityInfo& in
 , x6ec_pathSearch(nullptr, 1, pInfo.GetPathfindingIndex(), 1.f, 1.f)
 , x7d0_approachPathSearch(nullptr, 1, pInfo.GetPathfindingIndex(), 1.f, 1.f)
 , x8d0_initialSpeed(x3b4_speed)
-, x8f0_boneTracking(*ModelData()->AnimationData(), "Head_1"sv, zeus::degToRad(80.f), zeus::degToRad(180.f),
+, x8f0_boneTracking(*GetModelData()->GetAnimationData(), "Head_1"sv, zeus::degToRad(80.f), zeus::degToRad(180.f),
                     EBoneTrackingFlags::None)
 , x930_aabox(GetBoundingBox(), GetMaterialList())
 , x958_iceProjectile(babyData.x8_fireballWeapon, babyData.xc_fireballDamage)
@@ -72,7 +72,7 @@ CBabygoth::CBabygoth(TUniqueId uid, std::string_view name, const CEntityInfo& in
   TLockedToken<CSkinRules> skin = g_SimplePool->GetObj({SBIG('CSKR'), babyData.x13c_noShellSkin});
   xa08_noShellModel =
       CToken(TObjOwnerDerivedFromIObj<CSkinnedModel>::GetNewDerivedObject(std::make_unique<CSkinnedModel>(
-          model, skin, x64_modelData->AnimationData()->GetModelData()->GetLayoutInfo(), 1, 1)));
+          model, skin, x64_modelData->GetAnimationData()->GetModelData()->GetLayoutInfo(), 1, 1)));
   xa14_crackOneParticle = g_SimplePool->GetObj({SBIG('PART'), babyData.x14c_crackOneParticle});
   xa20_crackTwoParticle = g_SimplePool->GetObj({SBIG('PART'), babyData.x150_crackTwoParticle});
   xa2c_destroyShellParticle = g_SimplePool->GetObj({SBIG('PART'), babyData.x154_destroyShellParticle});
@@ -218,9 +218,9 @@ void CBabygoth::Think(float dt, CStateManager& mgr) {
   if (x450_bodyController->IsElectrocuting())
     x8f0_boneTracking.SetActive(false);
   UpdateTimers(dt);
-  ModelData()->AnimationData()->PreRender();
+  GetModelData()->GetAnimationData()->PreRender();
   x8f0_boneTracking.Update(dt);
-  x8f0_boneTracking.PreRender(mgr, *ModelData()->AnimationData(), GetTransform(), GetModelData()->GetScale(),
+  x8f0_boneTracking.PreRender(mgr, *GetModelData()->GetAnimationData(), GetTransform(), GetModelData()->GetScale(),
                               *x450_bodyController);
   x928_colActMgr->Update(dt, mgr, CCollisionActorManager::EUpdateOptions(!xa49_29_objectSpaceCollision));
   xa49_29_objectSpaceCollision = true;
@@ -1094,7 +1094,7 @@ bool CBabygoth::IsDestinationObstructed(CStateManager& mgr) {
 }
 
 void CBabygoth::DestroyShell(CStateManager& mgr) {
-  ModelData()->AnimationData()->SubstituteModelData(xa08_noShellModel);
+  GetModelData()->GetAnimationData()->SubstituteModelData(xa08_noShellModel);
 
   for (TUniqueId uid : x9f8_shellIds) {
     if (TCastToPtr<CCollisionActor> colAct = mgr.ObjectById(uid)) {

--- a/Runtime/MP1/World/CBloodFlower.cpp
+++ b/Runtime/MP1/World/CBloodFlower.cpp
@@ -79,11 +79,11 @@ static std::string_view sFireEffects[3] = {
 };
 
 void CBloodFlower::TurnEffectsOn(u32 effect, CStateManager& mgr) {
-  ModelData()->AnimationData()->SetParticleEffectState(sFireEffects[effect], true, mgr);
+  GetModelData()->GetAnimationData()->SetParticleEffectState(sFireEffects[effect], true, mgr);
 }
 
 void CBloodFlower::TurnEffectsOff(u32 effect, CStateManager& mgr) {
-  ModelData()->AnimationData()->SetParticleEffectState(sFireEffects[effect], false, mgr);
+  GetModelData()->GetAnimationData()->SetParticleEffectState(sFireEffects[effect], false, mgr);
 }
 
 void CBloodFlower::Think(float dt, CStateManager& mgr) {

--- a/Runtime/MP1/World/CEyeball.cpp
+++ b/Runtime/MP1/World/CEyeball.cpp
@@ -97,8 +97,8 @@ void CEyeball::Think(float dt, CStateManager& mgr) {
     x5a8_targetPosition = player.GetTranslation() - (0.5f * player.GetVelocity());
     x570_boneTracking.SetTargetPosition(x5a8_targetPosition);
     x570_boneTracking.Update(dt);
-    ModelData()->AnimationData()->PreRender();
-    x570_boneTracking.PreRender(mgr, *ModelData()->AnimationData(), GetTransform(), GetModelData()->GetScale(),
+    GetModelData()->GetAnimationData()->PreRender();
+    x570_boneTracking.PreRender(mgr, *GetModelData()->GetAnimationData(), GetTransform(), GetModelData()->GetScale(),
                                 *x450_bodyController.get());
   } else
     x570_boneTracking.SetActive(false);
@@ -232,7 +232,7 @@ void CEyeball::FireBeam(CStateManager& mgr, const zeus::CTransform& xf) {
 
 void CEyeball::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   CPatterned::PreRender(mgr, frustum);
-  x570_boneTracking.PreRender(mgr, *ModelData()->AnimationData(), GetTransform(), GetModelData()->GetScale(),
+  x570_boneTracking.PreRender(mgr, *GetModelData()->GetAnimationData(), GetTransform(), GetModelData()->GetScale(),
                               *x450_bodyController);
 }
 

--- a/Runtime/MP1/World/CFireFlea.cpp
+++ b/Runtime/MP1/World/CFireFlea.cpp
@@ -61,7 +61,7 @@ CFireFlea::CFireFlea(TUniqueId uid, std::string_view name, const CEntityInfo& in
   filter.ExcludeList().Add(EMaterialTypes::Character);
   SetMaterialFilter(filter);
 
-  ModelData()->AnimationData()->SetParticleLightIdx(sLightIdx);
+  GetModelData()->GetAnimationData()->SetParticleLightIdx(sLightIdx);
   ++sLightIdx;
 }
 

--- a/Runtime/MP1/World/CFlaahgra.cpp
+++ b/Runtime/MP1/World/CFlaahgra.cpp
@@ -119,7 +119,7 @@ void CFlaahgra::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateM
   switch (msg) {
   case EScriptObjectMessage::InitializedInArea: {
     if (!x8e4_25_loading && !x8e4_24_loaded) {
-      const_cast<CGameArea::CPostConstructed*>(mgr.WorldNC()->GetAreaAlways(GetAreaIdAlways())->GetPostConstructed())
+      const_cast<CGameArea::CPostConstructed*>(mgr.GetWorld()->GetAreaAlways(GetAreaIdAlways())->GetPostConstructed())
           ->x113c_playerActorsLoading++;
       x8e4_25_loading = true;
     }
@@ -396,7 +396,7 @@ void CFlaahgra::LoadTokens(CStateManager& mgr) {
 void CFlaahgra::FinalizeLoad(CStateManager& mgr) {
   x8e4_24_loaded = true;
   if (x8e4_25_loading) {
-    const_cast<CGameArea::CPostConstructed*>(mgr.WorldNC()->GetAreaAlways(GetAreaIdAlways())->GetPostConstructed())
+    const_cast<CGameArea::CPostConstructed*>(mgr.GetWorld()->GetAreaAlways(GetAreaIdAlways())->GetPostConstructed())
         ->x113c_playerActorsLoading--;
     x8e4_25_loading = false;
   }
@@ -411,7 +411,7 @@ void CFlaahgra::Think(float dt, CStateManager& mgr) {
   CPatterned::Think(dt, mgr);
   x6cc_boneTracking->Update(dt);
   UpdateCollisionManagers(dt, mgr);
-  x6cc_boneTracking->PreRender(mgr, *ModelData()->AnimationData(), GetTransform(), GetModelData()->GetScale(),
+  x6cc_boneTracking->PreRender(mgr, *GetModelData()->GetAnimationData(), GetTransform(), GetModelData()->GetScale(),
                                *x450_bodyController);
   UpdateSmallScaleReGrowth(dt);
   UpdateHealthInfo(mgr);
@@ -508,7 +508,7 @@ void CFlaahgra::SetupCollisionManagers(CStateManager& mgr) {
       {EMaterialTypes::CollisionActor, EMaterialTypes::AIPassthrough, EMaterialTypes::Player}));
   AddMaterial(EMaterialTypes::ProjectilePassthrough, EMaterialTypes::Target, EMaterialTypes::Orbit, mgr);
   RemoveMaterial(EMaterialTypes::Solid, mgr);
-  ModelData()->SetScale(oldScale);
+  GetModelData()->SetScale(oldScale);
   x7a4_sphereCollision->AddMaterial(mgr, {EMaterialTypes::AIJoint, EMaterialTypes::CameraPassthrough});
   x79c_leftArmCollision->AddMaterial(mgr, {EMaterialTypes::AIJoint, EMaterialTypes::CameraPassthrough});
   x7a0_rightArmCollision->AddMaterial(mgr, {EMaterialTypes::AIJoint, EMaterialTypes::CameraPassthrough});
@@ -797,7 +797,7 @@ void CFlaahgra::SetCollisionActorBounds(CStateManager& mgr, const std::unique_pt
 }
 void CFlaahgra::UpdateScale(float t, float min, float max) {
   float scale = (t * (max - min) + min);
-  ModelData()->SetScale(zeus::skOne3f * scale);
+  GetModelData()->SetScale(zeus::skOne3f * scale);
 }
 
 float CFlaahgra::GetEndActionTime() const {

--- a/Runtime/MP1/World/CFlaahgraTentacle.cpp
+++ b/Runtime/MP1/World/CFlaahgraTentacle.cpp
@@ -12,7 +12,7 @@ CFlaahgraTentacle::CFlaahgraTentacle(TUniqueId uid, std::string_view name, const
 : CPatterned(ECharacter::FlaahgraTentacle, uid, name, EFlavorType::Zero, info, xf, std::move(mData), pInfo,
              EMovementType::Flyer, EColliderType::One, EBodyType::Restricted, actParms, EKnockBackVariant::Large) {
   x58e_24_ = false;
-  ActorLights()->SetCastShadows(false);
+  GetActorLights()->SetCastShadows(false);
   x460_knockBackController.SetAutoResetImpulse(false);
   CreateShadow(false);
 }

--- a/Runtime/MP1/World/CNewIntroBoss.cpp
+++ b/Runtime/MP1/World/CNewIntroBoss.cpp
@@ -214,10 +214,10 @@ void CNewIntroBoss::Think(float dt, CStateManager& mgr) {
   if (x63c_attackTime > 0.f)
     x63c_attackTime -= dt;
 
-  ModelData()->AnimationData()->PreRender();
+  GetModelData()->GetAnimationData()->PreRender();
 
   if (x400_25_alive)
-    x574_boneTracking.PreRender(mgr, *ModelData()->AnimationData(), x34_transform, ModelData()->GetScale(),
+    x574_boneTracking.PreRender(mgr, *GetModelData()->GetAnimationData(), x34_transform, GetModelData()->GetScale(),
                                 *x450_bodyController);
 
   x5ec_collisionManager->Update(dt, mgr, CCollisionActorManager::EUpdateOptions::ObjectSpace);

--- a/Runtime/MP1/World/CParasite.cpp
+++ b/Runtime/MP1/World/CParasite.cpp
@@ -72,7 +72,7 @@ CParasite::CParasite(TUniqueId uid, std::string_view name, EFlavorType flavor, c
     TLockedToken<CModel> skin = g_SimplePool->GetObj({FOURCC('CSKR'), skinRes});
     x624_extraModel =
         CToken(TObjOwnerDerivedFromIObj<CSkinnedModel>::GetNewDerivedObject(std::make_unique<CSkinnedModel>(
-            model, skin, x64_modelData->AnimationData()->GetModelData()->GetLayoutInfo(), 1, 1)));
+            model, skin, x64_modelData->GetAnimationData()->GetModelData()->GetLayoutInfo(), 1, 1)));
     break;
   }
   default:
@@ -205,7 +205,7 @@ void CParasite::UpdateCollisionActors(float dt, CStateManager& mgr) {
       AddMaterial(EMaterialTypes::Solid, mgr);
       RemoveMaterial(EMaterialTypes::ProjectilePassthrough, mgr);
       DestroyActorManager(mgr);
-      x64_modelData->AnimationData()->SubstituteModelData(x624_extraModel);
+      x64_modelData->GetAnimationData()->SubstituteModelData(x624_extraModel);
     }
   }
 }
@@ -219,7 +219,7 @@ void CParasite::Think(float dt, CStateManager& mgr) {
     UpdateCollisionActors(dt, mgr);
 
   x5d6_26_playerObstructed = false;
-  CGameArea* area = mgr.WorldNC()->GetArea(GetAreaIdAlways());
+  CGameArea* area = mgr.GetWorld()->GetArea(GetAreaIdAlways());
 
   CGameArea::EOcclusionState r6 = CGameArea::EOcclusionState::Occluded;
   if (area->IsPostConstructed())

--- a/Runtime/MP1/World/CSpacePirate.cpp
+++ b/Runtime/MP1/World/CSpacePirate.cpp
@@ -64,7 +64,7 @@ CPirateRagDoll::CPirateRagDoll(CStateManager& mgr, CSpacePirate* sp, u16 thudSfx
   SetNumLengthConstraints(47);
   SetNumJointConstraints(4);
   zeus::CVector3f scale = x6c_spacePirate->GetModelData()->GetScale();
-  CAnimData* aData = x6c_spacePirate->ModelData()->AnimationData();
+  CAnimData* aData = x6c_spacePirate->GetModelData()->GetAnimationData();
   aData->BuildPose();
   zeus::CVector3f center = x6c_spacePirate->GetBoundingBox().center();
   for (int i = 0; i < 14; ++i) {
@@ -139,7 +139,7 @@ CPirateRagDoll::CPirateRagDoll(CStateManager& mgr, CSpacePirate* sp, u16 thudSfx
 
 void CPirateRagDoll::PreRender(const zeus::CVector3f& v, CModelData& mData) {
   if (!x68_25_over || x68_27_continueSmallMovements) {
-    CAnimData* aData = mData.AnimationData();
+    CAnimData* aData = mData.GetAnimationData();
     for (CSegId id : aData->GetCharLayoutInfo().GetSegIdList().GetList())
       if (aData->GetCharLayoutInfo().GetRootNode()->GetBoneMap()[id].x10_children.size() > 1)
         aData->PoseBuilder().GetTreeMap()[id].x4_rotation = zeus::CQuaternion();
@@ -341,7 +341,7 @@ CSpacePirate::CSpacePirate(TUniqueId uid, std::string_view name, const CEntityIn
 , x568_pirateData(in, propCount)
 , x660_pathFindSearch(nullptr, 0x1, pInfo.GetPathfindingIndex(), 1.f, 1.f)
 , x750_initialHP(pInfo.GetHealthInfo().GetHP())
-, x764_boneTracking(*x64_modelData->AnimationData(), "Head_1"sv, 1.22173f, 3.14159f, EBoneTrackingFlags::None)
+, x764_boneTracking(*x64_modelData->GetAnimationData(), "Head_1"sv, 1.22173f, 3.14159f, EBoneTrackingFlags::None)
 , x7c4_burstFire(skBursts, x568_pirateData.xac_firstBurstCount)
 , x8b8_minCloakAlpha(x568_pirateData.xb0_CloakOpacity)
 , x8bc_maxCloakAlpha(x568_pirateData.xb4_MaxCloakOpacity)
@@ -548,7 +548,7 @@ bool CSpacePirate::FireProjectile(float dt, CStateManager& mgr) {
     auto bestAnim = x450_bodyController->GetPASDatabase().FindBestAnimation({24, CPASAnimParm::FromEnum(2)},
                                                                             *mgr.GetActiveRandom(), -1);
     if (bestAnim.first > 0.f)
-      x64_modelData->AnimationData()->AddAdditiveAnimation(bestAnim.second, 1.f, false, true);
+      x64_modelData->GetAnimationData()->AddAdditiveAnimation(bestAnim.second, 1.f, false, true);
     CSfxManager::AddEmitter(x568_pirateData.x48_Sound_Projectile, GetTranslation(), zeus::skZero3f, true,
                             false, 0x7f, kInvalidAreaId);
   }
@@ -801,9 +801,9 @@ void CSpacePirate::SetEyeParticleActive(CStateManager& mgr, bool active) {
   if (!x636_24_trooper) {
     if (!x634_29_onlyAttackInRange || x635_26_seated) {
       if (!x635_27_shadowPirate)
-        x64_modelData->AnimationData()->SetParticleEffectState("TwoEyes"sv, active, mgr);
+        x64_modelData->GetAnimationData()->SetParticleEffectState("TwoEyes"sv, active, mgr);
     } else {
-      x64_modelData->AnimationData()->SetParticleEffectState("OneEye"sv, active, mgr);
+      x64_modelData->GetAnimationData()->SetParticleEffectState("OneEye"sv, active, mgr);
     }
   }
 }
@@ -978,9 +978,9 @@ void CSpacePirate::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) 
     x85c_ragDoll->PreRender(GetTranslation(), *x64_modelData);
   CPatterned::PreRender(mgr, frustum);
   if (!x85c_ragDoll || !x85c_ragDoll->IsPrimed()) {
-    x764_boneTracking.PreRender(mgr, *x64_modelData->AnimationData(), x34_transform, x64_modelData->GetScale(),
+    x764_boneTracking.PreRender(mgr, *x64_modelData->GetAnimationData(), x34_transform, x64_modelData->GetScale(),
                                 *x450_bodyController);
-    x860_ikChain.PreRender(*x64_modelData->AnimationData(), x34_transform, x64_modelData->GetScale());
+    x860_ikChain.PreRender(*x64_modelData->GetAnimationData(), x34_transform, x64_modelData->GetScale());
   }
 }
 
@@ -1043,7 +1043,7 @@ void CSpacePirate::DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node
       CSegId lctrId = x64_modelData->GetAnimationData()->GetLocatorSegId(node.GetLocatorName());
       if (lctrId != 3) {
         zeus::CTransform xf = GetLctrTransform(lctrId);
-        x860_ikChain.Activate(*x64_modelData->AnimationData(), lctrId, xf);
+        x860_ikChain.Activate(*x64_modelData->GetAnimationData(), lctrId, xf);
         x639_28_satUp = true;
       }
     }

--- a/Runtime/MP1/World/CSpankWeed.cpp
+++ b/Runtime/MP1/World/CSpankWeed.cpp
@@ -25,7 +25,7 @@ CSpankWeed::CSpankWeed(TUniqueId uid, std::string_view name, const CEntityInfo& 
   if (modelScale.x() != modelScale.y() || modelScale.x() != modelScale.z()) {
     float scale = modelScale.magnitude() / std::sqrt(3.f);
 
-    ModelData()->SetScale(zeus::CVector3f(scale));
+    GetModelData()->SetScale(zeus::CVector3f(scale));
     SpankLog.report(logvisor::Level::Warning,
                     fmt("WARNING: Non-uniform scale {} applied to Spank Weed"
                         "...changing scale to ({} {} {})\n"),

--- a/Runtime/Weapon/CGrappleArm.cpp
+++ b/Runtime/Weapon/CGrappleArm.cpp
@@ -116,42 +116,42 @@ void CGrappleArm::SetAnimState(EArmState state) {
   if (x334_animState == state)
     return;
 
-  x0_grappleArmModel->AnimationData()->EnableLooping(false);
+  x0_grappleArmModel->GetAnimationData()->EnableLooping(false);
   x3b2_28_isGrappling = true;
 
   switch (state) {
   case EArmState::IntoGrapple: {
     ResetAuxParams(true);
     CAnimPlaybackParms parms(0, -1, 1.f, true);
-    x0_grappleArmModel->AnimationData()->SetAnimation(parms, false);
+    x0_grappleArmModel->GetAnimationData()->SetAnimation(parms, false);
     x3b2_25_beamActive = false;
     x3b2_24_active = true;
     break;
   }
   case EArmState::IntoGrappleIdle: {
     CAnimPlaybackParms parms(1, -1, 1.f, true);
-    x0_grappleArmModel->AnimationData()->EnableLooping(true);
-    x0_grappleArmModel->AnimationData()->SetAnimation(parms, false);
+    x0_grappleArmModel->GetAnimationData()->EnableLooping(true);
+    x0_grappleArmModel->GetAnimationData()->SetAnimation(parms, false);
     break;
   }
   case EArmState::FireGrapple: {
     CAnimPlaybackParms parms(2, -1, 1.f, true);
-    x0_grappleArmModel->AnimationData()->SetAnimation(parms, false);
+    x0_grappleArmModel->GetAnimationData()->SetAnimation(parms, false);
     break;
   }
   case EArmState::ConnectGrapple: {
     CAnimPlaybackParms parms(3, -1, 1.f, true);
-    x0_grappleArmModel->AnimationData()->SetAnimation(parms, false);
+    x0_grappleArmModel->GetAnimationData()->SetAnimation(parms, false);
     break;
   }
   case EArmState::Connected: {
     CAnimPlaybackParms parms(3, -1, 1.f, true);
-    x0_grappleArmModel->AnimationData()->SetAnimation(parms, false);
+    x0_grappleArmModel->GetAnimationData()->SetAnimation(parms, false);
     break;
   }
   case EArmState::OutOfGrapple: {
     CAnimPlaybackParms parms(4, -1, 1.f, true);
-    x0_grappleArmModel->AnimationData()->SetAnimation(parms, false);
+    x0_grappleArmModel->GetAnimationData()->SetAnimation(parms, false);
     DisconnectGrappleBeam();
     break;
   }
@@ -465,9 +465,9 @@ void CGrappleArm::Update(float grappleSwingT, float dt, CStateManager& mgr) {
 
 void CGrappleArm::PreRender(const CStateManager& mgr, const zeus::CFrustum& frustum, const zeus::CVector3f& camPos) {
   if (x3b2_24_active && !x3b2_29_suitLoading) {
-    x0_grappleArmModel->AnimationData()->PreRender();
+    x0_grappleArmModel->GetAnimationData()->PreRender();
     if (x50_grappleArmSkeletonModel)
-      x50_grappleArmSkeletonModel->AnimationData()->PreRender();
+      x50_grappleArmSkeletonModel->GetAnimationData()->PreRender();
   }
 }
 
@@ -478,7 +478,7 @@ void CGrappleArm::RenderXRayModel(const CStateManager& mgr, const zeus::CTransfo
   // g_Renderer->SetAmbientColor(zeus::skWhite);
   CSkinnedModel& model = const_cast<CSkinnedModel&>(*x50_grappleArmSkeletonModel->GetAnimationData()->GetModelData());
   model.GetModelInst()->ActivateLights({CLight::BuildLocalAmbient({}, zeus::skWhite)});
-  const_cast<CGrappleArm*>(this)->x0_grappleArmModel->AnimationData()->Render(model, flags, {}, nullptr);
+  const_cast<CGrappleArm*>(this)->x0_grappleArmModel->GetAnimationData()->Render(model, flags, {}, nullptr);
   // g_Renderer->SetAmbientColor(zeus::skWhite);
   // CGraphics::DisableAllLights();
 }

--- a/Runtime/Weapon/CGunController.cpp
+++ b/Runtime/Weapon/CGunController.cpp
@@ -6,17 +6,17 @@
 namespace urde {
 
 void CGunController::LoadFidgetAnimAsync(CStateManager& mgr, s32 type, s32 gunId, s32 animSet) {
-  x30_fidget.LoadAnimAsync(*x0_modelData.AnimationData(), type, gunId, animSet, mgr);
+  x30_fidget.LoadAnimAsync(*x0_modelData.GetAnimationData(), type, gunId, animSet, mgr);
 }
 
 void CGunController::EnterFidget(CStateManager& mgr, s32 type, s32 gunId, s32 animSet) {
-  x54_curAnimId = x30_fidget.SetAnim(*x0_modelData.AnimationData(), type, gunId, animSet, mgr);
+  x54_curAnimId = x30_fidget.SetAnim(*x0_modelData.GetAnimationData(), type, gunId, animSet, mgr);
   x50_gunState = EGunState::Fidget;
 }
 
 void CGunController::EnterFreeLook(CStateManager& mgr, s32 gunId, s32 setId) {
   if (x50_gunState != EGunState::ComboFire && !x58_25_enteredComboFire)
-    x54_curAnimId = x4_freeLook.SetAnim(*x0_modelData.AnimationData(), gunId, setId, 0, mgr, 0.f);
+    x54_curAnimId = x4_freeLook.SetAnim(*x0_modelData.GetAnimationData(), gunId, setId, 0, mgr, 0.f);
   else
     x4_freeLook.SetLoopState(x1c_comboFire.GetLoopState());
   x50_gunState = EGunState::FreeLook;
@@ -24,7 +24,7 @@ void CGunController::EnterFreeLook(CStateManager& mgr, s32 gunId, s32 setId) {
 
 void CGunController::EnterComboFire(CStateManager& mgr, s32 gunId) {
   if (x50_gunState != EGunState::FreeLook)
-    x54_curAnimId = x1c_comboFire.SetAnim(*x0_modelData.AnimationData(), gunId, 0, mgr, 0.f);
+    x54_curAnimId = x1c_comboFire.SetAnim(*x0_modelData.GetAnimationData(), gunId, 0, mgr, 0.f);
   else
     x1c_comboFire.SetLoopState(x4_freeLook.GetLoopState());
   x50_gunState = EGunState::ComboFire;
@@ -46,13 +46,13 @@ void CGunController::EnterStruck(CStateManager& mgr, float angle, bool bigStrike
     break;
   }
 
-  const CPASDatabase& pasDatabase = x0_modelData.AnimationData()->GetCharacterInfo().GetPASDatabase();
+  const CPASDatabase& pasDatabase = x0_modelData.GetAnimationData()->GetCharacterInfo().GetPASDatabase();
   CPASAnimParmData parms(2, CPASAnimParm::FromInt32(x4_freeLook.GetGunId()), CPASAnimParm::FromReal32(angle),
                          CPASAnimParm::FromBool(bigStrike), CPASAnimParm::FromBool(b2));
   std::pair<float, s32> anim = pasDatabase.FindBestAnimation(parms, *mgr.GetActiveRandom(), -1);
-  x0_modelData.AnimationData()->EnableLooping(false);
+  x0_modelData.GetAnimationData()->EnableLooping(false);
   CAnimPlaybackParms aparms(anim.second, -1, 1.f, true);
-  x0_modelData.AnimationData()->SetAnimation(aparms, false);
+  x0_modelData.GetAnimationData()->SetAnimation(aparms, false);
   x54_curAnimId = anim.second;
   x58_25_enteredComboFire = false;
   x50_gunState = bigStrike ? EGunState::BigStrike : EGunState::Strike;
@@ -73,19 +73,19 @@ void CGunController::EnterIdle(CStateManager& mgr) {
     return;
   }
 
-  const CPASDatabase& pasDatabase = x0_modelData.AnimationData()->GetCharacterInfo().GetPASDatabase();
+  const CPASDatabase& pasDatabase = x0_modelData.GetAnimationData()->GetCharacterInfo().GetPASDatabase();
   CPASAnimParmData parms(5, parm);
   std::pair<float, s32> anim = pasDatabase.FindBestAnimation(parms, *mgr.GetActiveRandom(), -1);
-  x0_modelData.AnimationData()->EnableLooping(false);
+  x0_modelData.GetAnimationData()->EnableLooping(false);
   CAnimPlaybackParms aparms(anim.second, -1, 1.f, true);
-  x0_modelData.AnimationData()->SetAnimation(aparms, false);
+  x0_modelData.GetAnimationData()->SetAnimation(aparms, false);
   x54_curAnimId = anim.second;
   x50_gunState = EGunState::Idle;
   x58_25_enteredComboFire = false;
 }
 
 bool CGunController::Update(float dt, CStateManager& mgr) {
-  CAnimData& animData = *x0_modelData.AnimationData();
+  CAnimData& animData = *x0_modelData.GetAnimationData();
   switch (x50_gunState) {
   case EGunState::FreeLook: {
     x58_24_animDone = x4_freeLook.Update(animData, dt, mgr);
@@ -126,7 +126,7 @@ bool CGunController::Update(float dt, CStateManager& mgr) {
 }
 
 void CGunController::ReturnToDefault(CStateManager& mgr, float dt, bool setState) {
-  CAnimData& animData = *x0_modelData.AnimationData();
+  CAnimData& animData = *x0_modelData.GetAnimationData();
 
   switch (x50_gunState) {
   case EGunState::Strike:
@@ -159,11 +159,11 @@ void CGunController::ReturnToDefault(CStateManager& mgr, float dt, bool setState
 }
 
 void CGunController::ReturnToBasePosition(CStateManager& mgr, float) {
-  const CPASDatabase& pasDatabase = x0_modelData.AnimationData()->GetCharacterInfo().GetPASDatabase();
+  const CPASDatabase& pasDatabase = x0_modelData.GetAnimationData()->GetCharacterInfo().GetPASDatabase();
   std::pair<float, s32> anim = pasDatabase.FindBestAnimation(CPASAnimParmData(6), *mgr.GetActiveRandom(), -1);
-  x0_modelData.AnimationData()->EnableLooping(false);
+  x0_modelData.GetAnimationData()->EnableLooping(false);
   CAnimPlaybackParms parms(anim.second, -1, 1.f, true);
-  x0_modelData.AnimationData()->SetAnimation(parms, false);
+  x0_modelData.GetAnimationData()->SetAnimation(parms, false);
   x54_curAnimId = anim.second;
   x58_25_enteredComboFire = false;
 }

--- a/Runtime/Weapon/CGunMotion.cpp
+++ b/Runtime/Weapon/CGunMotion.cpp
@@ -12,7 +12,7 @@ CGunMotion::CGunMotion(CAssetId ancsId, const zeus::CVector3f& scale)
 }
 
 void CGunMotion::LoadAnimations() {
-  NWeaponTypes::get_token_vector(*x0_modelData.AnimationData(), 0, 14, xa8_anims, true);
+  NWeaponTypes::get_token_vector(*x0_modelData.GetAnimationData(), 0, 14, xa8_anims, true);
 }
 
 bool CGunMotion::PlayPasAnim(SamusGun::EAnimationState state, CStateManager& mgr, float angle, bool bigStrike) {
@@ -52,9 +52,9 @@ bool CGunMotion::PlayPasAnim(SamusGun::EAnimationState state, CStateManager& mgr
   }
 
   if (animId != -1) {
-    x0_modelData.AnimationData()->EnableLooping(loop);
+    x0_modelData.GetAnimationData()->EnableLooping(loop);
     CAnimPlaybackParms aparms(animId, -1, 1.f, true);
-    x0_modelData.AnimationData()->SetAnimation(aparms, false);
+    x0_modelData.GetAnimationData()->SetAnimation(aparms, false);
   }
 
   return loop;
@@ -65,9 +65,9 @@ void CGunMotion::ReturnToDefault(CStateManager& mgr, bool setState) {
 }
 
 void CGunMotion::BasePosition(bool bigStrikeReset) {
-  x0_modelData.AnimationData()->EnableLooping(false);
+  x0_modelData.GetAnimationData()->EnableLooping(false);
   CAnimPlaybackParms aparms(bigStrikeReset ? 6 : 0, -1, 1.f, true);
-  x0_modelData.AnimationData()->SetAnimation(aparms, false);
+  x0_modelData.GetAnimationData()->SetAnimation(aparms, false);
 }
 
 void CGunMotion::EnterFidget(CStateManager& mgr, SamusGun::EFidgetType type, s32 parm2) {

--- a/Runtime/Weapon/CGunWeapon.cpp
+++ b/Runtime/Weapon/CGunWeapon.cpp
@@ -104,7 +104,7 @@ void CGunWeapon::Reset(CStateManager& mgr) {
   if (!x218_26_loaded)
     return;
 
-  x10_solidModelData->AnimationData()->EnableLooping(false);
+  x10_solidModelData->GetAnimationData()->EnableLooping(false);
   if (x218_25_enableCharge)
     x218_25_enableCharge = false;
   else
@@ -116,9 +116,9 @@ static const s32 skAnimTypeList[] = {0, 4, 1, 2, 3, 5, 6, 7, 8, 9, 10};
 void CGunWeapon::PlayAnim(NWeaponTypes::EGunAnimType type, bool loop) {
   if (x218_26_loaded && type >= NWeaponTypes::EGunAnimType::BasePosition &&
       type <= NWeaponTypes::EGunAnimType::ToBeam) {
-    x10_solidModelData->AnimationData()->EnableLooping(loop);
+    x10_solidModelData->GetAnimationData()->EnableLooping(loop);
     CAnimPlaybackParms parms(skAnimTypeList[int(type)], -1, 1.f, true);
-    x10_solidModelData->AnimationData()->SetAnimation(parms, false);
+    x10_solidModelData->GetAnimationData()->SetAnimation(parms, false);
   }
 }
 
@@ -173,9 +173,9 @@ void CGunWeapon::Fire(bool underwater, float dt, EChargeState chargeState, const
     mgr.GetCameraManager()->AddCameraShaker(CCameraShakeData::skChargedShotCameraShakeData, false);
   }
 
-  x10_solidModelData->AnimationData()->EnableLooping(false);
+  x10_solidModelData->GetAnimationData()->EnableLooping(false);
   CAnimPlaybackParms parms(skShootAnim[int(chargeState)], -1, 1.f, true);
-  x10_solidModelData->AnimationData()->SetAnimation(parms, false);
+  x10_solidModelData->GetAnimationData()->SetAnimation(parms, false);
 }
 
 void CGunWeapon::EnableFx(bool enable) {
@@ -304,7 +304,7 @@ void CGunWeapon::LoadGunModels(CStateManager& mgr) {
   x10_solidModelData.emplace(CAnimRes(x214_ancsId, 0, x4_scale, defaultAnim, false));
   x60_holoModelData.emplace(CAnimRes(x214_ancsId, 1, x4_scale, defaultAnim, false));
   CAnimPlaybackParms parms(defaultAnim, -1, 1.f, true);
-  x10_solidModelData->AnimationData()->SetAnimation(parms, true);
+  x10_solidModelData->GetAnimationData()->SetAnimation(parms, true);
   LoadSuitArm(mgr);
   x10_solidModelData->SetSortThermal(true);
   x60_holoModelData->SetSortThermal(true);
@@ -478,7 +478,7 @@ void CGunWeapon::DrawHologram(const CStateManager& mgr, const zeus::CTransform& 
     // g_Renderer->SetAmbientColor(zeus::skWhite);
     CSkinnedModel& model = const_cast<CSkinnedModel&>(*x60_holoModelData->GetAnimationData()->GetModelData());
     model.GetModelInst()->ActivateLights({CLight::BuildLocalAmbient({}, zeus::skWhite)});
-    const_cast<CGunWeapon*>(this)->x10_solidModelData->AnimationData()->Render(model, flags, {}, nullptr);
+    const_cast<CGunWeapon*>(this)->x10_solidModelData->GetAnimationData()->Render(model, flags, {}, nullptr);
     // g_Renderer->SetAmbientColor(zeus::skWhite);
     // CGraphics::DisableAllLights();
   }

--- a/Runtime/Weapon/CPhazonBeam.cpp
+++ b/Runtime/Weapon/CPhazonBeam.cpp
@@ -28,7 +28,7 @@ CPhazonBeam::CPhazonBeam(CAssetId characterId, EWeaponType type, TUniqueId playe
 void CPhazonBeam::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) {
   TAreaId aid = mgr.GetPlayer().GetAreaIdAlways();
   if (msg == EScriptObjectMessage::Deleted && aid != kInvalidAreaId)
-    mgr.WorldNC()->GetArea(aid)->SetWeaponWorldLighting(4.f, 1.f);
+    mgr.GetWorld()->GetArea(aid)->SetWeaponWorldLighting(4.f, 1.f);
 }
 
 void CPhazonBeam::StopBeam(CStateManager& mgr, bool b1) {
@@ -102,7 +102,7 @@ void CPhazonBeam::Update(float dt, CStateManager& mgr) {
   x278_fireTime += dt;
   TAreaId aid = mgr.GetPlayer().GetAreaIdAlways();
   if (aid != kInvalidAreaId) {
-    CGameArea* area = mgr.WorldNC()->GetArea(aid);
+    CGameArea* area = mgr.GetWorld()->GetArea(aid);
     if (x278_fireTime > 1.f / 6.f)
       area->SetWeaponWorldLighting(4.f, 1.f);
     else

--- a/Runtime/Weapon/CPlasmaBeam.cpp
+++ b/Runtime/Weapon/CPlasmaBeam.cpp
@@ -21,7 +21,7 @@ void CPlasmaBeam::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CS
 
 void CPlasmaBeam::SetWorldLighting(CStateManager& mgr, TAreaId aid, float speed, float target) {
   if (x22c_25_worldLighingDim && x23c_stateArea != aid && x23c_stateArea != kInvalidAreaId) {
-    CGameArea* area = mgr.WorldNC()->GetArea(x23c_stateArea);
+    CGameArea* area = mgr.GetWorld()->GetArea(x23c_stateArea);
     if (area->IsPostConstructed())
       area->SetWeaponWorldLighting(2.f, 1.f);
   }
@@ -30,7 +30,7 @@ void CPlasmaBeam::SetWorldLighting(CStateManager& mgr, TAreaId aid, float speed,
   x22c_25_worldLighingDim = target != 1.f;
 
   if (x23c_stateArea != kInvalidAreaId) {
-    CGameArea* area = mgr.WorldNC()->GetArea(x23c_stateArea);
+    CGameArea* area = mgr.GetWorld()->GetArea(x23c_stateArea);
     if (area->IsPostConstructed())
       area->SetWeaponWorldLighting(speed, target);
   }

--- a/Runtime/Weapon/CPlayerGun.cpp
+++ b/Runtime/Weapon/CPlayerGun.cpp
@@ -216,7 +216,7 @@ void CPlayerGun::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CSt
     x72c_currentBeam->SetRainSplashGenerator(x748_rainSplashGenerator.get());
     x744_auxWeapon->Load(x310_currentBeam, mgr);
     CAnimPlaybackParms parms(skBeamAnimIds[int(mgr.GetPlayerState()->GetCurrentBeam())], -1, 1.f, true);
-    x6e0_rightHandModel.AnimationData()->SetAnimation(parms, false);
+    x6e0_rightHandModel.GetAnimationData()->SetAnimation(parms, false);
     break;
   }
   case EScriptObjectMessage::Deleted:
@@ -489,7 +489,7 @@ void CPlayerGun::ResetBeamParams(CStateManager& mgr, const CPlayerState& playerS
   if (playerState.ItemEnabled(CPlayerState::EItemType::ChargeBeam))
     ResetCharge(mgr, false);
   CAnimPlaybackParms parms(skBeamAnimIds[int(x314_nextBeam)], -1, 1.f, true);
-  x6e0_rightHandModel.AnimationData()->SetAnimation(parms, false);
+  x6e0_rightHandModel.GetAnimationData()->SetAnimation(parms, false);
   Reset(mgr, false);
   if (playSelectionSfx)
     CSfxManager::SfxStart(SFXwpn_morph_out_wipe, 1.f, 0.f, true, 0x7f, false, kInvalidAreaId);
@@ -2018,7 +2018,7 @@ void CPlayerGun::PreRender(const CStateManager& mgr, const zeus::CFrustum& frust
     x740_grappleArm->PreRender(mgr, frustum, camPos);
 
   if (x678_morph.GetGunState() != CGunMorph::EGunState::OutWipeDone || activeVisor == CPlayerState::EPlayerVisor::XRay)
-    x6e0_rightHandModel.AnimationData()->PreRender();
+    x6e0_rightHandModel.GetAnimationData()->PreRender();
 
   if (x833_28_phazonBeamActive)
     g_Renderer->AllocatePhazonSuitMaskTexture();

--- a/Runtime/Weapon/CWaveBeam.cpp
+++ b/Runtime/Weapon/CWaveBeam.cpp
@@ -76,8 +76,8 @@ void CWaveBeam::Fire(bool underwater, float dt, EChargeState chargeState, const 
 
   NWeaponTypes::play_sfx(kSoundId[int(chargeState)], underwater, false, 0.165f);
   CAnimPlaybackParms parms(skShootAnim[int(chargeState)], -1, 1.f, true);
-  x10_solidModelData->AnimationData()->EnableLooping(false);
-  x10_solidModelData->AnimationData()->SetAnimation(parms, false);
+  x10_solidModelData->GetAnimationData()->EnableLooping(false);
+  x10_solidModelData->GetAnimationData()->SetAnimation(parms, false);
 }
 
 void CWaveBeam::EnableSecondaryFx(ESecondaryFxType type) {

--- a/Runtime/World/CActor.cpp
+++ b/Runtime/World/CActor.cpp
@@ -80,7 +80,7 @@ void CActor::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateMana
   {
     RemoveEmitter();
     if (HasModelData() && !x64_modelData->IsNull())
-      if (CAnimData* aData = x64_modelData->AnimationData())
+      if (CAnimData* aData = x64_modelData->GetAnimationData())
         aData->GetParticleDB().DeleteAllLights(mgr);
     break;
   }
@@ -91,9 +91,9 @@ void CActor::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateMana
     else
       RemoveMaterial(EMaterialTypes::Scannable, mgr);
 
-    if (HasModelData() && x64_modelData->AnimationData()) {
+    if (HasModelData() && x64_modelData->GetAnimationData()) {
       TAreaId aid = GetAreaId();
-      x64_modelData->AnimationData()->InitializeEffects(mgr, aid, x64_modelData->GetScale());
+      x64_modelData->GetAnimationData()->InitializeEffects(mgr, aid, x64_modelData->GetScale());
     }
     break;
   }
@@ -161,7 +161,7 @@ void CActor::PreRender(CStateManager& mgr, const zeus::CFrustum& planes) {
     }
 
     if (x64_modelData->HasAnimData())
-      x64_modelData->AnimationData()->PreRender();
+      x64_modelData->GetAnimationData()->PreRender();
   } else {
     if (xe4_29_actorLightsDirty) {
       xe4_29_actorLightsDirty = false;
@@ -254,7 +254,7 @@ void CActor::Render(const CStateManager& mgr) const {
   if (x64_modelData && !x64_modelData->IsNull()) {
     bool renderPrePostParticles = xe6_29_renderParticleDBInside && x64_modelData && x64_modelData->HasAnimData();
     if (renderPrePostParticles)
-      x64_modelData->AnimationData()->GetParticleDB().RenderSystemsToBeDrawnFirst();
+      x64_modelData->GetAnimationData()->GetParticleDB().RenderSystemsToBeDrawnFirst();
 
     if (xe7_27_enableRender) {
       if (xe5_31_pointGeneratorParticles)
@@ -274,7 +274,7 @@ void CActor::Render(const CStateManager& mgr) const {
     }
 
     if (renderPrePostParticles)
-      x64_modelData->AnimationData()->GetParticleDB().RenderSystemsToBeDrawnLast();
+      x64_modelData->GetAnimationData()->GetParticleDB().RenderSystemsToBeDrawnLast();
   }
   DrawTouchBounds();
 }
@@ -289,7 +289,7 @@ bool CActor::CanRenderUnsorted(const CStateManager& mgr) const {
 }
 
 void CActor::CalculateRenderBounds() {
-  if (x64_modelData && (x64_modelData->AnimationData() || x64_modelData->GetNormalModel()))
+  if (x64_modelData && (x64_modelData->GetAnimationData() || x64_modelData->GetNormalModel()))
     x9c_renderBounds = x64_modelData->GetBounds(x34_transform);
   else
     x9c_renderBounds = zeus::CAABox(x34_transform.origin, x34_transform.origin);
@@ -636,7 +636,7 @@ SAdvancementDeltas CActor::UpdateAnimation(float dt, CStateManager& mgr, bool ad
       if (poi.GetCharacterIndex() != -1 &&
           x64_modelData->GetAnimationData()->GetCharacterIndex() != poi.GetCharacterIndex())
         continue;
-      x64_modelData->AnimationData()->GetParticleDB().SetParticleEffectState(poi.GetString(), true, mgr);
+      x64_modelData->GetAnimationData()->GetParticleDB().SetParticleEffectState(poi.GetString(), true, mgr);
     }
   }
   return deltas;

--- a/Runtime/World/CActor.hpp
+++ b/Runtime/World/CActor.hpp
@@ -166,7 +166,7 @@ public:
   float GetPitch() const;
   float GetYaw() const;
   const CModelData* GetModelData() const { return x64_modelData.get(); }
-  CModelData* ModelData() { return x64_modelData.get(); }
+  CModelData* GetModelData() { return x64_modelData.get(); }
   void EnsureRendered(const CStateManager&) const;
   void EnsureRendered(const CStateManager&, const zeus::CVector3f&, const zeus::CAABox&) const;
   void ProcessSoundEvent(u32 sfxId, float weight, u32 flags, float falloff, float maxDist, float minVol, float maxVol,
@@ -175,7 +175,7 @@ public:
   SAdvancementDeltas UpdateAnimation(float, CStateManager&, bool);
   void SetActorLights(std::unique_ptr<CActorLights>&& lights);
   const CActorLights* GetActorLights() const { return x90_actorLights.get(); }
-  CActorLights* ActorLights() { return x90_actorLights.get(); }
+  CActorLights* GetActorLights() { return x90_actorLights.get(); }
   bool CanDrawStatic() const;
   bool IsDrawEnabled() const { return xe7_29_drawEnabled; }
   void SetWorldLightingDirty(bool b) { xe7_28_worldLightingDirty = b; }

--- a/Runtime/World/CActorModelParticles.cpp
+++ b/Runtime/World/CActorModelParticles.cpp
@@ -309,8 +309,8 @@ bool CActorModelParticles::CItem::UpdateIcePop(float dt, CActor* actor, CStateMa
 
 bool CActorModelParticles::CItem::Update(float dt, CStateManager& mgr) {
   CActor* act = static_cast<CActor*>(mgr.ObjectById(x0_id));
-  if (act && act->HasModelData() && !act->ModelData()->IsNull()) {
-    xec_particleOffsetScale = act->ModelData()->GetScale();
+  if (act && act->HasModelData() && !act->GetModelData()->IsNull()) {
+    xec_particleOffsetScale = act->GetModelData()->GetScale();
     xf8_iceXf = act->GetTransform();
     x4_areaId = act->GetAreaIdAlways();
   } else {

--- a/Runtime/World/CAmbientAI.cpp
+++ b/Runtime/World/CAmbientAI.cpp
@@ -18,7 +18,7 @@ CAmbientAI::CAmbientAI(TUniqueId uid, std::string_view name, const CEntityInfo& 
 , x2dc_defaultAnim(GetModelData()->GetAnimationData()->GetDefaultAnimation())
 , x2e0_alertAnim(alertAnim)
 , x2e4_impactAnim(impactAnim) {
-  ModelData()->AnimationData()->EnableLooping(true);
+  GetModelData()->GetAnimationData()->EnableLooping(true);
 }
 
 void CAmbientAI::Accept(IVisitor& visitor) { visitor.Visit(this); }
@@ -51,8 +51,8 @@ void CAmbientAI::Think(float dt, CStateManager& mgr) {
   case EAnimationState::Ready: {
     if (inAlertRange) {
       x2d0_animState = EAnimationState::Alert;
-      ModelData()->AnimationData()->SetAnimation(CAnimPlaybackParms(x2e0_alertAnim, -1, 1.f, true), false);
-      ModelData()->EnableLooping(true);
+      GetModelData()->GetAnimationData()->SetAnimation(CAnimPlaybackParms(x2e0_alertAnim, -1, 1.f, true), false);
+      GetModelData()->EnableLooping(true);
       RandomizePlaybackRate(mgr);
     }
     break;
@@ -60,8 +60,8 @@ void CAmbientAI::Think(float dt, CStateManager& mgr) {
   case EAnimationState::Alert: {
     if (!inAlertRange) {
       x2d0_animState = EAnimationState::Ready;
-      ModelData()->AnimationData()->SetAnimation(CAnimPlaybackParms(x2dc_defaultAnim, -1, 1.f, true), false);
-      ModelData()->EnableLooping(true);
+      GetModelData()->GetAnimationData()->SetAnimation(CAnimPlaybackParms(x2dc_defaultAnim, -1, 1.f, true), false);
+      GetModelData()->EnableLooping(true);
       RandomizePlaybackRate(mgr);
     } else if (inImpactRange) {
       SendScriptMsgs(EScriptObjectState::Dead, mgr, EScriptObjectMessage::None);
@@ -72,8 +72,8 @@ void CAmbientAI::Think(float dt, CStateManager& mgr) {
   case EAnimationState::Impact: {
     if (!x2e8_25_animating) {
       x2d0_animState = EAnimationState::Ready;
-      ModelData()->AnimationData()->SetAnimation(CAnimPlaybackParms(x2dc_defaultAnim, -1, 1.f, true), false);
-      ModelData()->EnableLooping(true);
+      GetModelData()->GetAnimationData()->SetAnimation(CAnimPlaybackParms(x2dc_defaultAnim, -1, 1.f, true), false);
+      GetModelData()->EnableLooping(true);
       RandomizePlaybackRate(mgr);
     }
     break;
@@ -97,8 +97,8 @@ void CAmbientAI::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CState
     if (!GetActive())
       SetActive(true);
     x2d0_animState = EAnimationState::Ready;
-    ModelData()->AnimationData()->SetAnimation(CAnimPlaybackParms(x2dc_defaultAnim, -1, 1.f, true), false);
-    ModelData()->AnimationData()->EnableLooping(true);
+    GetModelData()->GetAnimationData()->SetAnimation(CAnimPlaybackParms(x2dc_defaultAnim, -1, 1.f, true), false);
+    GetModelData()->GetAnimationData()->EnableLooping(true);
     RandomizePlaybackRate(mgr);
     x2e8_24_dead = false;
     x260_healthInfo = x258_initialHealthInfo;
@@ -107,8 +107,8 @@ void CAmbientAI::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CState
   case EScriptObjectMessage::Damage: {
     if (GetActive()) {
       x2d0_animState = EAnimationState::Impact;
-      ModelData()->AnimationData()->SetAnimation(CAnimPlaybackParms(x2e4_impactAnim, -1, 1.f, true), false);
-      ModelData()->AnimationData()->EnableLooping(false);
+      GetModelData()->GetAnimationData()->SetAnimation(CAnimPlaybackParms(x2e4_impactAnim, -1, 1.f, true), false);
+      GetModelData()->GetAnimationData()->EnableLooping(false);
       RandomizePlaybackRate(mgr);
     }
     break;
@@ -129,7 +129,7 @@ std::optional<zeus::CAABox> CAmbientAI::GetTouchBounds() const {
 }
 
 void CAmbientAI::RandomizePlaybackRate(CStateManager& mgr) {
-  ModelData()->AnimationData()->MultiplyPlaybackRate(0.4f * mgr.GetActiveRandom()->Float() + 0.8f);
+  GetModelData()->GetAnimationData()->MultiplyPlaybackRate(0.4f * mgr.GetActiveRandom()->Float() + 0.8f);
 }
 
 } // namespace urde

--- a/Runtime/World/CFishCloud.cpp
+++ b/Runtime/World/CFishCloud.cpp
@@ -433,7 +433,7 @@ void CFishCloud::Think(float dt, CStateManager& mgr) {
     }
     if (x250_27_validModel) {
       for (auto& m : x1b0_models) {
-        m->AnimationData()->SetPlaybackRate(1.f);
+        m->GetAnimationData()->SetPlaybackRate(1.f);
         m->AdvanceAnimation(dt, mgr, x4_areaId, true);
       }
     }
@@ -449,7 +449,7 @@ void CFishCloud::AllocateSkinnedModels(CStateManager& mgr, CModelData::EWhichMod
   for (auto& m : x1b0_models) {
     m->EnableLooping(true);
     m->AdvanceAnimation(
-      m->AnimationData()->GetAnimTimeRemaining("Whole Body"sv) * 0.25f * idx, mgr, x4_areaId, true);
+      m->GetAnimationData()->GetAnimTimeRemaining("Whole Body"sv) * 0.25f * idx, mgr, x4_areaId, true);
     ++idx;
   }
   x230_whichModel = which;
@@ -487,7 +487,7 @@ void CFishCloud::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   CActor::PreRender(mgr, frustum);
   if (x250_27_validModel) {
     for (auto& m : x1b0_models) {
-      m->AnimationData()->PreRender();
+      m->GetAnimationData()->PreRender();
     }
   }
   xe4_30_outOfFrustum = false;
@@ -508,7 +508,7 @@ void CFishCloud::RenderBoid(int idx, const CBoid& boid, u32& drawMask,
   u32 thisDrawMask = 1u << modelIndex;
   if (drawMask & thisDrawMask) {
     drawMask &= ~thisDrawMask;
-    mData.AnimationData()->BuildPose();
+    mData.GetAnimationData()->BuildPose();
   }
   model.GetModelInst()->SetAmbientColor(zeus::skWhite);
   CGraphics::SetModelMatrix(zeus::lookAt(boid.x0_pos, boid.x0_pos + boid.xc_vel));
@@ -516,7 +516,7 @@ void CFishCloud::RenderBoid(int idx, const CBoid& boid, u32& drawMask,
     CModelFlags thermFlags(0, 0, 3, zeus::skWhite);
     mData.RenderThermal(zeus::skWhite, zeus::CColor(0.f, 0.25f), thermFlags);
   } else {
-    mData.AnimationData()->Render(model, flags, {}, nullptr);
+    mData.GetAnimationData()->Render(model, flags, {}, nullptr);
   }
 }
 

--- a/Runtime/World/CGameArea.cpp
+++ b/Runtime/World/CGameArea.cpp
@@ -860,7 +860,7 @@ void CGameArea::Validate(CStateManager& mgr) {
 
   PostConstructArea();
   if (x4_selfIdx != kInvalidAreaId)
-    mgr.WorldNC()->MoveAreaToAliveChain(x4_selfIdx);
+    mgr.GetWorld()->MoveAreaToAliveChain(x4_selfIdx);
 
   LoadScriptObjects(mgr);
 
@@ -882,7 +882,7 @@ void CGameArea::Validate(CStateManager& mgr) {
 }
 
 void CGameArea::LoadScriptObjects(CStateManager& mgr) {
-  CWorldLayerState& layerState = *mgr.LayerState();
+  CWorldLayerState& layerState = *mgr.WorldLayerState();
   u32 layerCount = layerState.GetAreaLayerCount(x4_selfIdx);
   std::vector<TEditorId> objIds;
   for (u32 i = 0; i < layerCount; ++i) {
@@ -1113,7 +1113,7 @@ void CGameArea::VerifyTokenList(CStateManager& stateMgr) {
   auto end = xac_deps2.end();
   for (int lidx = int(xbc_layerDepOffsets.size() - 1); lidx >= 0; --lidx) {
     auto begin = xac_deps2.begin() + xbc_layerDepOffsets[lidx];
-    if (stateMgr.LayerState()->IsLayerActive(x4_selfIdx, lidx)) {
+    if (stateMgr.WorldLayerState()->IsLayerActive(x4_selfIdx, lidx)) {
       for (auto it = begin; it != end; ++it) {
         xdc_tokens.push_back(g_SimplePool->GetObj(*it));
         xdc_tokens.back().Lock();

--- a/Runtime/World/CGameArea.hpp
+++ b/Runtime/World/CGameArea.hpp
@@ -288,7 +288,7 @@ public:
 
   CAssetId GetAreaAssetId() const { return x84_mrea; }
   const CAreaFog* GetAreaFog() const { return GetPostConstructed()->x10c4_areaFog.get(); }
-  CAreaFog* AreaFog() { return const_cast<CAreaFog*>(GetAreaFog()); }
+  CAreaFog* GetAreaFog() { return const_cast<CAreaFog*>(GetAreaFog()); }
   float GetXRayFogDistance() const;
   EEnvFxType DoesAreaNeedEnvFx() const;
   bool DoesAreaNeedSkyNow() const;
@@ -338,8 +338,8 @@ public:
 
   const std::vector<Dock>& GetDocks() const { return xcc_docks; }
   const Dock* GetDock(s32 dock) const { return &xcc_docks[dock]; }
+  Dock* GetDock(s32 dock) { return &xcc_docks[dock]; }
   s32 GetDockCount() const { return xcc_docks.size(); }
-  Dock* DockNC(s32 dock) { return &xcc_docks[dock]; }
 
   bool IsPostConstructed() const { return xf0_24_postConstructed; }
   const CPostConstructed* GetPostConstructed() const {

--- a/Runtime/World/CKnockBackController.cpp
+++ b/Runtime/World/CKnockBackController.cpp
@@ -396,7 +396,7 @@ bool CKnockBackController::TickDeferredTimer(float dt) {
 }
 
 EKnockBackCharacterState CKnockBackController::GetKnockBackCharacterState(CPatterned& parent) {
-  if (parent.BodyController()->IsFrozen())
+  if (parent.GetBodyController()->IsFrozen())
     return parent.IsAlive() ? EKnockBackCharacterState::FrozenAlive : EKnockBackCharacterState::FrozenDead;
   return parent.IsAlive() ? EKnockBackCharacterState::Alive : EKnockBackCharacterState::Dead;
 }
@@ -409,23 +409,23 @@ void CKnockBackController::ValidateState(CPatterned& parent) {
 
   EKnockBackAnimationState useState = EKnockBackAnimationState::Invalid;
   if (parent.IsAlive()) {
-    if (parent.BodyController()->HasBodyState(pas::EAnimationState::Hurled) && x80_availableStates.test(3) &&
+    if (parent.GetBodyController()->HasBodyState(pas::EAnimationState::Hurled) && x80_availableStates.test(3) &&
         x4_activeParms.x0_animState >= EKnockBackAnimationState::Hurled) {
       useState = EKnockBackAnimationState::Hurled;
-    } else if (parent.BodyController()->HasBodyState(pas::EAnimationState::KnockBack) && x80_availableStates.test(2) &&
+    } else if (parent.GetBodyController()->HasBodyState(pas::EAnimationState::KnockBack) && x80_availableStates.test(2) &&
                x4_activeParms.x0_animState >= EKnockBackAnimationState::KnockBack) {
       useState = EKnockBackAnimationState::KnockBack;
-    } else if (parent.BodyController()->HasBodyState(pas::EAnimationState::AdditiveFlinch) &&
+    } else if (parent.GetBodyController()->HasBodyState(pas::EAnimationState::AdditiveFlinch) &&
                x80_availableStates.test(1) && x4_activeParms.x0_animState >= EKnockBackAnimationState::Flinch) {
       useState = EKnockBackAnimationState::Flinch;
     }
   } else {
-    if (parent.BodyController()->HasBodyState(pas::EAnimationState::Fall) && x80_availableStates.test(4) &&
+    if (parent.GetBodyController()->HasBodyState(pas::EAnimationState::Fall) && x80_availableStates.test(4) &&
         (x4_activeParms.x0_animState >= EKnockBackAnimationState::Fall ||
-         (!parent.BodyController()->HasBodyState(pas::EAnimationState::Hurled) &&
+         (!parent.GetBodyController()->HasBodyState(pas::EAnimationState::Hurled) &&
           x4_activeParms.x0_animState >= EKnockBackAnimationState::Hurled))) {
       useState = EKnockBackAnimationState::Fall;
-    } else if (parent.BodyController()->HasBodyState(pas::EAnimationState::Hurled) && x80_availableStates.test(3) &&
+    } else if (parent.GetBodyController()->HasBodyState(pas::EAnimationState::Hurled) && x80_availableStates.test(3) &&
                x4_activeParms.x0_animState >= EKnockBackAnimationState::Hurled) {
       useState = EKnockBackAnimationState::Hurled;
     }
@@ -483,26 +483,26 @@ void CKnockBackController::DoKnockBackAnimation(const zeus::CVector3f& backVec, 
     hurlVel = std::sqrt(parent.GetGravityConstant() * 0.5f * hurlVel);
     zeus::CVector3f backUpVec = backVec + backVec.magnitude() * zeus::skUp;
     if (backUpVec.canBeNormalized()) {
-      parent.BodyController()->GetCommandMgr().DeliverCmd(CBCHurledCmd(-backVec, backUpVec.normalized() * hurlVel));
+      parent.GetBodyController()->GetCommandMgr().DeliverCmd(CBCHurledCmd(-backVec, backUpVec.normalized() * hurlVel));
       parent.SetMomentumWR({0.f, 0.f, parent.GetGravityConstant() * -parent.GetMass()});
     }
     break;
   }
   case EKnockBackAnimationState::Fall: {
-    parent.BodyController()->GetCommandMgr().DeliverCmd(CBCKnockDownCmd(-backVec, x7c_severity));
+    parent.GetBodyController()->GetCommandMgr().DeliverCmd(CBCKnockDownCmd(-backVec, x7c_severity));
     break;
   }
   case EKnockBackAnimationState::KnockBack: {
-    parent.BodyController()->GetCommandMgr().DeliverCmd(CBCKnockBackCmd(-backVec, x7c_severity));
+    parent.GetBodyController()->GetCommandMgr().DeliverCmd(CBCKnockBackCmd(-backVec, x7c_severity));
     break;
   }
   case EKnockBackAnimationState::Flinch: {
     std::pair<float, s32> bestAnim =
-        parent.BodyController()->GetPASDatabase().FindBestAnimation(CPASAnimParmData(23), *mgr.GetActiveRandom(), -1);
+        parent.GetBodyController()->GetPASDatabase().FindBestAnimation(CPASAnimParmData(23), *mgr.GetActiveRandom(), -1);
     if (bestAnim.first > 0.f) {
-      parent.ModelData()->AnimationData()->AddAdditiveAnimation(bestAnim.second, 1.f, false, true);
+      parent.GetModelData()->GetAnimationData()->AddAdditiveAnimation(bestAnim.second, 1.f, false, true);
       x64_flinchRemTime =
-          std::max(parent.ModelData()->AnimationData()->GetAnimationDuration(bestAnim.second), x64_flinchRemTime);
+          std::max(parent.GetModelData()->GetAnimationData()->GetAnimationDuration(bestAnim.second), x64_flinchRemTime);
     }
     break;
   }
@@ -562,8 +562,8 @@ void CKnockBackController::Update(float dt, CStateManager& mgr, CPatterned& pare
   x64_flinchRemTime -= dt;
   if (TickDeferredTimer(dt))
     DoDeferredKnockBack(mgr, parent);
-  if (x82_26_locomotionDuringElectrocution && parent.BodyController()->IsElectrocuting())
-    parent.BodyController()->GetCommandMgr().DeliverCmd(CBodyStateCmd(EBodyStateCmd::Locomotion));
+  if (x82_26_locomotionDuringElectrocution && parent.GetBodyController()->IsElectrocuting())
+    parent.GetBodyController()->GetCommandMgr().DeliverCmd(CBodyStateCmd(EBodyStateCmd::Locomotion));
 }
 
 EKnockBackWeaponType CKnockBackController::GetKnockBackWeaponType(const CDamageInfo& info, EWeaponType wType,

--- a/Runtime/World/CMorphBall.cpp
+++ b/Runtime/World/CMorphBall.cpp
@@ -985,7 +985,7 @@ void CMorphBall::EnterMorphBallState(CStateManager& mgr) {
   UpdateEffects(0.f, mgr);
   x187c_spiderBallState = ESpiderBallState::Inactive;
   CAnimPlaybackParms parms(0, -1, 1.f, true);
-  x58_ballModel->AnimationData()->SetAnimation(parms, false);
+  x58_ballModel->GetAnimationData()->SetAnimation(parms, false);
   x1e20_ballAnimIdx = 0;
   StopEffects();
   x1c30_boostOverLightFactor = 0.f;
@@ -1140,7 +1140,7 @@ void CMorphBall::ComputeBoostBallMovement(const CFinalInput& input, CStateManage
         x187c_spiderBallState != ESpiderBallState::Active) {
       if (x1e20_ballAnimIdx == 0) {
         CAnimPlaybackParms parms(1, -1, 1.f, true);
-        x58_ballModel->AnimationData()->SetAnimation(parms, false);
+        x58_ballModel->GetAnimationData()->SetAnimation(parms, false);
         x1e20_ballAnimIdx = 1;
         x1e24_boostSfxHandle = CSfxManager::SfxStart(SFXsam_ball_charge_lp, 1.f, 0.f, true, 0x7f, true, kInvalidAreaId);
       }
@@ -1150,7 +1150,7 @@ void CMorphBall::ComputeBoostBallMovement(const CFinalInput& input, CStateManage
     } else {
       if (x1e20_ballAnimIdx == 1) {
         CAnimPlaybackParms parms(0, -1, 1.f, true);
-        x58_ballModel->AnimationData()->SetAnimation(parms, false);
+        x58_ballModel->GetAnimationData()->SetAnimation(parms, false);
         x1e20_ballAnimIdx = 0;
         CSfxManager::RemoveEmitter(x1e24_boostSfxHandle);
         if (x1de8_boostChargeTime >= g_tweakBall->GetBoostBallMinChargeTime()) {
@@ -1251,7 +1251,7 @@ void CMorphBall::CancelBoosting() {
   x1df4_boostDrainTime = 0.f;
   if (x1e20_ballAnimIdx == 1) {
     CAnimPlaybackParms parms(0, -1, 1.f, true);
-    x58_ballModel->AnimationData()->SetAnimation(parms, false);
+    x58_ballModel->GetAnimationData()->SetAnimation(parms, false);
     x1e20_ballAnimIdx = 0;
     CSfxManager::SfxStop(x1e24_boostSfxHandle);
   }
@@ -1350,9 +1350,9 @@ void CMorphBall::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   if (x1c34_boostLightFactor == 1.f)
     return;
 
-  x0_player.ActorLights()->SetFindShadowLight(x1e44_damageEffect < 0.25f);
-  x0_player.ActorLights()->SetShadowDynamicRangeThreshold(0.05f);
-  x0_player.ActorLights()->SetDirty();
+  x0_player.GetActorLights()->SetFindShadowLight(x1e44_damageEffect < 0.25f);
+  x0_player.GetActorLights()->SetShadowDynamicRangeThreshold(0.05f);
+  x0_player.GetActorLights()->SetDirty();
 
   CCollidableSphere sphere = x38_collisionSphere;
   sphere.SetSphereCenter(zeus::skZero3f);
@@ -1361,11 +1361,11 @@ void CMorphBall::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   if (x0_player.GetAreaIdAlways() != kInvalidAreaId) {
     const CGameArea* area = mgr.GetWorld()->GetAreaAlways(x0_player.GetAreaIdAlways());
     if (area->IsPostConstructed())
-      x0_player.ActorLights()->BuildAreaLightList(mgr, *area, ballAABB);
+      x0_player.GetActorLights()->BuildAreaLightList(mgr, *area, ballAABB);
   }
 
-  x0_player.ActorLights()->BuildDynamicLightList(mgr, ballAABB);
-  if (x0_player.ActorLights()->HasShadowLight()) {
+  x0_player.GetActorLights()->BuildDynamicLightList(mgr, ballAABB);
+  if (x0_player.GetActorLights()->HasShadowLight()) {
     CCollidableSphere sphere = x38_collisionSphere;
     sphere.SetSphereCenter(zeus::skZero3f);
     x1c14_worldShadow->BuildLightShadowTexture(mgr, x0_player.GetAreaIdAlways(),
@@ -1375,17 +1375,17 @@ void CMorphBall::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
     x1c14_worldShadow->ResetBlur();
   }
 
-  zeus::CColor ambColor = x0_player.ActorLights()->GetAmbientColor();
+  zeus::CColor ambColor = x0_player.GetActorLights()->GetAmbientColor();
   ambColor.a() = 1.f;
-  x0_player.ActorLights()->SetAmbientColor(zeus::CColor::lerp(ambColor, zeus::skWhite, x1c34_boostLightFactor));
+  x0_player.GetActorLights()->SetAmbientColor(zeus::CColor::lerp(ambColor, zeus::skWhite, x1c34_boostLightFactor));
   *x1c18_actorLights = *x0_player.GetActorLights();
 
-  ambColor = x0_player.ActorLights()->GetAmbientColor();
+  ambColor = x0_player.GetActorLights()->GetAmbientColor();
   ambColor.a() = 1.f;
   x1c18_actorLights->SetAmbientColor(
       zeus::CColor::lerp(ambColor, zeus::skWhite, std::max(x1c38_spiderLightFactor, x1c34_boostLightFactor)));
 
-  if (CAnimData* animData = x58_ballModel->AnimationData())
+  if (CAnimData* animData = x58_ballModel->GetAnimationData())
     animData->PreRender();
 }
 

--- a/Runtime/World/CPatterned.cpp
+++ b/Runtime/World/CPatterned.cpp
@@ -1162,7 +1162,7 @@ void CPatterned::UpdateAlphaDelta(float dt, CStateManager& mgr) {
   }
   x94_simpleShadow->SetUserAlpha(alpha);
   SetModelAlpha(alpha);
-  x64_modelData->AnimationData()->GetParticleDB().SetModulationColorAllActiveEffects(zeus::CColor(1.f, alpha));
+  x64_modelData->GetAnimationData()->GetParticleDB().SetModulationColorAllActiveEffects(zeus::CColor(1.f, alpha));
 }
 
 float CPatterned::CalcDyingThinkRate() const {
@@ -1566,7 +1566,7 @@ void CPatterned::AddToRenderer(const zeus::CFrustum& frustum, const CStateManage
     if (x64_modelData && !x64_modelData->IsNull()) {
       int mask, target;
       mgr.GetCharacterRenderMaskAndTarget(x402_31_thawed, mask, target);
-      if (CAnimData* aData = x64_modelData->AnimationData())
+      if (CAnimData* aData = x64_modelData->GetAnimationData())
         aData->GetParticleDB().AddToRendererClippedMasked(frustum, mask, target);
     }
   }
@@ -1576,7 +1576,7 @@ void CPatterned::AddToRenderer(const zeus::CFrustum& frustum, const CStateManage
 void CPatterned::RenderIceModelWithFlags(const CModelFlags& flags) const {
   CModelFlags useFlags = flags;
   useFlags.x1_matSetIdx = 0;
-  CAnimData* animData = x64_modelData->AnimationData();
+  CAnimData* animData = x64_modelData->GetAnimationData();
   if (CMorphableSkinnedModel* iceModel = animData->IceModel().GetObj())
     animData->Render(*iceModel, useFlags, {*x510_vertexMorph}, iceModel->GetMorphMagnitudes());
 }
@@ -1690,7 +1690,7 @@ void CPatterned::PhazeOut(CStateManager& mgr) {
     SendScriptMsgs(EScriptObjectState::DeathRattle, mgr, EScriptObjectMessage::None);
   x401_27_phazingOut = true;
   x450_bodyController->SetPlaybackRate(0.f);
-  x64_modelData->AnimationData()->GetParticleDB().SetUpdatesEnabled(false);
+  x64_modelData->GetAnimationData()->GetParticleDB().SetUpdatesEnabled(false);
 }
 
 bool CPatterned::ApplyBoneTracking() const {

--- a/Runtime/World/CPatterned.hpp
+++ b/Runtime/World/CPatterned.hpp
@@ -361,7 +361,7 @@ public:
 
   void BuildBodyController(EBodyType);
   const CBodyController* GetBodyController() const { return x450_bodyController.get(); }
-  CBodyController* BodyController() { return x450_bodyController.get(); }
+  CBodyController* GetBodyController() { return x450_bodyController.get(); }
   const CKnockBackController& GetKnockBackController() const { return x460_knockBackController; }
   void SetupPlayerCollision(bool);
   void LaunchProjectile(const zeus::CTransform& gunXf, CStateManager& mgr, int maxAllowed, EProjectileAttrib attrib,

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -124,7 +124,7 @@ CPlayer::CPlayer(TUniqueId uid, const zeus::CTransform& xf, const zeus::CAABox& 
 
 void CPlayer::InitializeBallTransition() {
   if (x64_modelData && x64_modelData->HasAnimData())
-    x64_modelData->AnimationData()->SetAnimation(CAnimPlaybackParms(2, -1, 1.f, true), false);
+    x64_modelData->GetAnimationData()->SetAnimation(CAnimPlaybackParms(2, -1, 1.f, true), false);
 }
 
 bool CPlayer::IsTransparent() const { return x588_alpha < 1.f; }
@@ -173,8 +173,8 @@ void CPlayer::TransitionToMorphBallState(float dt, CStateManager& mgr) {
   x58c_transitionVel = x138_velocity.magnitude();
   if (x64_modelData && x64_modelData->HasAnimData()) {
     CAnimPlaybackParms parms(x584_ballTransitionAnim, -1, 1.f, true);
-    x64_modelData->AnimationData()->SetAnimation(parms, false);
-    x64_modelData->AnimationData()->SetAnimDir(CAnimData::EAnimDir::Forward);
+    x64_modelData->GetAnimationData()->SetAnimation(parms, false);
+    x64_modelData->GetAnimationData()->SetAnimDir(CAnimData::EAnimDir::Forward);
   }
   x64_modelData->EnableLooping(false);
   x64_modelData->Touch(mgr, 0);
@@ -224,8 +224,8 @@ void CPlayer::TransitionFromMorphBallState(CStateManager& mgr) {
 
   if (x64_modelData && x64_modelData->HasAnimData()) {
     CAnimPlaybackParms parms(x584_ballTransitionAnim, -1, 1.f, true);
-    x64_modelData->AnimationData()->SetAnimation(parms, false);
-    x64_modelData->AnimationData()->SetAnimDir(CAnimData::EAnimDir::Forward);
+    x64_modelData->GetAnimationData()->SetAnimation(parms, false);
+    x64_modelData->GetAnimationData()->SetAnimDir(CAnimData::EAnimDir::Forward);
   }
 
   x64_modelData->EnableLooping(false);
@@ -346,8 +346,8 @@ void CPlayer::UpdateMorphBallTransition(float dt, CStateManager& mgr) {
         x584_ballTransitionAnim = GetNextBallTransitionAnim(dt, loop, mgr);
         if (x64_modelData && x64_modelData->HasAnimData()) {
           CAnimPlaybackParms parms(x584_ballTransitionAnim, -1, 1.f, true);
-          x64_modelData->AnimationData()->SetAnimation(parms, false);
-          x64_modelData->AnimationData()->EnableLooping(loop);
+          x64_modelData->GetAnimationData()->SetAnimation(parms, false);
+          x64_modelData->GetAnimationData()->EnableLooping(loop);
         }
       }
     } else if (x584_ballTransitionAnim != 5 && x584_ballTransitionAnim != 7)
@@ -361,8 +361,8 @@ void CPlayer::UpdateMorphBallTransition(float dt, CStateManager& mgr) {
             x584_ballTransitionAnim != 7) {
           x584_ballTransitionAnim = nextAnim;
           CAnimPlaybackParms parms(x584_ballTransitionAnim, -1, 1.f, true);
-          x64_modelData->AnimationData()->SetAnimation(parms, false);
-          x64_modelData->AnimationData()->EnableLooping(loop);
+          x64_modelData->GetAnimationData()->SetAnimation(parms, false);
+          x64_modelData->GetAnimationData()->EnableLooping(loop);
           x58c_transitionVel = velMag;
         }
       }
@@ -1317,7 +1317,7 @@ void CPlayer::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   }
 
   for (auto& model : x730_transitionModels)
-    model->AnimationData()->PreRender();
+    model->GetAnimationData()->PreRender();
 
   if (x2f4_cameraState != EPlayerCameraState::FirstPerson)
     CActor::PreRender(mgr, frustum);
@@ -5323,10 +5323,10 @@ void CPlayer::SetHudDisable(float staticTimer, float outSpeed, float inSpeed) {
 
 void CPlayer::SetIntoBallReadyAnimation(CStateManager& mgr) {
   CAnimPlaybackParms parms(2, -1, 1.f, true);
-  x64_modelData->AnimationData()->SetAnimation(parms, false);
-  x64_modelData->AnimationData()->EnableLooping(false);
+  x64_modelData->GetAnimationData()->SetAnimation(parms, false);
+  x64_modelData->GetAnimationData()->EnableLooping(false);
   x64_modelData->AdvanceAnimation(0.f, mgr, kInvalidAreaId, true);
-  x64_modelData->AnimationData()->EnableAnimation(false);
+  x64_modelData->GetAnimationData()->EnableAnimation(false);
 }
 
 void CPlayer::LeaveMorphBallState(CStateManager& mgr) {

--- a/Runtime/World/CScriptActorKeyframe.cpp
+++ b/Runtime/World/CScriptActorKeyframe.cpp
@@ -68,7 +68,7 @@ void CScriptActorKeyframe::Think(float dt, CStateManager& mgr) {
     CEntity* ent = mgr.ObjectById(mgr.GetIdForScript(conn.x8_objId));
     if (TCastToPtr<CScriptActor> act = ent) {
       if (act->HasModelData() && act->GetModelData()->HasAnimData()) {
-        CAnimData* animData = act->ModelData()->AnimationData();
+        CAnimData* animData = act->GetModelData()->GetAnimationData();
         if (animData->IsAdditiveAnimation(x34_animationId))
           animData->DelAdditiveAnimation(x34_animationId);
 
@@ -76,12 +76,12 @@ void CScriptActorKeyframe::Think(float dt, CStateManager& mgr) {
           animData->EnableLooping(false);
       }
     } else if (TCastToPtr<CPatterned> ai = ent) {
-      CAnimData* animData = ai->ModelData()->AnimationData();
+      CAnimData* animData = ai->GetModelData()->GetAnimationData();
       if (animData->IsAdditiveAnimation(x34_animationId)) {
         animData->DelAdditiveAnimation(x34_animationId);
       } else if (ai->GetBodyController()->GetCurrentStateId() == pas::EAnimationState::Scripted &&
                  animData->GetDefaultAnimation() == x34_animationId) {
-        ai->BodyController()->GetCommandMgr().DeliverCmd(CBodyStateCmd(EBodyStateCmd::ExitState));
+        ai->GetBodyController()->GetCommandMgr().DeliverCmd(CBodyStateCmd(EBodyStateCmd::ExitState));
       }
     }
   }
@@ -102,21 +102,21 @@ void CScriptActorKeyframe::UpdateEntity(TUniqueId uid, CStateManager& mgr) {
       mgr.SendScriptMsg(act, GetUniqueId(), EScriptObjectMessage::Activate);
     act->SetDrawFlags({0, 0, 3, zeus::skWhite});
     if (act->HasModelData() && act->GetModelData()->HasAnimData()) {
-      CAnimData* animData = act->ModelData()->AnimationData();
+      CAnimData* animData = act->GetModelData()->GetAnimationData();
       if (animData->IsAdditiveAnimation(x34_animationId)) {
         animData->AddAdditiveAnimation(x34_animationId, 1.f, x44_24_looping, x44_26_fadeOut);
       } else {
         animData->SetAnimation(CAnimPlaybackParms(x34_animationId, -1, 1.f, true), false);
-        act->ModelData()->EnableLooping(x44_24_looping);
+        act->GetModelData()->EnableLooping(x44_24_looping);
         animData->MultiplyPlaybackRate(x3c_playbackRate);
       }
     }
   } else if (TCastToPtr<CPatterned> ai = ent) {
-    CAnimData* animData = ai->ModelData()->AnimationData();
+    CAnimData* animData = ai->GetModelData()->GetAnimationData();
     if (animData->IsAdditiveAnimation(x34_animationId)) {
       animData->AddAdditiveAnimation(x34_animationId, 1.f, x44_24_looping, x44_26_fadeOut);
     } else {
-      ai->BodyController()->GetCommandMgr().DeliverCmd(
+      ai->GetBodyController()->GetCommandMgr().DeliverCmd(
           CBCScriptedCmd(x34_animationId, x44_24_looping, x44_27_timedLoop, x38_initialLifetime));
     }
   }

--- a/Runtime/World/CScriptAreaAttributes.cpp
+++ b/Runtime/World/CScriptAreaAttributes.cpp
@@ -27,11 +27,11 @@ void CScriptAreaAttributes::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId 
     return;
 
   if (msg == EScriptObjectMessage::InitializedInArea) {
-    CGameArea* area = stateMgr.WorldNC()->GetArea(x4_areaId);
+    CGameArea* area = stateMgr.GetWorld()->GetArea(x4_areaId);
     area->SetAreaAttributes(this);
     stateMgr.GetEnvFxManager()->SetFxDensity(500, x3c_envFxDensity);
   } else if (msg == EScriptObjectMessage::Deleted) {
-    CGameArea* area = stateMgr.WorldNC()->GetArea(x4_areaId);
+    CGameArea* area = stateMgr.GetWorld()->GetArea(x4_areaId);
 
     if (!area->IsPostConstructed())
       return;

--- a/Runtime/World/CScriptDistanceFog.cpp
+++ b/Runtime/World/CScriptDistanceFog.cpp
@@ -38,7 +38,7 @@ void CScriptDistanceFog::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId obj
   if (msg == EScriptObjectMessage::InitializedInArea) {
     if (!x60_explicit)
       return;
-    CGameArea::CAreaFog* fog = stateMgr.WorldNC()->GetArea(x4_areaId)->AreaFog();
+    CGameArea::CAreaFog* fog = stateMgr.GetWorld()->GetArea(x4_areaId)->GetAreaFog();
     if (x34_mode == ERglFogMode::None)
       fog->DisableFog();
     else
@@ -47,18 +47,18 @@ void CScriptDistanceFog::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId obj
     if (!x61_nonZero)
       return;
 
-    CGameArea::CAreaFog* fog = stateMgr.WorldNC()->GetArea(x4_areaId)->AreaFog();
+    CGameArea::CAreaFog* fog = stateMgr.GetWorld()->GetArea(x4_areaId)->GetAreaFog();
     if (x34_mode == ERglFogMode::None)
       fog->RollFogOut(x48_rangeDelta.x(), x44_colorDelta, x38_color);
     else
       fog->FadeFog(x34_mode, x38_color, x3c_range, x44_colorDelta, x48_rangeDelta);
 
     if (zeus::close_enough(x54_thermalSpeed, 0.f) && !zeus::close_enough(x5c_xraySpeed, 0.f)) {
-      CWorld* world = stateMgr.WorldNC();
+      CWorld* world = stateMgr.GetWorld();
       CGameArea* area = world->GetArea(x4_areaId);
       area->SetXRaySpeedAndTarget(x5c_xraySpeed, x58_xrayTarget);
     } else {
-      CWorld* world = stateMgr.WorldNC();
+      CWorld* world = stateMgr.GetWorld();
       CGameArea* area = world->GetArea(x4_areaId);
       area->SetThermalSpeedAndTarget(x54_thermalSpeed, x50_thermalTarget);
     }

--- a/Runtime/World/CScriptDoor.cpp
+++ b/Runtime/World/CScriptDoor.cpp
@@ -358,8 +358,8 @@ CScriptDoor::EDoorOpenCondition CScriptDoor::GetDoorOpenCondition(CStateManager&
 void CScriptDoor::SetDoorAnimation(CScriptDoor::EDoorAnimType type) {
   x260_doorAnimState = type;
   CModelData* modelData = x64_modelData.get();
-  if (modelData && modelData->AnimationData())
-    modelData->AnimationData()->SetAnimation(CAnimPlaybackParms(s32(type), -1, 1.f, true), false);
+  if (modelData && modelData->GetAnimationData())
+    modelData->GetAnimationData()->SetAnimation(CAnimPlaybackParms(s32(type), -1, 1.f, true), false);
 }
 
 std::optional<zeus::CAABox> CScriptDoor::GetTouchBounds() const {

--- a/Runtime/World/CScriptGenerator.cpp
+++ b/Runtime/World/CScriptGenerator.cpp
@@ -101,7 +101,7 @@ void CScriptGenerator::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sende
           }
 
           float rnd = stateMgr.GetActiveRandom()->Range(x48_minScale, x4c_maxScale);
-          CModelData* mData = activateActor->ModelData();
+          CModelData* mData = activateActor->GetModelData();
           if (mData && !mData->IsNull())
             mData->SetScale(rnd * mData->GetScale());
 

--- a/Runtime/World/CScriptGunTurret.cpp
+++ b/Runtime/World/CScriptGunTurret.cpp
@@ -145,7 +145,7 @@ CScriptGunTurret::CScriptGunTurret(TUniqueId uid, std::string_view name, ETurret
   x560_31_frenzyReverse = false;
 
   if (comp == ETurretComponent::Base && HasModelData() && GetModelData()->HasAnimData())
-    ModelData()->EnableLooping(true);
+    GetModelData()->EnableLooping(true);
 
   x37c_projectileInfo.Token().Lock();
 }
@@ -403,21 +403,21 @@ void CScriptGunTurret::LaunchProjectile(CStateManager& mgr) {
                           x458_visorEffectDesc, x2d4_data.GetVisorSoundId(), false);
     mgr.AddObject(proj);
     auto pair =
-    x64_modelData->AnimationData()->GetCharacterInfo().GetPASDatabase().FindBestAnimation(
+    x64_modelData->GetAnimationData()->GetCharacterInfo().GetPASDatabase().FindBestAnimation(
     CPASAnimParmData(18, CPASAnimParm::FromEnum(1), CPASAnimParm::FromReal32(90.f),
       CPASAnimParm::FromEnum(skStateToLocoTypeLookup[int(x520_state)])), -1);
     if (pair.first > 0.f) {
       x64_modelData->EnableLooping(false);
-      x64_modelData->AnimationData()->SetAnimation(CAnimPlaybackParms(pair.second, -1, 1.f, true), false);
+      x64_modelData->GetAnimationData()->SetAnimation(CAnimPlaybackParms(pair.second, -1, 1.f, true), false);
     }
   }
 }
 
 void CScriptGunTurret::PlayAdditiveFlinchAnimation(CStateManager& mgr) {
-  auto pair = ModelData()->AnimationData()->GetCharacterInfo().GetPASDatabase().FindBestAnimation(
+  auto pair = GetModelData()->GetAnimationData()->GetCharacterInfo().GetPASDatabase().FindBestAnimation(
       CPASAnimParmData(23), *mgr.GetActiveRandom(), -1);
   if (pair.first > 0.f)
-    ModelData()->AnimationData()->AddAdditiveAnimation(pair.second, 1.f, false, true);
+    GetModelData()->GetAnimationData()->AddAdditiveAnimation(pair.second, 1.f, false, true);
 }
 
 void CScriptGunTurret::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
@@ -678,8 +678,8 @@ void CScriptGunTurret::UpdateTurretAnimation() {
   auto pair = GetModelData()->GetAnimationData()->GetCharacterInfo().GetPASDatabase().FindBestAnimation(parmData, -1);
 
   if (pair.first > 0.f && pair.second != x540_turretAnim) {
-    ModelData()->AnimationData()->SetAnimation(CAnimPlaybackParms(pair.second, -1, 1.f, true), false);
-    ModelData()->AnimationData()->EnableLooping(true);
+    GetModelData()->GetAnimationData()->SetAnimation(CAnimPlaybackParms(pair.second, -1, 1.f, true), false);
+    GetModelData()->GetAnimationData()->EnableLooping(true);
     x540_turretAnim = pair.second;
   }
 }
@@ -1126,14 +1126,14 @@ void CScriptGunTurret::PlayAdditiveChargingAnimation(CStateManager& mgr) {
     if (x55c_additiveChargeAnim != -1)
       return;
 
-    auto pair = ModelData()->AnimationData()->GetCharacterInfo().GetPASDatabase().FindBestAnimation(
+    auto pair = GetModelData()->GetAnimationData()->GetCharacterInfo().GetPASDatabase().FindBestAnimation(
         CPASAnimParmData(24, CPASAnimParm::FromEnum(2)), *mgr.GetActiveRandom(), -1);
     if (pair.first > 0.f) {
       x55c_additiveChargeAnim = pair.second;
-      ModelData()->AnimationData()->AddAdditiveAnimation(pair.second, 1.f, true, false);
+      GetModelData()->GetAnimationData()->AddAdditiveAnimation(pair.second, 1.f, true, false);
     }
   } else if (x55c_additiveChargeAnim != -1) {
-    ModelData()->AnimationData()->DelAdditiveAnimation(x55c_additiveChargeAnim);
+    GetModelData()->GetAnimationData()->DelAdditiveAnimation(x55c_additiveChargeAnim);
     x55c_additiveChargeAnim = -1;
   }
 }

--- a/Runtime/World/CScriptPickup.cpp
+++ b/Runtime/World/CScriptPickup.cpp
@@ -32,8 +32,8 @@ CScriptPickup::CScriptPickup(TUniqueId uid, std::string_view name, const CEntity
   if (pickupEffect.IsValid())
     x27c_pickupParticleDesc = g_SimplePool->GetObj({SBIG('PART'), pickupEffect});
 
-  if (x64_modelData && x64_modelData->AnimationData())
-    x64_modelData->AnimationData()->SetAnimation(CAnimPlaybackParms(0, -1, 1.f, true), false);
+  if (x64_modelData && x64_modelData->GetAnimationData())
+    x64_modelData->GetAnimationData()->SetAnimation(CAnimPlaybackParms(0, -1, 1.f, true), false);
 
   if (x278_delayTimer != 0.f) {
     xb4_drawFlags = CModelFlags(5, 0, 3, zeus::CColor(1.f, 1.f, 1.f, 0.f));

--- a/Runtime/World/CScriptPlatform.cpp
+++ b/Runtime/World/CScriptPlatform.cpp
@@ -51,8 +51,8 @@ CScriptPlatform::CScriptPlatform(
       CMaterialList(EMaterialTypes::Solid),
       CMaterialList(EMaterialTypes::NoStaticCollision, EMaterialTypes::NoPlatformCollision, EMaterialTypes::Platform)));
   xf8_24_movable = false;
-  if (HasModelData() && ModelData()->HasAnimData())
-    ModelData()->AnimationData()->EnableLooping(true);
+  if (HasModelData() && GetModelData()->HasAnimData())
+    GetModelData()->GetAnimationData()->EnableLooping(true);
   if (x304_treeGroupContainer)
     x314_treeGroup = std::make_unique<CCollidableOBBTreeGroup>(x304_treeGroupContainer->GetObj(), x68_material);
 }

--- a/Runtime/World/CScriptPlayerActor.cpp
+++ b/Runtime/World/CScriptPlayerActor.cpp
@@ -116,7 +116,7 @@ void CScriptPlayerActor::PumpBeamModel(CStateManager& mgr) {
     return;
   BuildBeamModelData();
   x314_beamModelData->Touch(mgr, 0);
-  mgr.WorldNC()->CycleLoadPauseState();
+  mgr.GetWorld()->CycleLoadPauseState();
   x31c_beamModel = TLockedToken<CModel>();
   x354_27_beamModelLoading = false;
 }
@@ -131,7 +131,7 @@ void CScriptPlayerActor::PumpSuitModel(CStateManager& mgr) {
     return;
 
   x320_suitModel->Touch(0);
-  mgr.WorldNC()->CycleLoadPauseState();
+  mgr.GetWorld()->CycleLoadPauseState();
 
   bool didSetup = false;
   if (x354_26_deferOfflineModelData) {
@@ -155,10 +155,10 @@ void CScriptPlayerActor::SetupOfflineModelData() {
   x2e8_suitRes.SetCharacterNodeId(x310_loadedCharIdx);
   x318_suitModelData = std::make_unique<CModelData>(x2e8_suitRes);
   if (!static_cast<MP1::CMain&>(*g_Main).GetScreenFading()) {
-    x328_backupModelData = x64_modelData->AnimationData()->GetModelData();
+    x328_backupModelData = x64_modelData->GetAnimationData()->GetModelData();
     x348_deallocateBackupCountdown = 2;
   }
-  x64_modelData->AnimationData()->SubstituteModelData(x318_suitModelData->AnimationData()->GetModelData());
+  x64_modelData->GetAnimationData()->SubstituteModelData(x318_suitModelData->GetAnimationData()->GetModelData());
 }
 
 void CScriptPlayerActor::SetupOnlineModelData() {
@@ -166,7 +166,7 @@ void CScriptPlayerActor::SetupOnlineModelData() {
     x2e8_suitRes.SetCharacterNodeId(x310_loadedCharIdx);
     SetModelData(std::make_unique<CModelData>(x2e8_suitRes));
     CAnimPlaybackParms parms(x2e8_suitRes.GetDefaultAnim(), -1, 1.f, true);
-    x64_modelData->AnimationData()->SetAnimation(parms, false);
+    x64_modelData->GetAnimationData()->SetAnimation(parms, false);
     if (x354_24_setBoundingBox)
       SetBoundingBox(x64_modelData->GetBounds(GetTransform().getRotation()));
   }

--- a/Runtime/World/CScriptSound.cpp
+++ b/Runtime/World/CScriptSound.cpp
@@ -180,7 +180,7 @@ void CScriptSound::PlaySound(CStateManager& mgr) {
         xec_sfxHandle = CSfxManager::SfxStart(x100_soundId, x10e_vol, x114_pan, x11c_29_acoustics, x112_prio,
                                               x11c_25_looped, x11c_30_worldSfx ? kInvalidAreaId : GetAreaIdAlways());
         if (x11c_30_worldSfx)
-          mgr.WorldNC()->AddGlobalSound(xec_sfxHandle);
+          mgr.GetWorld()->AddGlobalSound(xec_sfxHandle);
       }
     } else {
       float occVol = x11c_28_occlusionTest ? GetOccludedVolumeAmount(GetTranslation(), mgr) : 1.f;
@@ -202,7 +202,7 @@ void CScriptSound::PlaySound(CStateManager& mgr) {
 void CScriptSound::StopSound(CStateManager& mgr) {
   x11c_24_playRequested = false;
   if (x11c_30_worldSfx && x11c_26_nonEmitter) {
-    mgr.WorldNC()->StopGlobalSound(x100_soundId);
+    mgr.GetWorld()->StopGlobalSound(x100_soundId);
     xec_sfxHandle.reset();
   } else if (xec_sfxHandle) {
     CSfxManager::RemoveEmitter(xec_sfxHandle);

--- a/Runtime/World/CScriptSpawnPoint.cpp
+++ b/Runtime/World/CScriptSpawnPoint.cpp
@@ -49,10 +49,10 @@ void CScriptSpawnPoint::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objI
       CPlayer* player = stateMgr.Player();
 
       if (x4_areaId != stateMgr.GetNextAreaId()) {
-        CGameArea* area = stateMgr.WorldNC()->GetArea(x4_areaId);
+        CGameArea* area = stateMgr.GetWorld()->GetArea(x4_areaId);
         if (area->IsPostConstructed() && area->GetOcclusionState() == CGameArea::EOcclusionState::Occluded) {
           /* while (!area->TryTakingOutOfARAM()) {} */
-          CWorld::PropogateAreaChain(CGameArea::EOcclusionState::Visible, area, stateMgr.WorldNC());
+          CWorld::PropogateAreaChain(CGameArea::EOcclusionState::Visible, area, stateMgr.GetWorld());
         }
 
         stateMgr.SetCurrentAreaId(x4_areaId);
@@ -62,7 +62,7 @@ void CScriptSpawnPoint::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objI
 
         if (area->IsPostConstructed() && area->GetOcclusionState() == CGameArea::EOcclusionState::Visible)
           CWorld::PropogateAreaChain(CGameArea::EOcclusionState::Occluded,
-                                     stateMgr.WorldNC()->GetArea(stateMgr.GetNextAreaId()), stateMgr.WorldNC());
+                                     stateMgr.GetWorld()->GetArea(stateMgr.GetNextAreaId()), stateMgr.GetWorld());
       } else {
         player->Teleport(GetTransform(), stateMgr, true);
         player->SetSpawnedMorphBallState(CPlayer::EPlayerMorphBallState(x10c_25_morphed), stateMgr);

--- a/Runtime/World/CScriptSpecialFunction.cpp
+++ b/Runtime/World/CScriptSpecialFunction.cpp
@@ -181,7 +181,7 @@ void CScriptSpecialFunction::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId
     case ESpecialFunction::MapStation: {
       if (msg == EScriptObjectMessage::Action) {
         mgr.MapWorldInfo()->SetMapStationUsed(true);
-        const_cast<CMapWorld&>(*mgr.WorldNC()->GetMapWorld())
+        const_cast<CMapWorld&>(*mgr.GetWorld()->GetMapWorld())
             .RecalculateWorldSphere(*mgr.MapWorldInfo(), *mgr.GetWorld());
       }
       break;
@@ -327,7 +327,7 @@ void CScriptSpecialFunction::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId
           TAreaId aId = mgr.GetWorld()->GetAreaIdForSaveId(x1bc_areaSaveId);
           std::shared_ptr<CWorldLayerState> worldLayerState;
           if (aId != kInvalidAreaId)
-            worldLayerState = mgr.WorldLayerStateNC();
+            worldLayerState = mgr.WorldLayerState();
           else {
             std::pair<CAssetId, TAreaId> worldAreaPair = g_MemoryCardSys->GetAreaAndWorldIdForSaveId(x1bc_areaSaveId);
             if (worldAreaPair.first.IsValid()) {
@@ -763,7 +763,7 @@ void CScriptSpecialFunction::ThinkActorScale(float dt, CStateManager& mgr) {
     if (conn.x0_state != EScriptObjectState::Play || conn.x4_msg != EScriptObjectMessage::Activate)
       continue;
     if (TCastToPtr<CActor> act = mgr.ObjectById(mgr.GetIdForScript(conn.x8_objId))) {
-      CModelData* mData = act->ModelData();
+      CModelData* mData = act->GetModelData();
       if (mData && (mData->HasAnimData() || mData->HasNormalModel())) {
         zeus::CVector3f scale = mData->GetScale();
 

--- a/Runtime/World/CScriptWorldTeleporter.cpp
+++ b/Runtime/World/CScriptWorldTeleporter.cpp
@@ -77,7 +77,7 @@ void CScriptWorldTeleporter::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId
       transMgr->SfxStart();
       break;
     case EScriptObjectMessage::SetToZero: {
-      const auto& world = mgr.WorldNC();
+      const auto& world = mgr.GetWorld();
       world->SetLoadPauseState(true);
       CAssetId currentWorld = g_GameState->CurrentWorldAssetId();
       g_GameState->SetCurrentWorldId(x34_worldId);

--- a/Runtime/World/CWallCrawlerSwarm.cpp
+++ b/Runtime/World/CWallCrawlerSwarm.cpp
@@ -120,7 +120,7 @@ void CWallCrawlerSwarm::AllocateSkinnedModels(CStateManager& mgr, CModelData::EW
     //x430_.push_back(x4b0_[i]->PickAnimatedModel(which).Clone());
     x4b0_modelDatas[i]->EnableLooping(true);
     x4b0_modelDatas[i]->AdvanceAnimation(
-      x4b0_modelDatas[i]->AnimationData()->GetAnimTimeRemaining("Whole Body"sv) * (i * 0.0625f),
+      x4b0_modelDatas[i]->GetAnimationData()->GetAnimTimeRemaining("Whole Body"sv) * (i * 0.0625f),
       mgr, x4_areaId, true);
   }
   //x430_.push_back(x4b0_.back()->PickAnimatedModel(which).Clone());
@@ -799,7 +799,7 @@ void CWallCrawlerSwarm::Think(float dt, CStateManager& mgr) {
     }
   }
 
-  x4b0_modelDatas[8]->AnimationData()->SetPlaybackRate(x160_animPlaybackSpeed);
+  x4b0_modelDatas[8]->GetAnimationData()->SetPlaybackRate(x160_animPlaybackSpeed);
   x4b0_modelDatas[8]->AdvanceAnimation(dt, mgr, x4_areaId, true);
 
   SAdvancementDeltas deltas1, deltas2;
@@ -823,14 +823,14 @@ void CWallCrawlerSwarm::Think(float dt, CStateManager& mgr) {
   }
 
   for (int i = 0; i < 4; ++i) {
-    x4b0_modelDatas[i]->AnimationData()->SetPlaybackRate(x160_animPlaybackSpeed);
+    x4b0_modelDatas[i]->GetAnimationData()->SetPlaybackRate(x160_animPlaybackSpeed);
     deltas1 = x4b0_modelDatas[i]->AdvanceAnimation(dt, mgr, x4_areaId, true);
-    x4b0_modelDatas[i+4]->AnimationData()->SetPlaybackRate(x160_animPlaybackSpeed);
+    x4b0_modelDatas[i+4]->GetAnimationData()->SetPlaybackRate(x160_animPlaybackSpeed);
     deltas2 = x4b0_modelDatas[i+4]->AdvanceAnimation(dt, mgr, x4_areaId, true);
     if (x4b0_modelDatas[i]->HasAnimData() && _38F4[i])
-      UpdateEffects(mgr, *x4b0_modelDatas[i]->AnimationData(), r8 * 44 / x548_numBoids + 0x53);
+      UpdateEffects(mgr, *x4b0_modelDatas[i]->GetAnimationData(), r8 * 44 / x548_numBoids + 0x53);
     if (x4b0_modelDatas[i+4]->HasAnimData() && _38F8[i])
-      UpdateEffects(mgr, *x4b0_modelDatas[i+4]->AnimationData(), r3 * 44 / x548_numBoids + 0x53);
+      UpdateEffects(mgr, *x4b0_modelDatas[i+4]->GetAnimationData(), r3 * 44 / x548_numBoids + 0x53);
     for (int r20 = i; r20 < x108_boids.size(); r20 += 4) {
       CBoid& b = x108_boids[r20];
       if (b.GetActive()) {
@@ -885,7 +885,7 @@ void CWallCrawlerSwarm::Think(float dt, CStateManager& mgr) {
 
 void CWallCrawlerSwarm::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   for (int i = 0; i < 5; ++i)
-    x4b0_modelDatas[i]->AnimationData()->PreRender();
+    x4b0_modelDatas[i]->GetAnimationData()->PreRender();
   bool activeBoid = false;
   for (auto& b : x108_boids) {
     if (b.GetActive()) {
@@ -946,7 +946,7 @@ void CWallCrawlerSwarm::HardwareLight(const CStateManager& mgr, const zeus::CAAB
   lights.BuildDynamicLightList(mgr, aabb);
   for (auto& m : x4b0_modelDatas) {
     lights.ActivateLights(*m->PickAnimatedModel(x4dc_whichModel).GetModelInst());
-    if (auto iceModel = m->AnimationData()->GetIceModel())
+    if (auto iceModel = m->GetAnimationData()->GetIceModel())
       lights.ActivateLights(*iceModel->GetModelInst());
   }
 }
@@ -966,27 +966,27 @@ void CWallCrawlerSwarm::RenderBoid(const CBoid* boid, u32& drawMask, bool therma
   u32 thisDrawMask = 1u << modelIndex;
   if (drawMask & thisDrawMask) {
     drawMask &= ~thisDrawMask;
-    mData.AnimationData()->BuildPose();
+    mData.GetAnimationData()->BuildPose();
   }
   model.GetModelInst()->SetAmbientColor(boid->x40_ambientLighting);
   CGraphics::SetModelMatrix(boid->GetTransform());
   if (boid->x48_timeToDie > 0.f && !thermalHot) {
     CModelFlags useFlags(0, 0, 3, zeus::skWhite);
-    mData.AnimationData()->Render(model, useFlags, {}, nullptr);
-    if (auto iceModel = mData.AnimationData()->GetIceModel()) {
+    mData.GetAnimationData()->Render(model, useFlags, {}, nullptr);
+    if (auto iceModel = mData.GetAnimationData()->GetIceModel()) {
       if (!iceModel->GetModelInst()->TryLockTextures())
         return;
       iceModel->GetModelInst()->SetAmbientColor(zeus::skWhite);
       float alpha = 1.f - boid->x48_timeToDie;
       zeus::CColor color(1.f, alpha > 0.f ? boid->x48_timeToDie : 1.f);
       CModelFlags iceFlags(5, 0, 3, color);
-      mData.AnimationData()->Render(*iceModel, iceFlags, {}, nullptr);
+      mData.GetAnimationData()->Render(*iceModel, iceFlags, {}, nullptr);
     }
   } else if (thermalHot) {
     CModelFlags thermFlags(5, 0, 3, zeus::skWhite);
     mData.RenderThermal(zeus::skWhite, zeus::CColor(0.f, 0.25f), thermFlags);
   } else {
-    mData.AnimationData()->Render(model, flags, {}, nullptr);
+    mData.GetAnimationData()->Render(model, flags, {}, nullptr);
   }
 }
 

--- a/Runtime/World/CWallWalker.cpp
+++ b/Runtime/World/CWallWalker.cpp
@@ -154,10 +154,10 @@ void CWallWalker::Think(float dt, CStateManager& mgr) {
     return;
 
   if (x5c8_bendingHackWeight > 0.0001f) {
-    ModelData()->AnimationData()->AddAdditiveAnimation(x5cc_bendingHackAnim, x5c8_bendingHackWeight, true, false);
+    GetModelData()->GetAnimationData()->AddAdditiveAnimation(x5cc_bendingHackAnim, x5c8_bendingHackWeight, true, false);
     x5d6_29_applyBendingHack = true;
   } else {
-    ModelData()->AnimationData()->DelAdditiveAnimation(x5cc_bendingHackAnim);
+    GetModelData()->GetAnimationData()->DelAdditiveAnimation(x5cc_bendingHackAnim);
     x5d6_29_applyBendingHack = false;
   }
 }

--- a/Runtime/World/CWorldTransManager.cpp
+++ b/Runtime/World/CWorldTransManager.cpp
@@ -198,7 +198,7 @@ void CWorldTransManager::DrawAllModels(CActorLights* lights) {
     CModelFlags flags = {};
     flags.m_extendedShader = EExtendedShader::LightingCubeReflection;
 
-    x4_modelData->x1c_samusModelData.AnimationData()->PreRender();
+    x4_modelData->x1c_samusModelData.GetAnimationData()->PreRender();
     x4_modelData->x1c_samusModelData.Render(CModelData::EWhichModel::Normal, zeus::CTransform(), lights,
                                             flags);
 
@@ -359,7 +359,7 @@ void CWorldTransManager::TouchModels() {
     x4_modelData->x1c_samusModelData = {animRes, 2};
 
     CAnimPlaybackParms aData(animRes.GetDefaultAnim(), -1, 1.f, true);
-    x4_modelData->x1c_samusModelData.AnimationData()->SetAnimation(aData, false);
+    x4_modelData->x1c_samusModelData.GetAnimationData()->SetAnimation(aData, false);
   }
 
   if (!x4_modelData->x1c_samusModelData.IsNull())

--- a/Runtime/World/ScriptLoader.cpp
+++ b/Runtime/World/ScriptLoader.cpp
@@ -184,7 +184,7 @@ static SScaledActorHead LoadScaledActorHead(CInputStream& in, CStateManager& sta
 static zeus::CAABox GetCollisionBox(CStateManager& stateMgr, TAreaId id, const zeus::CVector3f& extent,
                                     const zeus::CVector3f& offset) {
   zeus::CAABox box(-extent * 0.5f + offset, extent * 0.5f + offset);
-  const zeus::CTransform& rot = stateMgr.WorldNC()->GetGameAreas()[id]->GetTransform().getRotation();
+  const zeus::CTransform& rot = stateMgr.GetWorld()->GetGameAreas()[id]->GetTransform().getRotation();
   return box.getTransformedAABox(rot);
 }
 
@@ -533,7 +533,7 @@ CEntity* ScriptLoader::LoadTrigger(CStateManager& mgr, CInputStream& in, int pro
 
   zeus::CAABox box(-extent * 0.5f, extent * 0.5f);
 
-  const zeus::CTransform& areaXf = mgr.WorldNC()->GetGameAreas()[info.GetAreaId()]->GetTransform();
+  const zeus::CTransform& areaXf = mgr.GetWorld()->GetGameAreas()[info.GetAreaId()]->GetTransform();
   zeus::CVector3f orientedForce = areaXf.basis * forceVec;
 
   return new CScriptTrigger(mgr.AllocateUniqueId(), name, info, position, box, dInfo, orientedForce, flags, active, b2,
@@ -1079,7 +1079,7 @@ u32 ClassifyVector(const zeus::CVector3f& dir) {
 }
 
 u32 TransformDamagableTriggerFlags(CStateManager& mgr, TAreaId aId, u32 flags) {
-  CGameArea* area = mgr.WorldNC()->GetGameAreas().at(u32(aId)).get();
+  CGameArea* area = mgr.GetWorld()->GetGameAreas().at(u32(aId)).get();
   zeus::CTransform rotation = area->GetTransform().getRotation();
 
   u32 ret = 0;


### PR DESCRIPTION
Makes for a more consistent interface, as getters won't have different names to remember based off whether or not they're const qualified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/42)
<!-- Reviewable:end -->
