### PR TITLE
RetroDataSpec: Use fmt::print where applicable

### DIFF
--- a/DataSpec/DNACommon/ANIM.cpp
+++ b/DataSpec/DNACommon/ANIM.cpp
@@ -163,7 +163,7 @@ std::vector<std::vector<Value>> BitstreamReader::read(const atUint8* data, size_
 
   for (size_t f = 0; f < keyFrameCount; ++f) {
 #if DUMP_KEYS
-    fprintf(stderr, "\nFRAME %" PRISize " %u %u\n", f, (m_bitCur / 32) * 4, m_bitCur % 32);
+    fmt::print(stderr, fmt("\nFRAME {} {} {}\n"), f, (m_bitCur / 32) * 4, m_bitCur % 32);
     int lastId = -1;
 #endif
     auto kit = chanKeys.begin();
@@ -172,7 +172,7 @@ std::vector<std::vector<Value>> BitstreamReader::read(const atUint8* data, size_
 #if DUMP_KEYS
       if (chan.id != lastId) {
         lastId = chan.id;
-        fprintf(stderr, "\n");
+        std::fputc('\n', stderr);
       }
 #endif
       QuantizedValue& p = *ait;
@@ -185,7 +185,7 @@ std::vector<std::vector<Value>> BitstreamReader::read(const atUint8* data, size_
         QuantizedRot qr = {{p[0], p[1], p[2]}, wBit};
         kit->emplace_back(DequantizeRotation(qr, rotDiv));
 #if DUMP_KEYS
-        fprintf(stderr, "%d R: %d %d %d %d\t", chan.id, wBit, p[0], p[1], p[2]);
+        fmt::print(stderr, fmt("{} R: {} {} {} {}\t"), chan.id, wBit, p[0], p[1], p[2]);
 #endif
         break;
       }
@@ -198,7 +198,7 @@ std::vector<std::vector<Value>> BitstreamReader::read(const atUint8* data, size_
         p[2] += val3;
         kit->push_back({p[0] * transMult, p[1] * transMult, p[2] * transMult});
 #if DUMP_KEYS
-        fprintf(stderr, "%d T: %d %d %d\t", chan.id, p[0], p[1], p[2]);
+        fmt::print(stderr, fmt("{} T: {} {} {}\t"), chan.id, p[0], p[1], p[2]);
 #endif
         break;
       }
@@ -208,7 +208,7 @@ std::vector<std::vector<Value>> BitstreamReader::read(const atUint8* data, size_
         p[2] += dequantize(data, chan.q[2]);
         kit->push_back({p[0] * scaleMult, p[1] * scaleMult, p[2] * scaleMult});
 #if DUMP_KEYS
-        fprintf(stderr, "%d S: %d %d %d\t", chan.id, p[0], p[1], p[2]);
+        fmt::print(stderr, fmt("{} S: {} {} {}\t"), chan.id, p[0], p[1], p[2]);
 #endif
         break;
       }
@@ -236,7 +236,7 @@ std::vector<std::vector<Value>> BitstreamReader::read(const atUint8* data, size_
       ++ait;
     }
 #if DUMP_KEYS
-    fprintf(stderr, "\n");
+    std::fputc('\n', stderr);
 #endif
   }
 

--- a/DataSpec/SpecBase.cpp
+++ b/DataSpec/SpecBase.cpp
@@ -927,9 +927,7 @@ void SpecBase::readCatalog(const hecl::ProjectPath& catalogPath, athena::io::YAM
 
       WriteNameTag(nameWriter, pathTag, p.first);
 #if 0
-            fprintf(stderr, "%s %s %08X\n",
-                    p.first.c_str(),
-                    pathTag.type.toString().c_str(), uint32_t(pathTag.id));
+      fmt::print(stderr, fmt("{} {} {:08X}\n"), p.first, pathTag.type.toString(), pathTag.id.Value());
 #endif
     }
   }


### PR DESCRIPTION
Replaces uses of `fprintf` with `fmt::print` where applicable in some debugging code. For trivial character insertion, we can make use of `fputc` instead of `fprintf`, given it's non-formatted text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/44)
<!-- Reviewable:end -->
