### PR TITLE
DNACommon: Replace platform-specific string conversion functions with standard facilities

### DIFF
--- a/DataSpec/DNACommon/DNACommon.hpp
+++ b/DataSpec/DNACommon/DNACommon.hpp
@@ -246,23 +246,15 @@ public:
   UniqueID64(const hecl::ProjectPath& path) { *this = path; }
   UniqueID64(const char* hexStr) {
     char copy[17];
-    strncpy(copy, hexStr, 16);
+    std::strncpy(copy, hexStr, 16);
     copy[16] = '\0';
-#if _WIN32
-    assign(_strtoui64(copy, nullptr, 16));
-#else
-    assign(strtouq(copy, nullptr, 16));
-#endif
+    assign(std::strtoull(copy, nullptr, 16));
   }
   UniqueID64(const wchar_t* hexStr) {
     wchar_t copy[17];
-    wcsncpy(copy, hexStr, 16);
+    std::wcsncpy(copy, hexStr, 16);
     copy[16] = L'\0';
-#if _WIN32
-    assign(_wcstoui64(copy, nullptr, 16));
-#else
-    assign(wcstoull(copy, nullptr, 16));
-#endif
+    assign(std::wcstoull(copy, nullptr, 16));
   }
 
   static constexpr size_t BinarySize() { return 8; }


### PR DESCRIPTION
These can be replaced with std::strtoull and std::wcstoull, eliminating a platform-specific ifdef.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/45)
<!-- Reviewable:end -->
