### PR TITLE
DataSpec/DNACommon: Resolve indirect includes where applicable

### DIFF
--- a/DataSpec/DNACommon/ANCS.cpp
+++ b/DataSpec/DNACommon/ANCS.cpp
@@ -1,11 +1,16 @@
-#include "ANCS.hpp"
+#include "DataSpec/DNACommon/ANCS.hpp"
+
+#include "DataSpec/DNACommon/CMDL.hpp"
+#include "DataSpec/DNACommon/DNACommon.hpp"
+#include "DataSpec/DNACommon/RigInverter.hpp"
 #include "DataSpec/DNAMP1/DNAMP1.hpp"
 #include "DataSpec/DNAMP1/ANCS.hpp"
 #include "DataSpec/DNAMP2/DNAMP2.hpp"
 #include "DataSpec/DNAMP2/ANCS.hpp"
 #include "DataSpec/DNAMP3/DNAMP3.hpp"
 #include "DataSpec/DNAMP3/CHAR.hpp"
-#include "hecl/Blender/Connection.hpp"
+
+#include <hecl/Blender/Connection.hpp>
 
 namespace DataSpec::DNAANCS {
 

--- a/DataSpec/DNACommon/ANCS.hpp
+++ b/DataSpec/DNACommon/ANCS.hpp
@@ -1,9 +1,21 @@
 #pragma once
 
-#include <unordered_set>
-#include "DNACommon.hpp"
-#include "CMDL.hpp"
-#include "RigInverter.hpp"
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <athena/Types.hpp>
+#include <hecl/Blender/Connection.hpp>
+#include <hecl/SystemChar.hpp>
+
+namespace DataSpec {
+struct SpecBase;
+}
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAANCS {
 

--- a/DataSpec/DNACommon/ANIM.cpp
+++ b/DataSpec/DNACommon/ANIM.cpp
@@ -1,7 +1,19 @@
-#include "zeus/Math.hpp"
-#include "ANIM.hpp"
+#include "DataSpec/DNACommon/ANIM.hpp"
+
+#include <cfloat>
+#include <cmath>
+#include <cstring>
+
+#include <hecl/hecl.hpp>
+#include <zeus/Global.hpp>
+#include <zeus/Math.hpp>
 
 #define DUMP_KEYS 0
+
+#if DUMP_KEYS
+#include <cstdio>
+#include <fmt/format.h>
+#endif
 
 namespace DataSpec::DNAANIM {
 

--- a/DataSpec/DNACommon/ANIM.hpp
+++ b/DataSpec/DNACommon/ANIM.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "DNACommon.hpp"
+#include <cassert>
 #include <cmath>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include <athena/Types.hpp>
 
 namespace DataSpec::DNAANIM {
 

--- a/DataSpec/DNACommon/ATBL.cpp
+++ b/DataSpec/DNACommon/ATBL.cpp
@@ -1,4 +1,19 @@
-#include "ATBL.hpp"
+#include "DataSpec/DNACommon/ATBL.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include <athena/FileReader.hpp>
+#include <athena/FileWriter.hpp>
+#include <athena/YAMLDocReader.hpp>
+#include <athena/YAMLDocWriter.hpp>
+
+#include <fmt/format.h>
 
 namespace DataSpec::DNAAudio {
 

--- a/DataSpec/DNACommon/ATBL.hpp
+++ b/DataSpec/DNACommon/ATBL.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "DNACommon.hpp"
-#include "PAK.hpp"
+namespace DataSpec {
+class PAKEntryReadStream;
+}
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAAudio {
 

--- a/DataSpec/DNACommon/BabeDead.cpp
+++ b/DataSpec/DNACommon/BabeDead.cpp
@@ -1,8 +1,15 @@
-#include "BabeDead.hpp"
+#include "DataSpec/DNACommon/BabeDead.hpp"
+
 #include "DataSpec/DNAMP1/MREA.hpp"
 #include "DataSpec/DNAMP3/MREA.hpp"
-#include "zeus/CTransform.hpp"
-#include "hecl/Blender/Connection.hpp"
+
+#include <cfloat>
+
+#include <hecl/Blender/Connection.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/Math.hpp>
+
+#include <fmt/format.h>
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/BabeDead.hpp
+++ b/DataSpec/DNACommon/BabeDead.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "zeus/Math.hpp"
-#include "hecl/hecl.hpp"
-#include <cfloat>
+namespace hecl::blender {
+struct Light;
+class PyOutStream;
+}
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/CMDL.cpp
+++ b/DataSpec/DNACommon/CMDL.cpp
@@ -1,13 +1,18 @@
-#include "CMDL.hpp"
-#include "../DNAMP1/CMDLMaterials.hpp"
-#include "../DNAMP1/CSKR.hpp"
-#include "../DNAMP1/MREA.hpp"
-#include "../DNAMP2/CMDLMaterials.hpp"
-#include "../DNAMP2/CSKR.hpp"
-#include "../DNAMP3/CMDLMaterials.hpp"
-#include "../DNAMP3/CSKR.hpp"
-#include "zeus/CAABox.hpp"
-#include "hecl/Blender/Connection.hpp"
+#include "DataSpec/DNACommon/CMDL.hpp"
+
+#include <utility>
+
+#include "DataSpec/DNAMP1/CMDLMaterials.hpp"
+#include "DataSpec/DNAMP1/CSKR.hpp"
+#include "DataSpec/DNAMP1/MREA.hpp"
+#include "DataSpec/DNAMP2/CMDLMaterials.hpp"
+#include "DataSpec/DNAMP2/CSKR.hpp"
+#include "DataSpec/DNAMP3/CMDLMaterials.hpp"
+#include "DataSpec/DNAMP3/CSKR.hpp"
+
+#include <fmt/format.h>
+#include <hecl/Blender/Connection.hpp>
+#include <zeus/CAABox.hpp>
 
 namespace DataSpec::DNACMDL {
 

--- a/DataSpec/DNACommon/CMDL.hpp
+++ b/DataSpec/DNACommon/CMDL.hpp
@@ -1,10 +1,23 @@
 #pragma once
 
-#include "athena/FileWriter.hpp"
-#include "PAK.hpp"
-#include "GX.hpp"
-#include "TXTR.hpp"
-#include "zeus/CAABox.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "DataSpec/DNACommon/GX.hpp"
+#include "DataSpec/DNACommon/TXTR.hpp"
+
+#include <athena/DNA.hpp>
+#include <athena/Types.hpp>
+#include <hecl/Blender/Connection.hpp>
+
+namespace hecl {
+class ProjectPath;
+}
+
+namespace zeus {
+class CAABox;
+}
 
 namespace DataSpec::DNACMDL {
 

--- a/DataSpec/DNACommon/CRSC.cpp
+++ b/DataSpec/DNACommon/CRSC.cpp
@@ -1,4 +1,10 @@
-#include "CRSC.hpp"
+#include "DataSpec/DNACommon/CRSC.hpp"
+
+#include <algorithm>
+
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 namespace DataSpec::DNAParticle {
 static const std::vector<FourCC> GeneratorTypes = {

--- a/DataSpec/DNACommon/CRSC.hpp
+++ b/DataSpec/DNACommon/CRSC.hpp
@@ -1,9 +1,21 @@
 #pragma once
 
-#include "ParticleCommon.hpp"
-#include "PAK.hpp"
-#include "athena/FileWriter.hpp"
-#include <optional>
+#include <cstdint>
+#include <unordered_map>
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+#include "DataSpec/DNACommon/ParticleCommon.hpp"
+
+#include <athena/DNA.hpp>
+
+namespace DataSpec {
+class PAKEntryReadStream;
+}
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAParticle {
 template <class IDType>

--- a/DataSpec/DNACommon/DGRP.cpp
+++ b/DataSpec/DNACommon/DGRP.cpp
@@ -1,7 +1,10 @@
-#include "athena/IStreamReader.hpp"
-#include "athena/IStreamWriter.hpp"
-#include "athena/FileWriter.hpp"
-#include "DGRP.hpp"
+#include "DataSpec/DNACommon/DGRP.hpp"
+
+#include <athena/DNAYaml.hpp>
+#include <athena/FileWriter.hpp>
+#include <athena/IStreamWriter.hpp>
+
+#include <hecl/hecl.hpp>
 
 namespace DataSpec::DNADGRP {
 

--- a/DataSpec/DNACommon/DGRP.hpp
+++ b/DataSpec/DNACommon/DGRP.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "DNACommon.hpp"
-#include "PAK.hpp"
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+#include "DataSpec/DNACommon/PAK.hpp"
 
 namespace DataSpec::DNADGRP {
 

--- a/DataSpec/DNACommon/DPSC.cpp
+++ b/DataSpec/DNACommon/DPSC.cpp
@@ -1,4 +1,9 @@
-#include "DPSC.hpp"
+#include "DataSpec/DNACommon/DPSC.hpp"
+
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include <athena/DNAYaml.hpp>
+#include <logvisor/logvisor.hpp>
 
 namespace DataSpec::DNAParticle {
 

--- a/DataSpec/DNACommon/DPSC.hpp
+++ b/DataSpec/DNACommon/DPSC.hpp
@@ -1,8 +1,21 @@
 #pragma once
 
-#include "ParticleCommon.hpp"
-#include "PAK.hpp"
-#include "athena/FileWriter.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+#include "DataSpec/DNACommon/ParticleCommon.hpp"
+
+#include <athena/FileWriter.hpp>
+
+namespace DataSpec {
+class PAKEntryReadStream;
+}
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAParticle {
 

--- a/DataSpec/DNACommon/DeafBabe.cpp
+++ b/DataSpec/DNACommon/DeafBabe.cpp
@@ -1,10 +1,18 @@
-#include "DeafBabe.hpp"
-#include "AROTBuilder.hpp"
-#include "DataSpec/DNAMP1/DeafBabe.hpp"
-#include "DataSpec/DNAMP2/DeafBabe.hpp"
-#include "DataSpec/DNAMP1/DCLN.hpp"
-#include "hecl/Blender/Connection.hpp"
+#include "DataSpec/DNACommon/DeafBabe.hpp"
+
 #include <cinttypes>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+
+#include "DataSpec/DNACommon/AROTBuilder.hpp"
+#include "DataSpec/DNAMP1/DeafBabe.hpp"
+#include "DataSpec/DNAMP1/DCLN.hpp"
+#include "DataSpec/DNAMP2/DeafBabe.hpp"
+
+#include <fmt/format.h>
+#include <hecl/Blender/Connection.hpp>
+#include <zeus/Global.hpp>
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/DeafBabe.hpp
+++ b/DataSpec/DNACommon/DeafBabe.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
-#include "DNACommon.hpp"
+#include <athena/Types.hpp>
+
+namespace hecl::blender {
+class PyOutStream;
+struct ColMesh;
+} // namespace hecl::blender
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/EGMC.hpp
+++ b/DataSpec/DNACommon/EGMC.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "DNACommon.hpp"
+#include "DataSpec/DNACommon/DNACommon.hpp"
 
 namespace DataSpec::DNACommon {
 struct EGMC : public BigDNA {

--- a/DataSpec/DNACommon/ELSC.cpp
+++ b/DataSpec/DNACommon/ELSC.cpp
@@ -1,4 +1,6 @@
-﻿#include "ELSC.hpp"
+﻿#include "DataSpec/DNACommon/ELSC.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 namespace DataSpec::DNAParticle {
 

--- a/DataSpec/DNACommon/ELSC.hpp
+++ b/DataSpec/DNACommon/ELSC.hpp
@@ -1,8 +1,15 @@
 #pragma once
 
-#include "ParticleCommon.hpp"
-#include "PAK.hpp"
-#include "athena/FileWriter.hpp"
+#include <vector>
+
+#include "DataSpec/DNACommon/ParticleCommon.hpp"
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include <athena/FileWriter.hpp>
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAParticle {
 template <class IDType>

--- a/DataSpec/DNACommon/FONT.cpp
+++ b/DataSpec/DNACommon/FONT.cpp
@@ -1,4 +1,8 @@
-#include "FONT.hpp"
+#include "DataSpec/DNACommon/FONT.hpp"
+
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 namespace DataSpec::DNAFont {
 logvisor::Module LogModule("urde::DNAFont");

--- a/DataSpec/DNACommon/FONT.hpp
+++ b/DataSpec/DNACommon/FONT.hpp
@@ -1,7 +1,19 @@
 #pragma once
 
-#include "PAK.hpp"
-#include "athena/FileWriter.hpp"
+#include <memory>
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+
+#include <athena/FileWriter.hpp>
+
+namespace DataSpec {
+class PAKEntryReadStream;
+}
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAFont {
 struct GlyphRect : BigDNA {

--- a/DataSpec/DNACommon/FSM2.cpp
+++ b/DataSpec/DNACommon/FSM2.cpp
@@ -1,8 +1,12 @@
+#include "DataSpec/DNACommon/FSM2.hpp"
+
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include <athena/FileWriter.hpp>
 #include <athena/Global.hpp>
-#include <athena/IStreamReader.hpp>
 #include <athena/IStreamWriter.hpp>
 
-#include "FSM2.hpp"
+#include <logvisor/logvisor.hpp>
 
 namespace DataSpec::DNAFSM2 {
 logvisor::Module LogDNAFSM2("urde::DNAFSM2");

--- a/DataSpec/DNACommon/FSM2.hpp
+++ b/DataSpec/DNACommon/FSM2.hpp
@@ -1,8 +1,18 @@
 #pragma once
 
-#include "PAK.hpp"
-#include "DNACommon.hpp"
-#include "athena/FileWriter.hpp"
+#include <memory>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+
+#include <athena/DNA.hpp>
+
+namespace DataSpec {
+class PAKEntryReadStream;
+}
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAFSM2 {
 struct IFSM : BigDNAVYaml {

--- a/DataSpec/DNACommon/GX.hpp
+++ b/DataSpec/DNACommon/GX.hpp
@@ -1,5 +1,8 @@
 #pragma once
-#include "athena/DNA.hpp"
+
+#include <cstdint>
+
+#include <athena/DNA.hpp>
 
 namespace GX {
 enum AttrType { NONE, DIRECT, INDEX8, INDEX16 };

--- a/DataSpec/DNACommon/MAPA.cpp
+++ b/DataSpec/DNACommon/MAPA.cpp
@@ -1,13 +1,16 @@
-#include "MAPA.hpp"
-#include "../DNAMP1/DNAMP1.hpp"
-#include "../DNAMP2/DNAMP2.hpp"
-#include "../DNAMP3/DNAMP3.hpp"
-#include "../DNAMP1/MAPA.hpp"
-#include "../DNAMP2/MAPA.hpp"
-#include "../DNAMP3/MAPA.hpp"
-#include "zeus/CTransform.hpp"
-#include "zeus/CAABox.hpp"
-#include "hecl/Blender/Connection.hpp"
+#include "DataSpec/DNACommon/MAPA.hpp"
+
+#include "DataSpec/DNACommon/GX.hpp"
+#include "DataSpec/DNAMP1/DNAMP1.hpp"
+#include "DataSpec/DNAMP2/DNAMP2.hpp"
+#include "DataSpec/DNAMP3/DNAMP3.hpp"
+#include "DataSpec/DNAMP1/MAPA.hpp"
+#include "DataSpec/DNAMP2/MAPA.hpp"
+#include "DataSpec/DNAMP3/MAPA.hpp"
+
+#include <hecl/Blender/Connection.hpp>
+#include <logvisor/logvisor.hpp>
+#include <zeus/CAABox.hpp>
 
 namespace DataSpec::DNAMAPA {
 

--- a/DataSpec/DNACommon/MAPA.hpp
+++ b/DataSpec/DNACommon/MAPA.hpp
@@ -1,7 +1,18 @@
 #pragma once
 
-#include "DNACommon.hpp"
-#include "GX.hpp"
+#include <memory>
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+
+namespace hecl {
+class ProjectPath;
+}
+
+namespace hecl::blender {
+class Connection;
+struct MapArea;
+} // namespace hecl::blender
 
 namespace DataSpec::DNAMAPA {
 struct MAPA : BigDNA {

--- a/DataSpec/DNACommon/MAPU.cpp
+++ b/DataSpec/DNACommon/MAPU.cpp
@@ -1,9 +1,11 @@
-#include "MAPU.hpp"
-#include "../DNAMP1/DNAMP1.hpp"
-#include "../DNAMP2/DNAMP2.hpp"
-#include "../DNAMP3/DNAMP3.hpp"
-#include "zeus/CTransform.hpp"
-#include "hecl/Blender/Connection.hpp"
+#include "DataSpec/DNACommon/MAPU.hpp"
+
+#include "DataSpec/DNAMP1/DNAMP1.hpp"
+#include "DataSpec/DNAMP2/DNAMP2.hpp"
+#include "DataSpec/DNAMP3/DNAMP3.hpp"
+
+#include <hecl/Blender/Connection.hpp>
+#include <zeus/Global.hpp>
 
 namespace DataSpec::DNAMAPU {
 

--- a/DataSpec/DNACommon/MAPU.hpp
+++ b/DataSpec/DNACommon/MAPU.hpp
@@ -1,6 +1,17 @@
 #pragma once
 
-#include "DNACommon.hpp"
+#include <cstdint>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+
+namespace hecl {
+class ProjectPath;
+}
+
+namespace hecl::blender {
+class Connection;
+struct MapUniverse;
+} // namespce hecl::blender
 
 namespace DataSpec::DNAMAPU {
 struct MAPU : BigDNA {

--- a/DataSpec/DNACommon/MLVL.cpp
+++ b/DataSpec/DNACommon/MLVL.cpp
@@ -1,8 +1,11 @@
-#include "MLVL.hpp"
-#include "../DNAMP1/MLVL.hpp"
-#include "../DNAMP2/MLVL.hpp"
-#include "../DNAMP3/MLVL.hpp"
-#include "hecl/Blender/Connection.hpp"
+#include "DataSpec/DNACommon/MLVL.hpp"
+
+#include "DataSpec/DNAMP1/MLVL.hpp"
+#include "DataSpec/DNAMP2/MLVL.hpp"
+#include "DataSpec/DNAMP3/MLVL.hpp"
+
+#include <hecl/Blender/Connection.hpp>
+#include <zeus/Global.hpp>
 
 namespace DataSpec::DNAMLVL {
 

--- a/DataSpec/DNACommon/MLVL.hpp
+++ b/DataSpec/DNACommon/MLVL.hpp
@@ -1,7 +1,18 @@
 #pragma once
 
-#include "DNACommon.hpp"
-#include "zeus/CVector3f.hpp"
+#include <functional>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+
+#include <hecl/SystemChar.hpp>
+
+namespace hecl {
+class ProjectPath;
+}
+
+namespace hecl::blender {
+class Connection;
+}
 
 namespace DataSpec::DNAMLVL {
 

--- a/DataSpec/DNACommon/OBBTreeBuilder.cpp
+++ b/DataSpec/DNACommon/OBBTreeBuilder.cpp
@@ -1,9 +1,15 @@
-#include "athena/Types.hpp"
-#include "OBBTreeBuilder.hpp"
-#include "zeus/CTransform.hpp"
+#include "DataSpec/DNACommon/OBBTreeBuilder.hpp"
+
+#include <cstddef>
+#include <unordered_set>
+#include <vector>
+
 #include "DataSpec/DNAMP1/DCLN.hpp"
-#include "gmm/gmm.h"
-#include "hecl/Blender/Connection.hpp"
+
+#include <athena/Types.hpp>
+#include <gmm/gmm.h>
+#include <hecl/Blender/Connection.hpp>
+#include <zeus/CTransform.hpp>
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/OBBTreeBuilder.hpp
+++ b/DataSpec/DNACommon/OBBTreeBuilder.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "DNACommon.hpp"
+#include <memory>
+
+#include <hecl/Blender/Connection.hpp>
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/PAK.cpp
+++ b/DataSpec/DNACommon/PAK.cpp
@@ -1,7 +1,8 @@
-#include "PAK.hpp"
-#include "../DNAMP1/DNAMP1.hpp"
-#include "../DNAMP2/DNAMP2.hpp"
-#include "../DNAMP3/DNAMP3.hpp"
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include "DataSpec/DNAMP1/DNAMP1.hpp"
+#include "DataSpec/DNAMP2/DNAMP2.hpp"
+#include "DataSpec/DNAMP3/DNAMP3.hpp"
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/PAK.hpp
+++ b/DataSpec/DNACommon/PAK.hpp
@@ -1,9 +1,17 @@
 #pragma once
 
-#include "DNACommon.hpp"
-#include "boo/ThreadLocalPtr.hpp"
 #include <array>
-#include "zeus/CMatrix4f.hpp"
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+
+#include <boo/ThreadLocalPtr.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/Global.hpp>
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/PART.cpp
+++ b/DataSpec/DNACommon/PART.cpp
@@ -1,4 +1,6 @@
-#include "PART.hpp"
+#include "DataSpec/DNACommon/PART.hpp"
+
+#include "DataSpec/DNACommon/PAK.hpp"
 
 namespace DataSpec::DNAParticle {
 

--- a/DataSpec/DNACommon/PART.hpp
+++ b/DataSpec/DNACommon/PART.hpp
@@ -1,8 +1,18 @@
 #pragma once
 
-#include "ParticleCommon.hpp"
-#include "PAK.hpp"
-#include "athena/FileWriter.hpp"
+#include <cstdint>
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+#include "DataSpec/DNACommon/ParticleCommon.hpp"
+
+namespace DataSpec {
+class PAKEntryReadStream;
+}
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAParticle {
 

--- a/DataSpec/DNACommon/ParticleCommon.hpp
+++ b/DataSpec/DNACommon/ParticleCommon.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
-#include "DNACommon.hpp"
+#include <memory>
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 namespace DataSpec::DNAParticle {
 extern logvisor::Module LogModule;

--- a/DataSpec/DNACommon/RigInverter.cpp
+++ b/DataSpec/DNACommon/RigInverter.cpp
@@ -1,8 +1,10 @@
-#include "RigInverter.hpp"
+#include "DataSpec/DNACommon/RigInverter.hpp"
+
 #include "DataSpec/DNAMP1/CINF.hpp"
 #include "DataSpec/DNAMP2/CINF.hpp"
 #include "DataSpec/DNAMP3/CINF.hpp"
-#include "hecl/Blender/Connection.hpp"
+
+#include <hecl/Blender/Connection.hpp>
 
 namespace DataSpec::DNAANIM {
 

--- a/DataSpec/DNACommon/RigInverter.hpp
+++ b/DataSpec/DNACommon/RigInverter.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "zeus/CVector3f.hpp"
-#include "zeus/CMatrix3f.hpp"
-#include "zeus/CQuaternion.hpp"
-#include "hecl/hecl.hpp"
+#include <string>
 #include <unordered_map>
+#include <vector>
+
+#include <hecl/hecl.hpp>
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace DataSpec::DNAANIM {
 

--- a/DataSpec/DNACommon/SAVWCommon.hpp
+++ b/DataSpec/DNACommon/SAVWCommon.hpp
@@ -1,6 +1,7 @@
 #pragma once
-#include "DNACommon.hpp"
-#include "PAK.hpp"
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+#include "DataSpec/DNACommon/PAK.hpp"
 
 namespace DataSpec::SAVWCommon {
 enum class EScanCategory { None, Data, Lore, Creature, Research, Artifact };

--- a/DataSpec/DNACommon/STRG.cpp
+++ b/DataSpec/DNACommon/STRG.cpp
@@ -1,7 +1,10 @@
-#include "STRG.hpp"
-#include "../DNAMP1/STRG.hpp"
-#include "../DNAMP2/STRG.hpp"
-#include "../DNAMP3/STRG.hpp"
+#include "DataSpec/DNACommon/STRG.hpp"
+
+#include "DataSpec/DNAMP1/STRG.hpp"
+#include "DataSpec/DNAMP2/STRG.hpp"
+#include "DataSpec/DNAMP3/STRG.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/STRG.hpp
+++ b/DataSpec/DNACommon/STRG.hpp
@@ -1,11 +1,18 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <string>
-#include <fstream>
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+
 #include <hecl/hecl.hpp>
-#include <hecl/Database.hpp>
-#include <athena/FileWriter.hpp>
-#include "DNACommon.hpp"
+
+namespace athena::io {
+class IStreamReader;
+}
 
 namespace DataSpec {
 struct ISTRG : BigDNAVYaml {

--- a/DataSpec/DNACommon/SWHC.cpp
+++ b/DataSpec/DNACommon/SWHC.cpp
@@ -1,4 +1,8 @@
-#include "SWHC.hpp"
+#include "DataSpec/DNACommon/SWHC.hpp"
+
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 namespace DataSpec::DNAParticle {
 

--- a/DataSpec/DNACommon/SWHC.hpp
+++ b/DataSpec/DNACommon/SWHC.hpp
@@ -1,8 +1,17 @@
 #pragma once
 
-#include "ParticleCommon.hpp"
-#include "PAK.hpp"
-#include "athena/FileWriter.hpp"
+#include <vector>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+#include "DataSpec/DNACommon/ParticleCommon.hpp"
+
+namespace DataSpec {
+class PAKEntryReadStream;
+}
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAParticle {
 

--- a/DataSpec/DNACommon/TXTR.cpp
+++ b/DataSpec/DNACommon/TXTR.cpp
@@ -1,9 +1,15 @@
+#include "DataSpec/DNACommon/TXTR.hpp"
+
+#include <cstdint>
+#include <memory>
+
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include <athena/FileWriter.hpp>
+#include <hecl/hecl.hpp>
+#include <logvisor/logvisor.hpp>
 #include <png.h>
 #include <squish.h>
-#include "TXTR.hpp"
-#include "PAK.hpp"
-#include "athena/FileWriter.hpp"
-#include "hecl/hecl.hpp"
 
 namespace DataSpec {
 

--- a/DataSpec/DNACommon/TXTR.hpp
+++ b/DataSpec/DNACommon/TXTR.hpp
@@ -1,6 +1,12 @@
 #pragma once
 
-#include "DNACommon.hpp"
+#include <climits>
+
+#include "DataSpec/DNACommon/DNACommon.hpp"
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec {
 class PAKEntryReadStream;

--- a/DataSpec/DNACommon/WPSC.cpp
+++ b/DataSpec/DNACommon/WPSC.cpp
@@ -1,4 +1,8 @@
-#include "WPSC.hpp"
+#include "DataSpec/DNACommon/WPSC.hpp"
+
+#include "DataSpec/DNACommon/PAK.hpp"
+
+#include <logvisor/logvisor.hpp>
 
 namespace DataSpec::DNAParticle {
 

--- a/DataSpec/DNACommon/WPSC.hpp
+++ b/DataSpec/DNACommon/WPSC.hpp
@@ -1,8 +1,15 @@
 #pragma once
 
-#include "ParticleCommon.hpp"
-#include "PAK.hpp"
-#include "athena/FileWriter.hpp"
+#include "DataSpec/DNACommon/DNACommon.hpp"
+#include "DataSpec/DNACommon/ParticleCommon.hpp"
+
+namespace DataSpec {
+class PAKEntryReadStream;
+}
+
+namespace hecl {
+class ProjectPath;
+}
 
 namespace DataSpec::DNAParticle {
 template <class IDType>

--- a/DataSpec/DNAMP1/DeafBabe.hpp
+++ b/DataSpec/DNAMP1/DeafBabe.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "DataSpec/DNACommon/DeafBabe.hpp"
+#include "DataSpec/DNACommon/DNACommon.hpp"
 
 namespace DataSpec::DNAMP1 {
 


### PR DESCRIPTION
Avoids indirect inclusions where applicable and includes the necessary headers as used by the interface. This way, it prevents code from failing to compile due to changes in other header inclusions.

Built on Windows

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/46)
<!-- Reviewable:end -->
