### PR TITLE
CPatterned: Correct use of bool in bitfield

### DIFF
--- a/Runtime/World/CPatterned.hpp
+++ b/Runtime/World/CPatterned.hpp
@@ -178,7 +178,7 @@ protected:
       bool x400_29_pendingMassiveFrozenDeath : 1;
       bool x400_30_patternShagged : 1;
       bool x400_31_isFlyer : 1;
-      bool x401_24_pathOverCount : 2;
+      uint32_t x401_24_pathOverCount : 2;
       bool x401_26_disableMove : 1;
       bool x401_27_phazingOut : 1;
       bool x401_28_burning : 1;


### PR DESCRIPTION
This is incremented within PathFind(), however, because the type within this bitfield is a bool, this can trigger compilation warnings (rightly so). So we can make it a uint32_t to make it obvious that the incrementing behavior is intended.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/47)
<!-- Reviewable:end -->
