### PR TITLE
CStringTable: Use std::array instead of std::vector

### DIFF
--- a/Runtime/GuiSys/CStringTable.cpp
+++ b/Runtime/GuiSys/CStringTable.cpp
@@ -1,11 +1,17 @@
-#include "CStringTable.hpp"
-#include "CToken.hpp"
+#include "Runtime/GuiSys/CStringTable.hpp"
+
+#include <array>
+
+#include "Runtime/CToken.hpp"
 
 namespace urde {
-const std::vector<FourCC> CStringTable::skLanguages = {FOURCC('ENGL'), FOURCC('FREN'), FOURCC('GERM'), FOURCC('SPAN'),
-                                                       FOURCC('ITAL'), FOURCC('DUTC'), FOURCC('JAPN')};
+namespace {
+constexpr std::array languages{
+    FOURCC('ENGL'), FOURCC('FREN'), FOURCC('GERM'), FOURCC('SPAN'), FOURCC('ITAL'), FOURCC('DUTC'), FOURCC('JAPN'),
+};
+} // Anonymous namespace
 
-FourCC CStringTable::mCurrentLanguage = CStringTable::skLanguages[0];
+FourCC CStringTable::mCurrentLanguage = languages[0];
 
 CStringTable::CStringTable(CInputStream& in) { LoadStringTable(in); }
 
@@ -64,7 +70,7 @@ const char16_t* CStringTable::GetString(s32 str) const {
   return reinterpret_cast<char16_t*>(x4_data.get() + off);
 }
 
-void CStringTable::SetLanguage(s32 lang) { mCurrentLanguage = skLanguages[lang]; }
+void CStringTable::SetLanguage(s32 lang) { mCurrentLanguage = languages[lang]; }
 
 CFactoryFnReturn FStringTableFactory(const SObjectTag&, CInputStream& in, const CVParamTransfer&,
                                      CObjectReference* selfRef) {

--- a/Runtime/GuiSys/CStringTable.hpp
+++ b/Runtime/GuiSys/CStringTable.hpp
@@ -5,7 +5,6 @@
 
 namespace urde {
 class CStringTable {
-  static const std::vector<FourCC> skLanguages;
   static FourCC mCurrentLanguage;
   u32 x0_stringCount = 0;
   std::unique_ptr<u8[]> x4_data = 0;

--- a/Runtime/GuiSys/CStringTable.hpp
+++ b/Runtime/GuiSys/CStringTable.hpp
@@ -7,7 +7,7 @@ namespace urde {
 class CStringTable {
   static FourCC mCurrentLanguage;
   u32 x0_stringCount = 0;
-  std::unique_ptr<u8[]> x4_data = 0;
+  std::unique_ptr<u8[]> x4_data;
   u32 m_bufLen;
 
 public:


### PR DESCRIPTION
We can use a std::array instead, avoiding the need for heap allocations, given we can just make the lookup-table constexpr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/49)
<!-- Reviewable:end -->
