### PR TITLE
PAK: Zero initialize m_sz and m_pos of PAKEntryReadStream

### DIFF
--- a/DataSpec/DNACommon/PAK.hpp
+++ b/DataSpec/DNACommon/PAK.hpp
@@ -23,7 +23,7 @@ class PAKEntryReadStream : public athena::io::IStreamReader {
 
 public:
   PAKEntryReadStream() = default;
-  operator bool() const { return m_buf.operator bool(); }
+  explicit operator bool() const { return m_buf.operator bool(); }
   PAKEntryReadStream(const PAKEntryReadStream& other) = delete;
   PAKEntryReadStream(PAKEntryReadStream&& other) = default;
   PAKEntryReadStream& operator=(const PAKEntryReadStream& other) = delete;

--- a/DataSpec/DNACommon/PAK.hpp
+++ b/DataSpec/DNACommon/PAK.hpp
@@ -18,11 +18,11 @@ namespace DataSpec {
 /** PAK entry stream reader */
 class PAKEntryReadStream : public athena::io::IStreamReader {
   std::unique_ptr<atUint8[]> m_buf;
-  atUint64 m_sz;
-  atUint64 m_pos;
+  atUint64 m_sz = 0;
+  atUint64 m_pos = 0;
 
 public:
-  PAKEntryReadStream() {}
+  PAKEntryReadStream() = default;
   operator bool() const { return m_buf.operator bool(); }
   PAKEntryReadStream(const PAKEntryReadStream& other) = delete;
   PAKEntryReadStream(PAKEntryReadStream&& other) = default;


### PR DESCRIPTION
Makes the initial value of the members in the default constructor case deterministic, preventing potential uninitialized reads via the member functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/52)
<!-- Reviewable:end -->
