### PR TITLE
DNAMP1/CTweakPlayerGun: Prevent array overrun cases

### DIFF
--- a/DataSpec/DNAMP1/Tweaks/CTweakPlayerGun.hpp
+++ b/DataSpec/DNAMP1/Tweaks/CTweakPlayerGun.hpp
@@ -89,14 +89,16 @@ struct CTweakPlayerGun final : ITweakPlayerGun {
   }
 
   const SWeaponInfo& GetBeamInfo(atInt32 beam) const override {
-    if (beam < 0 || beam > 5)
+    if (beam < 0 || beam >= 5) {
       return xa8_beams[0];
+    }
     return xa8_beams[beam];
   }
 
   const SComboShotParam& GetComboShotInfo(atInt32 beam) const override {
-    if (beam < 0 || beam > 5)
+    if (beam < 0 || beam >= 5) {
       return x1f0_combos[0];
+    }
     return x1f0_combos[beam];
   }
 


### PR DESCRIPTION
These arrays are both 5 elements in size. Accessing them at index 5 would be out of bounds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/54)
<!-- Reviewable:end -->
