### PR TITLE
WPSC: Correct typo within WPSM's _read() function

### DIFF
--- a/DataSpec/DNACommon/WPSC.cpp
+++ b/DataSpec/DNACommon/WPSC.cpp
@@ -113,7 +113,7 @@ void WPSM<IDType>::_read(athena::io::YAMLDocReader& r) {
         xunk_FC60.read(r);
         break;
       case SBIG('SPS1'):
-        xunk_SPS2.read(r);
+        xunk_SPS1.read(r);
         break;
       case SBIG('SPS2'):
         xunk_SPS2.read(r);


### PR DESCRIPTION
This should be calling read() on xunk_SPS1, not xunk_SPS2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/55)
<!-- Reviewable:end -->
