### PR TITLE
CActorModelParticles: Make DGRP array constexpr

### DIFF
--- a/Runtime/World/CActorModelParticles.cpp
+++ b/Runtime/World/CActorModelParticles.cpp
@@ -1,4 +1,7 @@
 #include "CActorModelParticles.hpp"
+
+#include <array>
+
 #include "CStateManager.hpp"
 #include "GameGlobalObjects.hpp"
 #include "CSimplePool.hpp"
@@ -377,7 +380,7 @@ void CActorModelParticles::IncrementDependency(EDependency d) {
     xe4_loadingDeps |= (1 << int(d));
 }
 
-static const char* ParticleDGRPs[] = {
+constexpr std::array<const char*, 6> ParticleDGRPs{
     "Effect_OnFire_DGRP",  "Effect_IceBreak_DGRP", "Effect_Ash_DGRP",
     "Effect_FirePop_DGRP", "Effect_Electric_DGRP", "Effect_IcePop_DGRP",
 };
@@ -393,8 +396,9 @@ CActorModelParticles::Dependency CActorModelParticles::GetParticleDGRPTokens(con
 }
 
 void CActorModelParticles::LoadParticleDGRPs() {
-  for (int i = 0; i < 6; ++i)
-    x50_dgrps.push_back(GetParticleDGRPTokens(ParticleDGRPs[i]));
+  for (const char* dgrp : ParticleDGRPs) {
+    x50_dgrps.push_back(GetParticleDGRPTokens(dgrp));
+  }
 }
 
 std::unique_ptr<CElementGen> CActorModelParticles::MakeOnFireGen() const {


### PR DESCRIPTION
Technically this array wasn't read-only and contained a sequence of modifiable elements. We can make this constexpr so that the compiler can definitively place it into the read-only segment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/63)
<!-- Reviewable:end -->
