### PR TITLE
CRumbleVoice: Make SAdsrData and SAdsrDelta interfaces constexpr

### DIFF
--- a/Runtime/Input/CRumbleManager.cpp
+++ b/Runtime/Input/CRumbleManager.cpp
@@ -19,7 +19,7 @@ s16 CRumbleManager::Rumble(CStateManager& mgr, const zeus::CVector3f& pos, ERumb
 
 s16 CRumbleManager::Rumble(CStateManager& mgr, ERumbleFxId fx, float gain, ERumblePriority priority) {
   if (g_GameState->GameOptions().GetIsRumbleEnabled())
-    return x0_rumbleGenerator.Rumble(RumbleFxTable[int(fx)], gain, priority, EIOPort::Zero);
+    return x0_rumbleGenerator.Rumble(RumbleFxTable[size_t(fx)], gain, priority, EIOPort::Zero);
   return -1;
 }
 

--- a/Runtime/Input/CRumbleVoice.hpp
+++ b/Runtime/Input/CRumbleVoice.hpp
@@ -37,9 +37,9 @@ struct SAdsrData {
     u8 dummy = 0;
   };
 
-  SAdsrData() = default;
-  SAdsrData(float attackGain, float autoReleaseDur, float attackDur, float decayDur, float sustainGain,
-            float releaseDur, bool hasSustain, bool autoRelease)
+  constexpr SAdsrData() noexcept = default;
+  constexpr SAdsrData(float attackGain, float autoReleaseDur, float attackDur, float decayDur, float sustainGain,
+                      float releaseDur, bool hasSustain, bool autoRelease) noexcept
   : x0_attackGain(attackGain)
   , x4_autoReleaseDur(autoReleaseDur)
   , x8_attackDur(attackDur)

--- a/Runtime/Input/CRumbleVoice.hpp
+++ b/Runtime/Input/CRumbleVoice.hpp
@@ -59,17 +59,17 @@ struct SAdsrDelta {
   float x8_decayTime = 0.f;
   float xc_releaseTime = 0.f;
   float x10_autoReleaseTime = 0.f;
-  float x14_attackIntensity;
-  float x18_sustainIntensity;
+  float x14_attackIntensity = 0.f;
+  float x18_sustainIntensity = 0.f;
   ERumblePriority x1c_priority;
   EPhase x20_phase;
 
-  SAdsrDelta(EPhase phase, ERumblePriority priority)
+  constexpr SAdsrDelta(EPhase phase, ERumblePriority priority) noexcept
   : x0_curIntensity(phase == EPhase::PrePulse ? 2.f : 0.f), x1c_priority(priority), x20_phase(phase) {}
-  SAdsrDelta(EPhase phase) : x1c_priority(ERumblePriority::None), x20_phase(phase) {}
+  constexpr SAdsrDelta(EPhase phase) noexcept : x1c_priority(ERumblePriority::None), x20_phase(phase) {}
 
-  static SAdsrDelta Stopped() { return SAdsrDelta(EPhase::Stop); }
-  static SAdsrDelta Start(ERumblePriority priority, bool prePulse) {
+  static constexpr SAdsrDelta Stopped() noexcept { return SAdsrDelta(EPhase::Stop); }
+  static constexpr SAdsrDelta Start(ERumblePriority priority, bool prePulse) noexcept {
     return SAdsrDelta(prePulse ? EPhase::PrePulse : EPhase::Attack, priority);
   }
 };

--- a/Runtime/Input/RumbleFxTable.cpp
+++ b/Runtime/Input/RumbleFxTable.cpp
@@ -1,8 +1,8 @@
-#include "RumbleFxTable.hpp"
+#include "Runtime/Input/RumbleFxTable.hpp"
 
 namespace urde {
 
-const SAdsrData RumbleFxTable[] = {
+const RumbleFXTable RumbleFxTable{{
     /* attackGain, autoReleaseDur, attackDur, decayDur, sustainGain, releaseDur, hasSustain, autoRelease */
     {0.48f, 0.f, 0.3f, 0.125f, 0.1f, 0.5f, false, false},
     {0.66f, 0.f, 0.11f, 0.175f, 0.42f, 0.375f, false, false},
@@ -27,6 +27,7 @@ const SAdsrData RumbleFxTable[] = {
     {1.2f, 0.f, 0.01f, 0.621f, 0.f, 0.f, false, false},
     {0.5268f, 0.f, 0.114f, 1.008f, 0.f, 0.325f, false, false},
     {0.6828f, 0.f, 0.f, 0.821f, 0.f, 0.f, false, false},
-    {1.8f, 0.f, 0.5f, 0.425f, 0.35f, 0.5f, false, false}};
+    {1.8f, 0.f, 0.5f, 0.425f, 0.35f, 0.5f, false, false},
+}};
 
 }

--- a/Runtime/Input/RumbleFxTable.hpp
+++ b/Runtime/Input/RumbleFxTable.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "CRumbleVoice.hpp"
+#include <array>
+#include "Runtime/Input/CRumbleVoice.hpp"
 
 namespace urde {
 
-extern const SAdsrData RumbleFxTable[];
+using RumbleFXTable = std::array<SAdsrData, 24>;
+
+extern const RumbleFXTable RumbleFxTable;
 
 }

--- a/Runtime/MP1/CFrontEndUI.cpp
+++ b/Runtime/MP1/CFrontEndUI.cpp
@@ -1429,7 +1429,7 @@ void CFrontEndUI::SOptionsFrontEndFrame::DoMenuSelectionChange(CGuiTableGroup* c
 
       if (option.option == EGameOption::Rumble && caller->GetUserSelection() > 0) {
         x40_rumbleGen.HardStopAll();
-        x40_rumbleGen.Rumble(RumbleFxTable[int(ERumbleFxId::PlayerBump)], 1.f, ERumblePriority::One, EIOPort::Zero);
+        x40_rumbleGen.Rumble(RumbleFxTable[size_t(ERumbleFxId::PlayerBump)], 1.f, ERumblePriority::One, EIOPort::Zero);
       }
     }
   }

--- a/Runtime/MP1/COptionsScreen.cpp
+++ b/Runtime/MP1/COptionsScreen.cpp
@@ -86,7 +86,7 @@ void COptionsScreen::OnEnumChanged(CGuiTableGroup* caller, int oldSel) {
 
   if (opt == EGameOption::Rumble && caller->GetUserSelection() > 0) {
     x1a8_rumble.HardStopAll();
-    x1a8_rumble.Rumble(RumbleFxTable[int(ERumbleFxId::PlayerBump)], 1.f, ERumblePriority::One, EIOPort::Zero);
+    x1a8_rumble.Rumble(RumbleFxTable[size_t(ERumbleFxId::PlayerBump)], 1.f, ERumblePriority::One, EIOPort::Zero);
   }
 
   CPauseScreenBase::UpdateSideTable(caller);


### PR DESCRIPTION
SAdsrData instances are used in a file-scope lookup-table, however, given the constructors aren't constexpr, these instances all technically have a runtime static constructor (from a language point-of-view). We can declare the constructor as constexpr to formally give the compiler leeway to remove them.

This makes the interface of SAdsrDelta constexpr capable as well in order to remain consistent between the two structs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/64)
<!-- Reviewable:end -->
