### PR TITLE
Runtime: Make use of std::make_unique where applicable

### DIFF
--- a/Runtime/CResLoader.cpp
+++ b/Runtime/CResLoader.cpp
@@ -7,17 +7,19 @@ static logvisor::Module Log("CResLoader");
 CResLoader::CResLoader() { x48_curPak = x18_pakLoadedList.end(); }
 
 const std::vector<CAssetId>* CResLoader::GetTagListForFile(std::string_view name) const {
-  std::string namePak = std::string(name) + ".upak";
-  for (const std::unique_ptr<CPakFile>& pak : x18_pakLoadedList)
-    if (!CStringExtras::CompareCaseInsensitive(namePak, pak->x18_path))
+  const std::string namePak = std::string(name).append(".upak");
+  for (const std::unique_ptr<CPakFile>& pak : x18_pakLoadedList) {
+    if (!CStringExtras::CompareCaseInsensitive(namePak, pak->x18_path)) {
       return &pak->GetDepList();
+    }
+  }
   return nullptr;
 }
 
 void CResLoader::AddPakFileAsync(std::string_view name, bool buildDepList, bool worldPak) {
-  std::string namePak = std::string(name) + ".upak";
-  if (CDvdFile::FileExists(namePak.c_str())) {
-    x30_pakLoadingList.emplace_back(new CPakFile(namePak, buildDepList, worldPak));
+  const std::string namePak = std::string(name).append(".upak");
+  if (CDvdFile::FileExists(namePak)) {
+    x30_pakLoadingList.emplace_back(std::make_unique<CPakFile>(namePak, buildDepList, worldPak));
     ++x44_pakLoadingCount;
   }
 }
@@ -35,11 +37,13 @@ void CResLoader::WaitForPakFileLoadingComplete() {
 std::unique_ptr<CInputStream> CResLoader::LoadNewResourcePartSync(const SObjectTag& tag, u32 length, u32 offset,
                                                                   void* extBuf) {
   void* buf = extBuf;
-  CPakFile* file = FindResourceForLoad(tag);
-  if (!buf)
+  if (buf == nullptr) {
     buf = new u8[length];
+  }
+
+  CPakFile* const file = FindResourceForLoad(tag);
   file->SyncSeekRead(buf, length, ESeekOrigin::Begin, x50_cachedResInfo->GetOffset() + offset);
-  return std::unique_ptr<CInputStream>(new athena::io::MemoryReader((atUint8*)buf, length, !extBuf));
+  return std::make_unique<athena::io::MemoryReader>(buf, length, !extBuf);
 }
 
 void CResLoader::LoadMemResourceSync(const SObjectTag& tag, std::unique_ptr<u8[]>& bufOut, int* sizeOut) {
@@ -52,29 +56,36 @@ void CResLoader::LoadMemResourceSync(const SObjectTag& tag, std::unique_ptr<u8[]
 
 std::unique_ptr<CInputStream> CResLoader::LoadResourceFromMemorySync(const SObjectTag& tag, const void* buf) {
   FindResourceForLoad(tag);
-  CInputStream* newStrm = new athena::io::MemoryReader((atUint8*)buf, x50_cachedResInfo->GetSize());
+  std::unique_ptr<CInputStream> newStrm = std::make_unique<athena::io::MemoryReader>(buf, x50_cachedResInfo->GetSize());
   if (x50_cachedResInfo->IsCompressed()) {
     newStrm->readUint32Big();
-    newStrm = new CZipInputStream(std::unique_ptr<CInputStream>(newStrm));
+    newStrm = std::make_unique<CZipInputStream>(std::move(newStrm));
   }
-  return std::unique_ptr<CInputStream>(newStrm);
+  return newStrm;
 }
 
 std::unique_ptr<CInputStream> CResLoader::LoadNewResourceSync(const SObjectTag& tag, void* extBuf) {
-  void* buf = extBuf;
-  if (CPakFile* file = FindResourceForLoad(tag)) {
-    size_t resSz = ROUND_UP_32(x50_cachedResInfo->GetSize());
-    if (!buf)
+  if (CPakFile* const file = FindResourceForLoad(tag)) {
+    const size_t resSz = ROUND_UP_32(x50_cachedResInfo->GetSize());
+
+    void* buf = extBuf;
+    if (buf == nullptr) {
       buf = new u8[resSz];
+    }
+
     file->SyncSeekRead(buf, resSz, ESeekOrigin::Begin, x50_cachedResInfo->GetOffset());
-    CInputStream* newStrm = new athena::io::MemoryReader((atUint8*)buf, resSz, !extBuf);
+
+    const bool takeOwnership = extBuf == nullptr;
+    std::unique_ptr<CInputStream> newStrm = std::make_unique<athena::io::MemoryReader>(buf, resSz, takeOwnership);
     if (x50_cachedResInfo->IsCompressed()) {
       newStrm->readUint32Big();
-      newStrm = new CZipInputStream(std::unique_ptr<CInputStream>(newStrm));
+      newStrm = std::make_unique<CZipInputStream>(std::move(newStrm));
     }
-    return std::unique_ptr<CInputStream>(newStrm);
+
+    return newStrm;
   }
-  return {};
+
+  return nullptr;
 }
 
 std::shared_ptr<IDvdRequest> CResLoader::LoadResourcePartAsync(const SObjectTag& tag, u32 off, u32 size, void* buf) {

--- a/Runtime/CSimplePool.cpp
+++ b/Runtime/CSimplePool.cpp
@@ -11,15 +11,17 @@ CSimplePool::CSimplePool(IFactory& factory)
 CSimplePool::~CSimplePool() { assert(x8_resources.empty() && "Dangling CSimplePool resources detected"); }
 
 CToken CSimplePool::GetObj(const SObjectTag& tag, const CVParamTransfer& paramXfer) {
-  if (!tag)
+  if (!tag) {
     return {};
+  }
 
-  auto iter = x8_resources.find(tag);
-  if (iter != x8_resources.end())
+  const auto iter = x8_resources.find(tag);
+  if (iter != x8_resources.end()) {
     return CToken(iter->second);
+  }
 
-  CObjectReference* ret = new CObjectReference(*this, std::unique_ptr<IObj>(), tag, paramXfer);
-  x8_resources.emplace(std::make_pair<SObjectTag, CObjectReference*>((SObjectTag)tag, std::move(ret)));
+  auto* const ret = new CObjectReference(*this, nullptr, tag, paramXfer);
+  x8_resources.emplace(tag, ret);
   return CToken(ret);
 }
 

--- a/Runtime/CStateManager.cpp
+++ b/Runtime/CStateManager.cpp
@@ -71,7 +71,7 @@ CStateManager::CStateManager(const std::weak_ptr<CRelayTracker>& relayTracker,
 , x8c0_mapWorldInfo(mwInfo)
 , x8c4_worldTransManager(wtMgr)
 , x8c8_worldLayerState(layerState) {
-  x86c_stateManagerContainer.reset(new CStateManagerContainer);
+  x86c_stateManagerContainer = std::make_unique<CStateManagerContainer>();
   x870_cameraManager = &x86c_stateManagerContainer->x0_cameraManager;
   x874_sortedListManager = &x86c_stateManagerContainer->x3c0_sortedListManager;
   x878_weaponManager = &x86c_stateManagerContainer->xe3d8_weaponManager;
@@ -2146,7 +2146,7 @@ void CStateManager::InitializeState(CAssetId mlvlId, TAreaId aid, CAssetId mreaI
 
   if (xb3c_initPhase == EInitPhase::LoadWorld) {
     CreateStandardGameObjects();
-    x850_world.reset(new CWorld(*g_SimplePool, *g_ResFactory, mlvlId));
+    x850_world = std::make_unique<CWorld>(*g_SimplePool, *g_ResFactory, mlvlId);
     xb3c_initPhase = EInitPhase::LoadFirstArea;
   }
 
@@ -2216,17 +2216,18 @@ void CStateManager::InitializeState(CAssetId mlvlId, TAreaId aid, CAssetId mreaI
 }
 
 void CStateManager::CreateStandardGameObjects() {
-  float height = g_tweakPlayer->GetPlayerHeight();
-  float xyHe = g_tweakPlayer->GetPlayerXYHalfExtent();
-  float stepUp = g_tweakPlayer->GetStepUpHeight();
-  float stepDown = g_tweakPlayer->GetStepDownHeight();
-  float ballRadius = g_tweakPlayer->GetPlayerBallHalfExtent();
-  zeus::CAABox pBounds = {{-xyHe, -xyHe, 0.f}, {xyHe, xyHe, height}};
-  auto q = zeus::CQuaternion::fromAxisAngle(zeus::CVector3f{0.f, 0.f, 1.f}, zeus::degToRad(129.6f));
-  x84c_player.reset(
-      new CPlayer(AllocateUniqueId(), zeus::CTransform(q), pBounds, g_tweakPlayerRes->xc4_ballTransitionsANCS,
-                  zeus::CVector3f{1.65f, 1.65f, 1.65f}, 200.f, stepUp, stepDown, ballRadius,
-                  CMaterialList(EMaterialTypes::Player, EMaterialTypes::Solid, EMaterialTypes::GroundCollider)));
+  const float height = g_tweakPlayer->GetPlayerHeight();
+  const float xyHe = g_tweakPlayer->GetPlayerXYHalfExtent();
+  const float stepUp = g_tweakPlayer->GetStepUpHeight();
+  const float stepDown = g_tweakPlayer->GetStepDownHeight();
+  const float ballRadius = g_tweakPlayer->GetPlayerBallHalfExtent();
+  const zeus::CAABox pBounds = {{-xyHe, -xyHe, 0.f}, {xyHe, xyHe, height}};
+  const auto q = zeus::CQuaternion::fromAxisAngle(zeus::CVector3f{0.f, 0.f, 1.f}, zeus::degToRad(129.6f));
+
+  x84c_player = std::make_unique<CPlayer>(
+      AllocateUniqueId(), zeus::CTransform(q), pBounds, g_tweakPlayerRes->xc4_ballTransitionsANCS,
+      zeus::CVector3f{1.65f, 1.65f, 1.65f}, 200.f, stepUp, stepDown, ballRadius,
+      CMaterialList(EMaterialTypes::Player, EMaterialTypes::Solid, EMaterialTypes::GroundCollider));
   AddObject(*x84c_player);
   x870_cameraManager->CreateStandardCameras(*this);
 }

--- a/Runtime/Character/CAnimTreeTimeScale.cpp
+++ b/Runtime/Character/CAnimTreeTimeScale.cpp
@@ -45,15 +45,18 @@ void CAnimTreeTimeScale::VSetPhase(float phase) { x14_child->VSetPhase(phase); }
 
 std::optional<std::unique_ptr<IAnimReader>> CAnimTreeTimeScale::VSimplified() {
   if (auto simp = x14_child->Simplified()) {
-    CAnimTreeTimeScale* newNode = new CAnimTreeTimeScale(CAnimTreeNode::Cast(std::move(*simp)), x18_timeScale->Clone(),
-                                                         x28_targetAccelTime, x4_name);
+    auto newNode = std::make_unique<CAnimTreeTimeScale>(CAnimTreeNode::Cast(std::move(*simp)), x18_timeScale->Clone(),
+                                                        x28_targetAccelTime, x4_name);
     newNode->x20_curAccelTime = x20_curAccelTime;
     newNode->x30_initialTime = x30_initialTime;
-    return {std::unique_ptr<IAnimReader>(newNode)};
-  } else if (x20_curAccelTime == x28_targetAccelTime) {
+    return {std::move(newNode)};
+  }
+
+  if (x20_curAccelTime == x28_targetAccelTime) {
     return {x14_child->Clone()};
   }
-  return {};
+
+  return std::nullopt;
 }
 
 u32 CAnimTreeTimeScale::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
@@ -112,21 +115,21 @@ CAnimTreeEffectiveContribution CAnimTreeTimeScale::VGetContributionOfHighestInfl
 
 std::shared_ptr<IAnimReader> CAnimTreeTimeScale::VGetBestUnblendedChild() const {
   if (std::shared_ptr<IAnimReader> bestChild = x14_child->VGetBestUnblendedChild()) {
-    CAnimTreeTimeScale* newNode = new CAnimTreeTimeScale(CAnimTreeNode::Cast(bestChild->Clone()),
+    auto newNode = std::make_shared<CAnimTreeTimeScale>(CAnimTreeNode::Cast(bestChild->Clone()),
                                                          x18_timeScale->Clone(), x28_targetAccelTime, x4_name);
     newNode->x20_curAccelTime = x20_curAccelTime;
     newNode->x30_initialTime = x30_initialTime;
-    return {std::shared_ptr<IAnimReader>(newNode)};
+    return {std::move(newNode)};
   }
-  return {};
+  return nullptr;
 }
 
 std::unique_ptr<IAnimReader> CAnimTreeTimeScale::VClone() const {
-  CAnimTreeTimeScale* newNode = new CAnimTreeTimeScale(CAnimTreeNode::Cast(x14_child->Clone()), x18_timeScale->Clone(),
-                                                       x28_targetAccelTime, x4_name);
+  auto newNode = std::make_unique<CAnimTreeTimeScale>(CAnimTreeNode::Cast(x14_child->Clone()), x18_timeScale->Clone(),
+                                                      x28_targetAccelTime, x4_name);
   newNode->x20_curAccelTime = x20_curAccelTime;
   newNode->x30_initialTime = x30_initialTime;
-  return {std::unique_ptr<IAnimReader>(newNode)};
+  return {std::move(newNode)};
 }
 
 CSteadyStateAnimInfo CAnimTreeTimeScale::VGetSteadyStateAnimInfo() const {

--- a/Runtime/Character/CGroundMovement.cpp
+++ b/Runtime/Character/CGroundMovement.cpp
@@ -556,15 +556,14 @@ void CGroundMovement::MoveGroundCollider_New(CStateManager& mgr, CPhysicsActor& 
   std::unique_ptr<CCollisionPrimitive> prim;
   if (usePrim->GetPrimType() == FOURCC('AABX')) {
     const CCollidableAABox& existingAABB = static_cast<const CCollidableAABox&>(*usePrim);
-    prim.reset(
-        new CCollidableAABox(zeus::CAABox(existingAABB.GetBox().min + 0.0001f, existingAABB.GetBox().max - 0.0001f),
-                             usePrim->GetMaterial()));
+    prim = std::make_unique<CCollidableAABox>(
+        zeus::CAABox(existingAABB.GetBox().min + 0.0001f, existingAABB.GetBox().max - 0.0001f), usePrim->GetMaterial());
     usePrim = prim.get();
   } else if (usePrim->GetPrimType() == FOURCC('SPHR')) {
     const CCollidableSphere& existingSphere = static_cast<const CCollidableSphere&>(*usePrim);
-    prim.reset(new CCollidableSphere(
+    prim = std::make_unique<CCollidableSphere>(
         zeus::CSphere(existingSphere.GetSphere().position, existingSphere.GetSphere().radius - 0.0001f),
-        usePrim->GetMaterial()));
+        usePrim->GetMaterial());
     usePrim = prim.get();
   }
 

--- a/Runtime/Character/CParticleDatabase.cpp
+++ b/Runtime/Character/CParticleDatabase.cpp
@@ -336,16 +336,15 @@ void CParticleDatabase::AddAuxiliaryParticleEffect(std::string_view name, int fl
   else
     scaleVec = scale * data.GetScale();
 
-  std::unique_ptr<CParticleGenInfo> newGen;
   switch (data.GetTag().type.toUint32()) {
   case SBIG('PART'): {
-    auto search = x0_particleDescs.find(data.GetTag().id);
-    if (search != x0_particleDescs.end()) {
+    const auto search = x0_particleDescs.find(data.GetTag().id);
+    if (search != x0_particleDescs.cend()) {
       auto sys = std::make_shared<CElementGen>(*search->second);
-      newGen = std::make_unique<CParticleGenInfoGeneric>(data.GetTag(), sys, data.GetDuration(), "NOT_A_VALID_LOCATOR",
-                                                         scaleVec, CParticleData::EParentedMode::Initial, flags, mgr,
-                                                         aid, lightId + _getGraphicLightId(sys, *search->second),
-                                                         EParticleGenType::Auxiliary);
+      auto newGen = std::make_unique<CParticleGenInfoGeneric>(
+          data.GetTag(), sys, data.GetDuration(), "NOT_A_VALID_LOCATOR", scaleVec,
+          CParticleData::EParentedMode::Initial, flags, mgr, aid, lightId + _getGraphicLightId(sys, *search->second),
+          EParticleGenType::Auxiliary);
 
       newGen->SetGlobalTranslation(data.GetTranslation(), mgr);
       newGen->SetIsGrabInitialData(false);
@@ -380,8 +379,8 @@ void CParticleDatabase::AddParticleEffect(std::string_view name, int flags, cons
   std::unique_ptr<CParticleGenInfo> newGen;
   switch (data.GetTag().type.toUint32()) {
   case SBIG('PART'): {
-    auto search = x0_particleDescs.find(data.GetTag().id);
-    if (search != x0_particleDescs.end()) {
+    const auto search = x0_particleDescs.find(data.GetTag().id);
+    if (search != x0_particleDescs.cend()) {
       auto sys = std::make_shared<CElementGen>(*search->second);
       newGen = std::make_unique<CParticleGenInfoGeneric>(
           data.GetTag(), sys, data.GetDuration(), data.GetSegmentName(), scaleVec, data.GetParentedMode(), flags, mgr,
@@ -390,8 +389,8 @@ void CParticleDatabase::AddParticleEffect(std::string_view name, int flags, cons
     break;
   }
   case SBIG('SWHC'): {
-    auto search = x14_swooshDescs.find(data.GetTag().id);
-    if (search != x14_swooshDescs.end()) {
+    const auto search = x14_swooshDescs.find(data.GetTag().id);
+    if (search != x14_swooshDescs.cend()) {
       auto sys = std::make_shared<CParticleSwoosh>(*search->second, 0);
       newGen = std::make_unique<CParticleGenInfoGeneric>(data.GetTag(), sys, data.GetDuration(), data.GetSegmentName(),
                                                          scaleVec, data.GetParentedMode(), flags, mgr, aid, -1,
@@ -400,8 +399,8 @@ void CParticleDatabase::AddParticleEffect(std::string_view name, int flags, cons
     break;
   }
   case SBIG('ELSC'): {
-    auto search = x28_electricDescs.find(data.GetTag().id);
-    if (search != x28_electricDescs.end()) {
+    const auto search = x28_electricDescs.find(data.GetTag().id);
+    if (search != x28_electricDescs.cend()) {
       auto sys = std::make_shared<CParticleElectric>(*search->second);
       newGen = std::make_unique<CParticleGenInfoGeneric>(
           data.GetTag(), sys, data.GetDuration(), data.GetSegmentName(), scaleVec, data.GetParentedMode(), flags, mgr,

--- a/Runtime/Collision/CCollidableOBBTreeGroup.cpp
+++ b/Runtime/Collision/CCollidableOBBTreeGroup.cpp
@@ -12,11 +12,11 @@ const CCollisionPrimitive::Type CCollidableOBBTreeGroup::sType(CCollidableOBBTre
 u32 CCollidableOBBTreeGroup::sTableIndex = -1;
 
 CCollidableOBBTreeGroupContainer::CCollidableOBBTreeGroupContainer(CInputStream& in) {
-  u32 treeCount = in.readUint32Big();
+  const u32 treeCount = in.readUint32Big();
   x0_trees.reserve(treeCount);
 
   for (u32 i = 0; i < treeCount; i++) {
-    std::unique_ptr<COBBTree> tree(new COBBTree(in));
+    auto tree = std::make_unique<COBBTree>(in);
     x0_trees.push_back(std::move(tree));
   }
 

--- a/Runtime/Collision/CCollisionActor.cpp
+++ b/Runtime/Collision/CCollisionActor.cpp
@@ -20,8 +20,8 @@ CCollisionActor::CCollisionActor(TUniqueId uid1, TAreaId aId, TUniqueId uid2, co
 , x25c_owner(uid2)
 , x260_boxSize(extent)
 , x26c_center(center)
-, x278_obbContainer(new CCollidableOBBTreeGroupContainer(extent, center))
-, x27c_obbTreeGroupPrimitive(new CCollidableOBBTreeGroup(x278_obbContainer.get(), GetMaterialList())) {
+, x278_obbContainer(std::make_unique<CCollidableOBBTreeGroupContainer>(extent, center))
+, x27c_obbTreeGroupPrimitive(std::make_unique<CCollidableOBBTreeGroup>(x278_obbContainer.get(), GetMaterialList())) {
   x10_name += ' ';
   x10_name += name;
   SetCoefficientOfRestitutionModifier(0.5f);
@@ -38,8 +38,9 @@ CCollisionActor::CCollisionActor(TUniqueId uid1, TAreaId aId, TUniqueId uid2, co
 , x258_primitiveType(EPrimitiveType::AABox)
 , x25c_owner(uid2)
 , x260_boxSize(boxSize)
-, x280_aaboxPrimitive(new CCollidableAABox(zeus::CAABox(-0.5f * boxSize, 0.5f * boxSize),
-                                           CMaterialList(EMaterialTypes::Solid, EMaterialTypes::NoStaticCollision))) {
+, x280_aaboxPrimitive(
+      std::make_unique<CCollidableAABox>(zeus::CAABox(-0.5f * boxSize, 0.5f * boxSize),
+                                         CMaterialList(EMaterialTypes::Solid, EMaterialTypes::NoStaticCollision))) {
   x10_name += ' ';
   x10_name += name;
   SetCoefficientOfRestitutionModifier(0.5f);
@@ -55,8 +56,8 @@ CCollisionActor::CCollisionActor(TUniqueId uid1, TAreaId aId, TUniqueId uid2, bo
                 zeus::skNullBox, SMoverData(mass), CActorParameters::None(), 0.3f, 0.1f)
 , x258_primitiveType(EPrimitiveType::Sphere)
 , x25c_owner(uid2)
-, x284_spherePrimitive(new CCollidableSphere(zeus::CSphere(zeus::skZero3f, radius),
-                                             CMaterialList(EMaterialTypes::NoStaticCollision, EMaterialTypes::Solid)))
+, x284_spherePrimitive(std::make_unique<CCollidableSphere>(
+      zeus::CSphere(zeus::skZero3f, radius), CMaterialList(EMaterialTypes::NoStaticCollision, EMaterialTypes::Solid)))
 , x288_sphereRadius(radius) {
   x10_name += ' ';
   x10_name += name;

--- a/Runtime/Collision/CCollisionPrimitive.cpp
+++ b/Runtime/Collision/CCollisionPrimitive.cpp
@@ -149,13 +149,13 @@ bool CCollisionPrimitive::CollideMoving(const CInternalCollisionStructure::CPrim
 }
 
 void CCollisionPrimitive::InitBeginTypes() {
-  sCollisionTypeList.reset(new std::vector<CCollisionPrimitive::Type>());
+  sCollisionTypeList = std::make_unique<std::vector<Type>>();
   sCollisionTypeList->reserve(3);
   sTypesAdding = true;
   InternalColliders::AddTypes();
 }
 
-void CCollisionPrimitive::InitAddType(const CCollisionPrimitive::Type& tp) {
+void CCollisionPrimitive::InitAddType(const Type& tp) {
   tp.GetSetter()(sCollisionTypeList->size());
   sCollisionTypeList->push_back(tp);
 }
@@ -168,13 +168,10 @@ void CCollisionPrimitive::InitEndTypes() {
 }
 
 void CCollisionPrimitive::InitBeginColliders() {
-  sTableOfCollidables.reset(new std::vector<ComparisonFunc>());
-  sTableOfBooleanCollidables.reset(new std::vector<BooleanComparisonFunc>());
-  sTableOfMovingCollidables.reset(new std::vector<MovingComparisonFunc>());
-  size_t tableSz = sCollisionTypeList->size() * sCollisionTypeList->size();
-  sTableOfCollidables->resize(tableSz);
-  sTableOfBooleanCollidables->resize(tableSz);
-  sTableOfMovingCollidables->resize(tableSz);
+  const size_t tableSz = sCollisionTypeList->size() * sCollisionTypeList->size();
+  sTableOfCollidables = std::make_unique<std::vector<ComparisonFunc>>(tableSz);
+  sTableOfBooleanCollidables = std::make_unique<std::vector<BooleanComparisonFunc>>(tableSz);
+  sTableOfMovingCollidables = std::make_unique<std::vector<MovingComparisonFunc>>(tableSz);
   sCollidersAdding = true;
   InternalColliders::AddColliders();
 }

--- a/Runtime/Collision/CCollisionResponseData.cpp
+++ b/Runtime/Collision/CCollisionResponseData.cpp
@@ -232,7 +232,6 @@ FourCC CCollisionResponseData::UncookedResType() { return SBIG('CRSM'); }
 CFactoryFnReturn FCollisionResponseDataFactory(const SObjectTag& tag, CInputStream& in, const CVParamTransfer& vparms,
                                                CObjectReference*) {
   CSimplePool* sp = vparms.GetOwnedObj<CSimplePool*>();
-  return TToken<CCollisionResponseData>::GetIObjObjectFor(
-      std::unique_ptr<CCollisionResponseData>(new CCollisionResponseData(in, sp)));
+  return TToken<CCollisionResponseData>::GetIObjObjectFor(std::make_unique<CCollisionResponseData>(in, sp));
 }
 } // namespace urde

--- a/Runtime/Collision/COBBTree.cpp
+++ b/Runtime/Collision/COBBTree.cpp
@@ -13,7 +13,7 @@ COBBTree::COBBTree(CInputStream& in)
 , x4_version(verify_version(in))
 , x8_memsize(in.readUint32())
 , x18_indexData(in)
-, x88_root(new CNode(in)) {}
+, x88_root(std::make_unique<CNode>(in)) {}
 
 static const u8 DefaultEdgeMaterials[] = {
   2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 0, 2, 0, 0, 2, 2
@@ -168,10 +168,10 @@ COBBTree::CNode::CNode(CInputStream& in) {
   x0_obb = zeus::COBBox::ReadBig(in);
   x3c_isLeaf = in.readBool();
   if (x3c_isLeaf)
-    x48_leaf.reset(new CLeafData(in));
+    x48_leaf = std::make_unique<CLeafData>(in);
   else {
-    x40_left.reset(new CNode(in));
-    x44_right.reset(new CNode(in));
+    x40_left = std::make_unique<CNode>(in);
+    x44_right = std::make_unique<CNode>(in);
   }
 }
 

--- a/Runtime/GuiSys/CGuiFrame.cpp
+++ b/Runtime/GuiSys/CGuiFrame.cpp
@@ -18,9 +18,9 @@ CGuiFrame::CGuiFrame(CAssetId id, CGuiSys& sys, int a, int b, int c, CSimplePool
 : x0_id(id), x8_guiSys(sys), x4c_a(a), x50_b(b), x54_c(c), x58_24_loaded(false) {
   x3c_lights.reserve(8);
   m_indexedLights.reserve(8);
-  x10_rootWidget.reset(new CGuiWidget(CGuiWidget::CGuiWidgetParms(
+  x10_rootWidget = std::make_unique<CGuiWidget>(CGuiWidget::CGuiWidgetParms(
       this, false, 0, 0, false, false, false, zeus::skWhite, CGuiWidget::EGuiModelDrawFlags::Alpha, false,
-      x8_guiSys.x8_mode != CGuiSys::EUsageMode::Zero, "<root>"s)));
+      x8_guiSys.x8_mode != CGuiSys::EUsageMode::Zero, "<root>"s));
   x8_guiSys.m_registeredFrames.insert(this);
 }
 

--- a/Runtime/GuiSys/CGuiSys.cpp
+++ b/Runtime/GuiSys/CGuiSys.cpp
@@ -61,8 +61,8 @@ CGuiSys::CGuiSys(IFactory& resFactory, CSimplePool& resStore, EUsageMode mode)
 : x0_resFactory(resFactory)
 , x4_resStore(resStore)
 , x8_mode(mode)
-, xc_textExecuteBuf(new CTextExecuteBuffer())
-, x10_textParser(new CTextParser(resStore)) {
+, xc_textExecuteBuf(std::make_unique<CTextExecuteBuffer>())
+, x10_textParser(std::make_unique<CTextParser>(resStore)) {
   g_TextExecuteBuf = xc_textExecuteBuf.get();
   g_TextParser = x10_textParser.get();
 }

--- a/Runtime/MP1/MP1.cpp
+++ b/Runtime/MP1/MP1.cpp
@@ -361,14 +361,17 @@ void CMain::InitializeSubsystems() {
 }
 
 void CMain::MemoryCardInitializePump() {
-  if (!g_MemoryCardSys) {
-    std::unique_ptr<CMemoryCardSys>& memSys = x128_globalObjects.x0_memoryCardSys;
-    if (!memSys)
-      memSys.reset(new CMemoryCardSys());
-    if (memSys->InitializePump()) {
-      g_MemoryCardSys = memSys.get();
-      g_GameState->InitializeMemoryStates();
-    }
+  if (g_MemoryCardSys) {
+    return;
+  }
+
+  std::unique_ptr<CMemoryCardSys>& memSys = x128_globalObjects.x0_memoryCardSys;
+  if (!memSys) {
+    memSys = std::make_unique<CMemoryCardSys>();
+  }
+  if (memSys->InitializePump()) {
+    g_MemoryCardSys = memSys.get();
+    g_GameState->InitializeMemoryStates();
   }
 }
 
@@ -728,7 +731,7 @@ void CMain::Init(const hecl::Runtime::FileStoreManager& storeMgr, hecl::CVarMana
   }
 
   FillInAssetIDs();
-  x164_archSupport.reset(new CGameArchitectureSupport(*this, voiceEngine, backend));
+  x164_archSupport = std::make_unique<CGameArchitectureSupport>(*this, voiceEngine, backend);
   g_archSupport = x164_archSupport.get();
   x164_archSupport->PreloadAudio();
   std::srand(static_cast<unsigned int>(std::time(nullptr)));

--- a/Runtime/MP1/MP1.hpp
+++ b/Runtime/MP1/MP1.hpp
@@ -76,18 +76,18 @@ public:
   CGameGlobalObjects(IFactory* resFactory, CSimplePool* objStore)
   : x4_resFactory(resFactory), xcc_simplePool(objStore) {
     if (!x4_resFactory) {
-      m_gameResFactory.reset(new CResFactory());
+      m_gameResFactory = std::make_unique<CResFactory>();
       x4_resFactory = m_gameResFactory.get();
     }
     if (!xcc_simplePool) {
-      m_gameSimplePool.reset(new CSimplePool(*x4_resFactory));
+      m_gameSimplePool = std::make_unique<CSimplePool>(*x4_resFactory);
       xcc_simplePool = m_gameSimplePool.get();
     }
     g_ResFactory = x4_resFactory;
     g_SimplePool = xcc_simplePool;
     g_CharFactoryBuilder = &xec_charFactoryBuilder;
     g_AiFuncMap = &x110_aiFuncMap;
-    x134_gameState.reset(new CGameState());
+    x134_gameState = std::make_unique<CGameState>();
     g_GameState = x134_gameState.get();
     g_TweakManager = &x150_tweakManager;
   }
@@ -104,12 +104,12 @@ public:
   }
 
   void ResetGameState() {
-    x134_gameState.reset(new CGameState());
+    x134_gameState = std::make_unique<CGameState>();
     g_GameState = x134_gameState.get();
   }
 
   void StreamInGameState(CBitStreamReader& stream, u32 saveIdx) {
-    x134_gameState.reset(new CGameState(stream, saveIdx));
+    x134_gameState = std::make_unique<CGameState>(stream, saveIdx);
     g_GameState = x134_gameState.get();
   }
 };

--- a/Runtime/MP1/World/CBabygoth.cpp
+++ b/Runtime/MP1/World/CBabygoth.cpp
@@ -298,7 +298,7 @@ void CBabygoth::AddSphereCollisionList(const SSphereJointInfo* sphereJointInfo, 
 void CBabygoth::SetupCollisionManager(CStateManager& mgr) {
   std::vector<CJointCollisionDescription> joints;
   AddSphereCollisionList(skSphereJointList, skSphereJointCount, joints);
-  x928_colActMgr.reset(new CCollisionActorManager(mgr, GetUniqueId(), GetAreaIdAlways(), joints, false));
+  x928_colActMgr = std::make_unique<CCollisionActorManager>(mgr, GetUniqueId(), GetAreaIdAlways(), joints, false);
   x928_colActMgr->SetActive(mgr, GetActive());
 
   for (u32 i = 0; i < x928_colActMgr->GetNumCollisionActors(); ++i) {

--- a/Runtime/MP1/World/CBloodFlower.cpp
+++ b/Runtime/MP1/World/CBloodFlower.cpp
@@ -18,7 +18,7 @@ CBloodFlower::CBloodFlower(TUniqueId uid, std::string_view name, const CEntityIn
 : CPatterned(ECharacter::BloodFlower, uid, name, EFlavorType::Zero, info, xf, std::move(mData), pInfo,
              EMovementType::Ground, EColliderType::One, EBodyType::Restricted, actParms, EKnockBackVariant::Medium)
 , x568_podEffectDesc(g_SimplePool->GetObj({FOURCC('PART'), partId1}))
-, x574_podEffect(new CElementGen(x568_podEffectDesc))
+, x574_podEffect(std::make_unique<CElementGen>(x568_podEffectDesc))
 , x578_projectileDesc(g_SimplePool->GetObj({FOURCC('WPSC'), wpscId1}))
 , x590_projectileInfo(wpscId2, dInfo1)
 , x5d4_visorSfx(CSfxManager::TranslateSFXID(soundId))

--- a/Runtime/MP1/World/CFlaahgra.cpp
+++ b/Runtime/MP1/World/CFlaahgra.cpp
@@ -345,8 +345,9 @@ void CFlaahgra::ResetModelDataAndBodyController() {
   CreateShadow(true);
   x94_simpleShadow->SetAlwaysCalculateRadius(false);
   BuildBodyController(EBodyType::Restricted);
-  x6cc_boneTracking.reset(new CBoneTracking(*GetModelData()->GetAnimationData(), "Head_1"sv, zeus::degToRad(80.f),
-                                            zeus::degToRad(180.f), EBoneTrackingFlags::None));
+  x6cc_boneTracking =
+      std::make_unique<CBoneTracking>(*GetModelData()->GetAnimationData(), "Head_1"sv, zeus::degToRad(80.f),
+                                      zeus::degToRad(180.f), EBoneTrackingFlags::None);
 }
 void CFlaahgra::GatherAssets(CStateManager& mgr) {
   if (x8e4_24_loaded)
@@ -488,19 +489,20 @@ void CFlaahgra::SetupCollisionManagers(CStateManager& mgr) {
   zeus::CVector3f oldScale = GetModelData()->GetScale();
   leftArmjointList.reserve(3);
   AddCollisionList(skLeftArmJointList, 3, leftArmjointList);
-  x79c_leftArmCollision.reset(
-      new CCollisionActorManager(mgr, GetUniqueId(), GetAreaIdAlways(), leftArmjointList, true));
+  x79c_leftArmCollision =
+      std::make_unique<CCollisionActorManager>(mgr, GetUniqueId(), GetAreaIdAlways(), leftArmjointList, true);
   SetMaterialProperties(x79c_leftArmCollision, mgr);
   std::vector<CJointCollisionDescription> rightArmJointList;
   rightArmJointList.reserve(3);
   AddCollisionList(skRightArmJointList, 3, rightArmJointList);
-  x7a0_rightArmCollision.reset(
-      new CCollisionActorManager(mgr, GetUniqueId(), GetAreaIdAlways(), rightArmJointList, true));
+  x7a0_rightArmCollision =
+      std::make_unique<CCollisionActorManager>(mgr, GetUniqueId(), GetAreaIdAlways(), rightArmJointList, true);
   SetMaterialProperties(x7a0_rightArmCollision, mgr);
   std::vector<CJointCollisionDescription> sphereJointList;
   sphereJointList.reserve(5);
   AddSphereCollisionList(skSphereJointList, 5, sphereJointList);
-  x7a4_sphereCollision.reset(new CCollisionActorManager(mgr, GetUniqueId(), GetAreaIdAlways(), sphereJointList, true));
+  x7a4_sphereCollision =
+      std::make_unique<CCollisionActorManager>(mgr, GetUniqueId(), GetAreaIdAlways(), sphereJointList, true);
   SetMaterialProperties(x7a4_sphereCollision, mgr);
   SetupHealthInfo(mgr);
   SetMaterialFilter(CMaterialFilter::MakeIncludeExclude(
@@ -1208,7 +1210,7 @@ CFlaahgraPlants::CFlaahgraPlants(const TToken<CGenDescription>& genDesc, const C
                                  const CDamageInfo& dInfo, const zeus::CVector3f& extents)
 : CActor(uid, true, "Flaahgra Plants"sv, CEntityInfo(aId, NullConnectionList), xf, CModelData::CModelDataNull(),
          CMaterialList(EMaterialTypes::Projectile), actParms, kInvalidUniqueId)
-, xe8_elementGen(new CElementGen(genDesc))
+, xe8_elementGen(std::make_unique<CElementGen>(genDesc))
 , xf0_ownerId(owner)
 , x130_obbox(xf, extents) {
   xe8_elementGen->SetOrientation(xf.getRotation());

--- a/Runtime/MP1/World/CFlaahgraTentacle.cpp
+++ b/Runtime/MP1/World/CFlaahgraTentacle.cpp
@@ -103,7 +103,8 @@ const SSphereJointInfo CFlaahgraTentacle::skJointList[3] = {{"Arm_8", 2.f}, {"Ar
 void CFlaahgraTentacle::SetupCollisionManager(CStateManager& mgr) {
   std::vector<CJointCollisionDescription> jointList;
   AddSphereCollisionList(skJointList, 3, jointList);
-  x56c_collisionManager.reset(new CCollisionActorManager(mgr, GetUniqueId(), GetAreaIdAlways(), jointList, true));
+  x56c_collisionManager =
+      std::make_unique<CCollisionActorManager>(mgr, GetUniqueId(), GetAreaIdAlways(), jointList, true);
 
   for (u32 i = 0; i < x56c_collisionManager->GetNumCollisionActors(); ++i) {
     const CJointCollisionDescription& desc = x56c_collisionManager->GetCollisionDescFromIndex(i);

--- a/Runtime/MP1/World/CMetroidBeta.cpp
+++ b/Runtime/MP1/World/CMetroidBeta.cpp
@@ -51,11 +51,11 @@ CMetroidBeta::CMetroidBeta(TUniqueId uid, std::string_view name, const CEntityIn
 , x7fc_(g_SimplePool->GetObj({FOURCC('PART'), metroidData.xfc_}))
 , x808_(g_SimplePool->GetObj({FOURCC('PART'), metroidData.x100_}))
 , x814_(g_SimplePool->GetObj({FOURCC('PART'), metroidData.x104_}))
-, x820_(new CElementGen(x7e4_))
-, x824_(new CParticleSwoosh(x7f0_, 0))
-, x828_(new CElementGen(x7fc_))
-, x82c_(new CElementGen(x808_))
-, x830_(new CElementGen(x814_)) {
+, x820_(std::make_unique<CElementGen>(x7e4_))
+, x824_(std::make_unique<CParticleSwoosh>(x7f0_, 0))
+, x828_(std::make_unique<CElementGen>(x7fc_))
+, x82c_(std::make_unique<CElementGen>(x808_))
+, x830_(std::make_unique<CElementGen>(x814_)) {
   x820_->SetParticleEmission(false);
   x828_->SetParticleEmission(false);
   x82c_->SetParticleEmission(false);
@@ -237,7 +237,8 @@ void CMetroidBeta::CreateCollisionActorManager(CStateManager& mgr) {
   std::vector<CJointCollisionDescription> joints;
   AddSphereJoints(skPelvisInfo, 1, joints);
 
-  x764_collisionManager.reset(new CCollisionActorManager(mgr, GetUniqueId(), GetAreaIdAlways(), joints, false));
+  x764_collisionManager =
+      std::make_unique<CCollisionActorManager>(mgr, GetUniqueId(), GetAreaIdAlways(), joints, false);
   x764_collisionManager->SetActive(mgr, GetActive());
 
   for (u32 i = 0; i < x764_collisionManager->GetNumCollisionActors(); ++i) {

--- a/Runtime/MP1/World/CPuddleSpore.cpp
+++ b/Runtime/MP1/World/CPuddleSpore.cpp
@@ -37,7 +37,7 @@ CPuddleSpore::CPuddleSpore(TUniqueId uid, std::string_view name, EFlavorType fla
 , x614_25(false) {
   x5dc_elemGens.reserve(kEyeCount);
   for (u32 i = 0; i < kEyeCount; ++i)
-    x5dc_elemGens.emplace_back(new CElementGen(x5d0_));
+    x5dc_elemGens.emplace_back(std::make_unique<CElementGen>(x5d0_));
   x5ec_projectileInfo.Token().Lock();
   x460_knockBackController.SetAutoResetImpulse(false);
 }

--- a/Runtime/MP1/World/CPuddleToadGamma.cpp
+++ b/Runtime/MP1/World/CPuddleToadGamma.cpp
@@ -39,7 +39,7 @@ CPuddleToadGamma::CPuddleToadGamma(TUniqueId uid, std::string_view name, EFlavor
   SetMovable(false);
   if (dcln.IsValid() && g_ResFactory->GetResourceTypeById(dcln) != 0) {
     TLockedToken<CCollidableOBBTreeGroupContainer> container = g_SimplePool->GetObj({FOURCC('DCLN'), dcln});
-    x5e4_collisionTreePrim.reset(new CCollidableOBBTreeGroup(container.GetObj(), GetMaterialList()));
+    x5e4_collisionTreePrim = std::make_unique<CCollidableOBBTreeGroup>(container.GetObj(), GetMaterialList());
   }
 }
 

--- a/Runtime/MP1/World/CSeedling.cpp
+++ b/Runtime/MP1/World/CSeedling.cpp
@@ -17,7 +17,7 @@ CSeedling::CSeedling(TUniqueId uid, std::string_view name, const CEntityInfo& in
               EMovementType::Ground, EColliderType::Zero, EBodyType::WallWalker, actParms, f1, f2,
               EKnockBackVariant::Small, f3, EWalkerType::Seedling, f4, false)
 , x5d8_searchPath(nullptr, 1, pInfo.GetPathfindingIndex(), 1.f, 1.f)
-, x6bc_spikeData(new CModelData(CStaticRes(needleId, GetModelData()->GetScale())))
+, x6bc_spikeData(std::make_unique<CModelData>(CStaticRes(needleId, GetModelData()->GetScale())))
 , x6c0_projectileInfo(weaponId, dInfo1)
 , x6e8_deathDamage(dInfo2)
 , x722_24_renderOnlyClusterA(true)

--- a/Runtime/MP1/World/CSpankWeed.cpp
+++ b/Runtime/MP1/World/CSpankWeed.cpp
@@ -76,7 +76,8 @@ void CSpankWeed::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CState
         joints.push_back(CJointCollisionDescription::SphereCollision(id, joint.radius, joint.name, 0.001f));
     }
 
-    x594_collisionMgr.reset(new CCollisionActorManager(mgr, GetUniqueId(), GetAreaIdAlways(), joints, GetActive()));
+    x594_collisionMgr =
+        std::make_unique<CCollisionActorManager>(mgr, GetUniqueId(), GetAreaIdAlways(), joints, GetActive());
     CMaterialList list;
     list.Add(EMaterialTypes::CameraPassthrough);
     list.Add(EMaterialTypes::Immovable);

--- a/Runtime/Particle/CElementGen.cpp
+++ b/Runtime/Particle/CElementGen.cpp
@@ -567,8 +567,8 @@ void CElementGen::UpdatePSTranslationAndOrientation() {
 }
 
 std::unique_ptr<CParticleGen> CElementGen::ConstructChildParticleSystem(const TToken<CGenDescription>& desc) const {
-  CElementGen* ret = new CElementGen(desc, EModelOrientationType::Normal,
-                                     x26d_27_enableOPTS ? EOptionalSystemFlags::Two : EOptionalSystemFlags::One);
+  auto ret = std::make_unique<CElementGen>(desc, EModelOrientationType::Normal,
+                                           x26d_27_enableOPTS ? EOptionalSystemFlags::Two : EOptionalSystemFlags::One);
   ret->x26d_26_modelsUseLights = x26d_26_modelsUseLights;
   ret->SetGlobalTranslation(xe8_globalTranslation);
   ret->SetGlobalOrientation(x22c_globalOrientation);
@@ -578,7 +578,7 @@ std::unique_ptr<CParticleGen> CElementGen::ConstructChildParticleSystem(const TT
   ret->SetOrientation(x1d8_orientation);
   ret->SetParticleEmission(x88_particleEmission);
   ret->SetModulationColor(x338_moduColor);
-  return std::unique_ptr<CParticleGen>(ret);
+  return ret;
 }
 
 void CElementGen::UpdateChildParticleSystems(double dt) {

--- a/Runtime/Particle/CParticleDataFactory.cpp
+++ b/Runtime/Particle/CParticleDataFactory.cpp
@@ -761,7 +761,7 @@ bool CParticleDataFactory::CreateGPSM(CGenDescription* fillDesc, CInputStream& i
       FourCC cid = GetClassID(in);
       if (cid != SBIG('CNST'))
         break;
-      fillDesc->xd0_xbc_KSSM.reset(new CSpawnSystemKeyframeData(in));
+      fillDesc->xd0_xbc_KSSM = std::make_unique<CSpawnSystemKeyframeData>(in);
       fillDesc->xd0_xbc_KSSM->LoadAllSpawnedSystemTokens(resPool);
       break;
     }

--- a/Runtime/Weapon/CBomb.cpp
+++ b/Runtime/Weapon/CBomb.cpp
@@ -20,10 +20,10 @@ CBomb::CBomb(const TCachedToken<CGenDescription>& particle1, const TCachedToken<
           {EMaterialTypes::Projectile, EMaterialTypes::Bomb}, dInfo, EProjectileAttrib::Bombs,
           CModelData::CModelDataNull())
 , x17c_fuseTime(f1)
-, x180_particle1(
-      new CElementGen(particle1, CElementGen::EModelOrientationType::Normal, CElementGen::EOptionalSystemFlags::One))
-, x184_particle2(
-      new CElementGen(particle2, CElementGen::EModelOrientationType::Normal, CElementGen::EOptionalSystemFlags::One))
+, x180_particle1(std::make_unique<CElementGen>(particle1, CElementGen::EModelOrientationType::Normal,
+                                               CElementGen::EOptionalSystemFlags::One))
+, x184_particle2(std::make_unique<CElementGen>(particle2, CElementGen::EModelOrientationType::Normal,
+                                               CElementGen::EOptionalSystemFlags::One))
 , x18c_particle2Obj(particle2.GetObj())
 , x190_24_isNotDetonated(true)
 , x190_25_beingDragged(false)

--- a/Runtime/Weapon/CElectricBeamProjectile.cpp
+++ b/Runtime/Weapon/CElectricBeamProjectile.cpp
@@ -15,9 +15,9 @@ CElectricBeamProjectile::CElectricBeamProjectile(const TToken<CWeaponDescription
                                                  TAreaId areaId, TUniqueId owner, EProjectileAttrib attribs)
 : CBeamProjectile(wDesc, "ElectricBeamProjectile"sv, wType, xf, u32(elec.x8_maxLength), elec.xc_radius,
                   elec.x10_travelSpeed, matTypes, dInfo, uid, areaId, owner, attribs, false)
-, x468_electric(new CParticleElectric(elec.x0_electricDescription))
+, x468_electric(std::make_unique<CParticleElectric>(elec.x0_electricDescription))
 , x46c_genDescription(g_SimplePool->GetObj({SBIG('PART'), elec.x14_particleId}))
-, x478_elementGen(new CElementGen(x46c_genDescription))
+, x478_elementGen(std::make_unique<CElementGen>(x46c_genDescription))
 , x47c_(elec.x18_)
 , x488_(elec.x1c_) {
   x478_elementGen->SetParticleEmission(false);

--- a/Runtime/Weapon/CFlameThrower.cpp
+++ b/Runtime/Weapon/CFlameThrower.cpp
@@ -24,7 +24,7 @@ CFlameThrower::CFlameThrower(const TToken<CWeaponDescription>& wDesc, std::strin
 , x2e8_flameXf(xf)
 , x338_(flameInfo.x10_)
 , x33c_flameDesc(g_SimplePool->GetObj({FOURCC('PART'), flameInfo.GetFlameFxId()}))
-, x348_flameGen(new CElementGen(x33c_flameDesc))
+, x348_flameGen(std::make_unique<CElementGen>(x33c_flameDesc))
 , x34c_flameWarp(176.f - float(flameInfo.GetLength()), xf.origin, bool(flameInfo.GetAttributes() & 0x4))
 , x3f4_playerSteamTxtr(playerSteamTxtr)
 , x3f8_playerHitSfx(playerHitSfx)
@@ -80,7 +80,7 @@ void CFlameThrower::Fire(const zeus::CTransform&, CStateManager& mgr, bool) {
 
 void CFlameThrower::CreateFlameParticles(CStateManager& mgr) {
   DeleteProjectileLight(mgr);
-  x348_flameGen.reset(new CElementGen(x33c_flameDesc));
+  x348_flameGen = std::make_unique<CElementGen>(x33c_flameDesc);
   x348_flameGen->SetParticleEmission(true);
   x348_flameGen->SetZTest(x400_27_coneCollision);
   x348_flameGen->AddModifier(&x34c_flameWarp);

--- a/Runtime/Weapon/CPlayerGun.cpp
+++ b/Runtime/Weapon/CPlayerGun.cpp
@@ -107,7 +107,7 @@ void CPlayerGun::InitBombData() {
 void CPlayerGun::InitMuzzleData() {
   for (int i = 0; i < 5; ++i) {
     x7c0_auxMuzzleEffects.push_back(g_SimplePool->GetObj(SObjectTag{FOURCC('PART'), g_tweakGunRes->xa4_auxMuzzle[i]}));
-    x800_auxMuzzleGenerators.emplace_back(new CElementGen(x7c0_auxMuzzleEffects.back()));
+    x800_auxMuzzleGenerators.emplace_back(std::make_unique<CElementGen>(x7c0_auxMuzzleEffects.back()));
     x800_auxMuzzleGenerators.back()->SetParticleEmission(false);
   }
 }

--- a/Runtime/Weapon/CPowerBomb.cpp
+++ b/Runtime/Weapon/CPowerBomb.cpp
@@ -24,7 +24,7 @@ CPowerBomb::CPowerBomb(const TToken<CGenDescription>& particle, TUniqueId uid, T
 , x158_24_canStartFilter(true)
 , x158_25_filterEnabled(false)
 , x164_radiusIncrement(dInfo.GetRadius() / 2.5f)
-, x168_particle(new CElementGen(particle))
+, x168_particle(std::make_unique<CElementGen>(particle))
 , x16c_radius(dInfo.GetRadius()) {
   x168_particle->SetGlobalTranslation(GetTranslation());
 }

--- a/Runtime/World/CActor.cpp
+++ b/Runtime/World/CActor.cpp
@@ -32,7 +32,7 @@ CActor::CActor(TUniqueId uid, bool active, std::string_view name, const CEntityI
 , x68_material(MakeActorMaterialList(list, params))
 , x70_materialFilter(CMaterialFilter::MakeIncludeExclude({EMaterialTypes::Solid}, {0ull}))
 , xc6_nextDrawNode(otherUid) {
-  x90_actorLights = mData.IsNull() ? std::unique_ptr<CActorLights>() : params.x0_lightParms.MakeActorLights();
+  x90_actorLights = mData.IsNull() ? nullptr : params.x0_lightParms.MakeActorLights();
   if (mData.x10_animData || mData.x1c_normalModel)
     x64_modelData = std::make_unique<CModelData>(std::move(mData));
   xd0_damageMag = params.x64_thermalMag;
@@ -431,8 +431,9 @@ void CActor::CreateShadow(bool b) {
 }
 
 void CActor::_CreateShadow() {
-  if (!x94_simpleShadow && x64_modelData && (x64_modelData->HasAnimData() || x64_modelData->HasNormalModel()))
-    x94_simpleShadow.reset(new CSimpleShadow(1.f, 1.f, 20.f, 0.05f));
+  if (!x94_simpleShadow && x64_modelData && (x64_modelData->HasAnimData() || x64_modelData->HasNormalModel())) {
+    x94_simpleShadow = std::make_unique<CSimpleShadow>(1.f, 1.f, 20.f, 0.05f);
+  }
 }
 
 void CActor::_CreateReflectionCube() {

--- a/Runtime/World/CFire.cpp
+++ b/Runtime/World/CFire.cpp
@@ -14,7 +14,7 @@ CFire::CFire(TToken<CGenDescription> effect, TUniqueId uid, TAreaId aId, bool ac
              float f3, float f4)
 : CActor(uid, active, "Fire"sv, CEntityInfo(aId, NullConnectionList), xf, CModelData::CModelDataNull(),
          CMaterialList(EMaterialTypes::Projectile), CActorParameters::None(), owner)
-, xe8_(new CElementGen(effect))
+, xe8_(std::make_unique<CElementGen>(effect))
 , xec_ownerId(owner)
 , xf0_damageInfo(dInfo)
 , x10c_damageInfo(dInfo)

--- a/Runtime/World/CFishCloud.cpp
+++ b/Runtime/World/CFishCloud.cpp
@@ -50,10 +50,10 @@ CFishCloud::CFishCloud(TUniqueId uid, bool active, std::string_view name, const 
   x108_modifierSources.reserve(10);
   x250_25_worldSpace = true; // The result of a close_enough paradox (weird inlined test?)
   if (aRes.GetId().IsValid()) {
-    x1b0_models.emplace_back(new CModelData(aRes));
-    x1b0_models.emplace_back(new CModelData(aRes));
-    x1b0_models.emplace_back(new CModelData(aRes));
-    x1b0_models.emplace_back(new CModelData(aRes));
+    x1b0_models.emplace_back(std::make_unique<CModelData>(aRes));
+    x1b0_models.emplace_back(std::make_unique<CModelData>(aRes));
+    x1b0_models.emplace_back(std::make_unique<CModelData>(aRes));
+    x1b0_models.emplace_back(std::make_unique<CModelData>(aRes));
     x250_27_validModel = true;
   }
   if (part1.IsValid())
@@ -65,7 +65,7 @@ CFishCloud::CFishCloud(TUniqueId uid, bool active, std::string_view name, const 
   if (part4.IsValid())
     x1c4_particleDescs.push_back(g_SimplePool->GetObj({FOURCC('PART'), part4}));
   for (const auto& p : x1c4_particleDescs) {
-    x1f8_particleGens.emplace_back(new CElementGen(p));
+    x1f8_particleGens.emplace_back(std::make_unique<CElementGen>(p));
     x1f8_particleGens.back()->SetParticleEmission(false);
   }
   x21c_deathParticleCounts.push_back(partCount1);

--- a/Runtime/World/CLightParameters.hpp
+++ b/Runtime/World/CLightParameters.hpp
@@ -72,18 +72,21 @@ public:
   }
 
   std::unique_ptr<CActorLights> MakeActorLights() const {
-    if (!x1c_makeLights)
-      return {};
+    if (!x1c_makeLights) {
+      return nullptr;
+    }
 
-    u32 updateFrames = GetFramesBetweenRecalculation(x24_lightRecalcOpts);
-    CActorLights* lights = new CActorLights(updateFrames, x2c_actorPosBias, x38_maxDynamicLights, x3c_maxAreaLights,
-                                            x1d_ambientChannelOverflow, x28_layerIdx == 1,
-                                            x20_worldLightingOptions == EWorldLightingOptions::DisableWorld, 0.1f);
-    if (x20_worldLightingOptions == EWorldLightingOptions::NoShadowCast)
+    const u32 updateFrames = GetFramesBetweenRecalculation(x24_lightRecalcOpts);
+    auto lights = std::make_unique<CActorLights>(updateFrames, x2c_actorPosBias, x38_maxDynamicLights,
+                                                 x3c_maxAreaLights, x1d_ambientChannelOverflow, x28_layerIdx == 1,
+                                                 x20_worldLightingOptions == EWorldLightingOptions::DisableWorld, 0.1f);
+    if (x20_worldLightingOptions == EWorldLightingOptions::NoShadowCast) {
       lights->SetCastShadows(false);
-    if (x3c_maxAreaLights == 0)
+    }
+    if (x3c_maxAreaLights == 0) {
       lights->SetAmbientColor(x18_noLightsAmbient);
-    return std::unique_ptr<CActorLights>(lights);
+    }
+    return lights;
   }
   const zeus::CColor& GetNoLightsAmbient() const { return x18_noLightsAmbient; }
 };

--- a/Runtime/World/CPatterned.cpp
+++ b/Runtime/World/CPatterned.cpp
@@ -944,7 +944,7 @@ void CPatterned::BuildBodyController(EBodyType bodyType) {
   if (x450_bodyController)
     return;
 
-  x450_bodyController.reset(new CBodyController(*this, x3b8_turnSpeed, bodyType));
+  x450_bodyController = std::make_unique<CBodyController>(*this, x3b8_turnSpeed, bodyType);
   auto anim =
       x450_bodyController->GetPASDatabase().FindBestAnimation(CPASAnimParmData(24, CPASAnimParm::FromEnum(0)), -1);
   x460_knockBackController.x81_26_enableShock = anim.first > 0.f;

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -76,9 +76,9 @@ CPlayer::CPlayer(TUniqueId uid, const zeus::CTransform& xf, const zeus::CAABox& 
 , x2d8_fpBounds(aabb)
 , x7d0_animRes(resId, 0, playerScale, 0, true)
 , x7d8_beamScale(playerScale) {
-  x490_gun.reset(new CPlayerGun(uid));
+  x490_gun = std::make_unique<CPlayerGun>(uid);
   x49c_gunHolsterRemTime = g_tweakPlayerGun->GetGunNotFiringTime();
-  x4a0_failsafeTest.reset(new CFailsafeTest());
+  x4a0_failsafeTest = std::make_unique<CFailsafeTest>();
   x76c_cameraBob.reset(
       new CPlayerCameraBob(CPlayerCameraBob::ECameraBobType::One,
                            zeus::CVector2f{CPlayerCameraBob::kCameraBobExtentX, CPlayerCameraBob::kCameraBobExtentY},
@@ -90,7 +90,7 @@ CPlayer::CPlayer(TUniqueId uid, const zeus::CTransform& xf, const zeus::CAABox& 
   CAssetId beamId = g_tweakPlayerRes->GetBeamBallTransitionModel(x7ec_beam);
   x7f0_ballTransitionBeamModel = std::make_unique<CModelData>(CStaticRes(beamId, playerScale));
   x730_transitionModels.reserve(3);
-  x768_morphball.reset(new CMorphBall(*this, ballRadius));
+  x768_morphball = std::make_unique<CMorphBall>(*this, ballRadius);
 
   SetInertiaTensorScalar(xe8_mass);
   x1f4_lastNonCollidingState = GetMotionState();
@@ -476,11 +476,12 @@ void CPlayer::UpdatePlayerSounds(float dt) {
 void CPlayer::Update(float dt, CStateManager& mgr) {
   SetCoefficientOfRestitutionModifier(0.f);
   UpdateMorphBallTransition(dt, mgr);
-  CPlayerState::EBeamId newBeam = mgr.GetPlayerState()->GetCurrentBeam();
+
+  const CPlayerState::EBeamId newBeam = mgr.GetPlayerState()->GetCurrentBeam();
   if (newBeam != x7ec_beam) {
     x7ec_beam = newBeam;
-    x7f0_ballTransitionBeamModel.reset(
-        new CModelData(CStaticRes(g_tweakPlayerRes->GetBeamBallTransitionModel(x7ec_beam), x7d8_beamScale)));
+    x7f0_ballTransitionBeamModel = std::make_unique<CModelData>(
+        CStaticRes(g_tweakPlayerRes->GetBeamBallTransitionModel(x7ec_beam), x7d8_beamScale));
   }
 
   if (!mgr.GetPlayerState()->IsPlayerAlive()) {
@@ -662,9 +663,9 @@ void CPlayer::PostUpdate(float dt, CStateManager& mgr) {
 
   float cameraBobT = 0.f;
   if (mgr.GetCameraManager()->IsInCinematicCamera()) {
-    zeus::CVector2f bobExtent(CPlayerCameraBob::kCameraBobExtentX, CPlayerCameraBob::kCameraBobExtentY);
-    x76c_cameraBob.reset(
-        new CPlayerCameraBob(CPlayerCameraBob::ECameraBobType::One, bobExtent, CPlayerCameraBob::kCameraBobPeriod));
+    const zeus::CVector2f bobExtent(CPlayerCameraBob::kCameraBobExtentX, CPlayerCameraBob::kCameraBobExtentY);
+    x76c_cameraBob = std::make_unique<CPlayerCameraBob>(CPlayerCameraBob::ECameraBobType::One, bobExtent,
+                                                        CPlayerCameraBob::kCameraBobPeriod);
   } else {
     cameraBobT = UpdateCameraBob(dt, mgr);
   }

--- a/Runtime/World/CScriptEMPulse.cpp
+++ b/Runtime/World/CScriptEMPulse.cpp
@@ -43,8 +43,8 @@ void CScriptEMPulse::Think(float dt, CStateManager& mgr) {
 void CScriptEMPulse::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) {
   CActor::AcceptScriptMsg(msg, uid, mgr);
   if (msg == EScriptObjectMessage::Activate) {
-    x114_particleGen.reset(new CElementGen(x108_particleDesc, CElementGen::EModelOrientationType::Normal,
-                                           CElementGen::EOptionalSystemFlags::One));
+    x114_particleGen = std::make_unique<CElementGen>(x108_particleDesc, CElementGen::EModelOrientationType::Normal,
+                                                     CElementGen::EOptionalSystemFlags::One);
 
     x114_particleGen->SetOrientation(GetTransform().getRotation());
     x114_particleGen->SetGlobalTranslation(GetTranslation());

--- a/Runtime/World/CScriptEffect.cpp
+++ b/Runtime/World/CScriptEffect.cpp
@@ -54,7 +54,7 @@ CScriptEffect::CScriptEffect(TUniqueId uid, std::string_view name, const CEntity
 
   if (partId.IsValid()) {
     xf8_particleSystemToken = g_SimplePool->GetObj({FOURCC('PART'), partId});
-    x104_particleSystem.reset(new CElementGen(xf8_particleSystemToken));
+    x104_particleSystem = std::make_unique<CElementGen>(xf8_particleSystemToken);
     zeus::CTransform newXf = xf;
     newXf.origin = zeus::skZero3f;
     x104_particleSystem->SetOrientation(newXf);
@@ -67,7 +67,7 @@ CScriptEffect::CScriptEffect(TUniqueId uid, std::string_view name, const CEntity
 
   if (elscId.IsValid()) {
     xe8_electricToken = g_SimplePool->GetObj({FOURCC('ELSC'), elscId});
-    xf4_electric.reset(new CParticleElectric(xe8_electricToken));
+    xf4_electric = std::make_unique<CParticleElectric>(xe8_electricToken);
     zeus::CTransform newXf = xf;
     newXf.origin = zeus::skZero3f;
     xf4_electric->SetOrientation(newXf);
@@ -87,9 +87,9 @@ void CScriptEffect::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CSt
   case EScriptObjectMessage::Activate:
     if (x110_26_rebuildSystemsOnActivate) {
       if (x104_particleSystem) {
-        zeus::CVector3f scale = x104_particleSystem->GetGlobalScale();
-        zeus::CColor color = x104_particleSystem->GetModulationColor();
-        x104_particleSystem.reset(new CElementGen(xf8_particleSystemToken));
+        const zeus::CVector3f scale = x104_particleSystem->GetGlobalScale();
+        const zeus::CColor color = x104_particleSystem->GetModulationColor();
+        x104_particleSystem = std::make_unique<CElementGen>(xf8_particleSystemToken);
         zeus::CTransform newXf = GetTransform();
         newXf.origin = zeus::skZero3f;
         x104_particleSystem->SetOrientation(newXf);
@@ -101,9 +101,9 @@ void CScriptEffect::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CSt
       }
 
       if (xf4_electric) {
-        zeus::CVector3f scale = xf4_electric->GetGlobalScale();
-        zeus::CColor color = xf4_electric->GetModulationColor();
-        xf4_electric.reset(new CParticleElectric(xe8_electricToken));
+        const zeus::CVector3f scale = xf4_electric->GetGlobalScale();
+        const zeus::CColor color = xf4_electric->GetModulationColor();
+        xf4_electric = std::make_unique<CParticleElectric>(xe8_electricToken);
         zeus::CTransform newXf = GetTransform();
         newXf.origin = zeus::skZero3f;
         xf4_electric->SetOrientation(newXf);

--- a/Runtime/World/CScriptGunTurret.cpp
+++ b/Runtime/World/CScriptGunTurret.cpp
@@ -125,12 +125,12 @@ CScriptGunTurret::CScriptGunTurret(TUniqueId uid, std::string_view name, ETurret
 , x44c_panningEffectDesc(g_SimplePool->GetObj({SBIG('PART'), turretData.GetPanningEffectRes()})) {
   if (turretData.GetVisorEffectRes().IsValid())
     x458_visorEffectDesc = g_SimplePool->GetObj({SBIG('PART'), turretData.GetVisorEffectRes()});
-  x468_idleLight.reset(new CElementGen(x410_idleLightDesc));
-  x470_deactivateLight.reset(new CElementGen(x41c_deactivateLightDesc));
-  x478_targettingLight.reset(new CElementGen(x428_targettingLightDesc));
-  x480_frozenEffect.reset(new CElementGen(x434_frozenEffectDesc));
-  x488_chargingEffect.reset(new CElementGen(x440_chargingEffectDesc));
-  x490_panningEffect.reset(new CElementGen(x44c_panningEffectDesc));
+  x468_idleLight = std::make_unique<CElementGen>(x410_idleLightDesc);
+  x470_deactivateLight = std::make_unique<CElementGen>(x41c_deactivateLightDesc);
+  x478_targettingLight = std::make_unique<CElementGen>(x428_targettingLightDesc);
+  x480_frozenEffect = std::make_unique<CElementGen>(x434_frozenEffectDesc);
+  x488_chargingEffect = std::make_unique<CElementGen>(x440_chargingEffectDesc);
+  x490_panningEffect = std::make_unique<CElementGen>(x44c_panningEffectDesc);
   x4fc_extensionOffset = xf.origin;
   x514_lastFrontVector = xf.frontVector();
   x544_originalFrontVec = xf.frontVector();
@@ -330,8 +330,7 @@ void CScriptGunTurret::SetupCollisionManager(CStateManager& mgr) {
       x508_gunSDKSeg, blastLCTR, 0.6f, 1.f, CJointCollisionDescription::EOrientationType::One, "Gun_SDK"sv, 1000.f));
   jointDescs.push_back(CJointCollisionDescription::SphereCollision(blastLCTR, 0.3f, "Blast_LCTR"sv, 1000.f));
 
-  x49c_collisionManager.reset(new CCollisionActorManager(mgr, GetUniqueId(), GetAreaIdAlways(), jointDescs, true));
-
+  x49c_collisionManager = std::make_unique<CCollisionActorManager>(mgr, GetUniqueId(), GetAreaIdAlways(), jointDescs, true);
   x49c_collisionManager->SetActive(mgr, GetActive());
 
   for (int i = 0; i < x49c_collisionManager->GetNumCollisionActors(); ++i) {

--- a/Runtime/World/CWallCrawlerSwarm.cpp
+++ b/Runtime/World/CWallCrawlerSwarm.cpp
@@ -78,16 +78,16 @@ CWallCrawlerSwarm::CWallCrawlerSwarm(TUniqueId uid, bool active, std::string_vie
   CAnimRes launchAnimRes(animRes);
   launchAnimRes.SetCanLoop(true);
   launchAnimRes.SetDefaultAnim(launchAnim != -1 ? launchAnim : 0);
-  x4b0_modelDatas.emplace_back(new CModelData(animRes));
-  x4b0_modelDatas.emplace_back(new CModelData(animRes));
-  x4b0_modelDatas.emplace_back(new CModelData(animRes));
-  x4b0_modelDatas.emplace_back(new CModelData(animRes));
-  x4b0_modelDatas.emplace_back(new CModelData(attractAnimRes));
-  x4b0_modelDatas.emplace_back(new CModelData(attractAnimRes));
-  x4b0_modelDatas.emplace_back(new CModelData(attractAnimRes));
-  x4b0_modelDatas.emplace_back(new CModelData(attractAnimRes));
-  x4b0_modelDatas.emplace_back(new CModelData(launchAnimRes));
-  x4b0_modelDatas.emplace_back(new CModelData(animRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(animRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(animRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(animRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(animRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(attractAnimRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(attractAnimRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(attractAnimRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(attractAnimRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(launchAnimRes));
+  x4b0_modelDatas.emplace_back(std::make_unique<CModelData>(animRes));
   if (aParams.GetXRayAssets().first.IsValid()) {
     for (int i = 0; i < 9; ++i)
       x4b0_modelDatas[i]->SetXRayModel(aParams.GetXRayAssets());

--- a/Runtime/World/CWorldTransManager.cpp
+++ b/Runtime/World/CWorldTransManager.cpp
@@ -384,7 +384,7 @@ void CWorldTransManager::EnableTransition(const CAnimRes& samusRes, CAssetId pla
   x44_25_stopSoon = false;
   x44_26_goingUp = goingUp;
   x30_type = ETransType::Enabled;
-  x4_modelData.reset(new SModelDatas(samusRes));
+  x4_modelData = std::make_unique<SModelDatas>(samusRes);
 
   if (!m_reflectionCube[0] && hecl::com_cubemaps->toBoolean())
     CGraphics::CommitResources([this](boo::IGraphicsDataFactory::Context& ctx) {
@@ -437,11 +437,9 @@ void CWorldTransManager::EnableTransition(CAssetId fontId, CAssetId stringId, u3
   x4_modelData.reset();
   x44_27_fadeWhite = fadeWhite;
 
-  CGuiTextProperties props(false, true, EJustification::Center, EVerticalJustification::Center);
-  x8_textData.reset(new CGuiTextSupport(fontId, props, zeus::skWhite, zeus::skBlack,
-                                        zeus::skWhite, 640, 448, g_SimplePool,
-                                        CGuiWidget::EGuiModelDrawFlags::Additive));
-
+  const CGuiTextProperties props(false, true, EJustification::Center, EVerticalJustification::Center);
+  x8_textData = std::make_unique<CGuiTextSupport>(fontId, props, zeus::skWhite, zeus::skBlack, zeus::skWhite, 640, 448,
+                                                  g_SimplePool, CGuiWidget::EGuiModelDrawFlags::Additive);
   x8_textData->SetTypeWriteEffectOptions(true, chFadeTime, chFadeRate);
   xc_strTable = g_SimplePool->GetObj(SObjectTag{FOURCC('STRG'), stringId});
   x8_textData->SetText(u"");


### PR DESCRIPTION
Makes use of the C++14 make_unique allocation function to allocate class instances where applicable instead of a reset with a new operator within it.

This doesn't touch cases where buffers are allocated, given make_unique would zero-initialize them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/65)
<!-- Reviewable:end -->
