### PR TITLE
CEntityInfo: std::move vector in constructor

### DIFF
--- a/Runtime/CStateManager.cpp
+++ b/Runtime/CStateManager.cpp
@@ -1292,21 +1292,21 @@ void CStateManager::LoadScriptObjects(TAreaId aid, CInputStream& in, std::vector
 
 std::pair<TEditorId, TUniqueId> CStateManager::LoadScriptObject(TAreaId aid, EScriptObjectType type, u32 length,
                                                                 CInputStream& in) {
-  TEditorId id = in.readUint32Big();
-  u32 connCount = in.readUint32Big();
+  const TEditorId id = in.readUint32Big();
+  const u32 connCount = in.readUint32Big();
   length -= 8;
   std::vector<SConnection> conns;
   conns.reserve(connCount);
-  for (int i = 0; i < connCount; ++i) {
-    EScriptObjectState state = EScriptObjectState(in.readUint32Big());
-    EScriptObjectMessage msg = EScriptObjectMessage(in.readUint32Big());
-    TEditorId target = in.readUint32Big();
+  for (u32 i = 0; i < connCount; ++i) {
+    const auto state = EScriptObjectState(in.readUint32Big());
+    const auto msg = EScriptObjectMessage(in.readUint32Big());
+    const TEditorId target = in.readUint32Big();
     length -= 12;
     conns.push_back(SConnection{state, msg, target});
   }
-  u32 propCount = in.readUint32Big();
+  const u32 propCount = in.readUint32Big();
   length -= 4;
-  auto startPos = in.position();
+  const auto startPos = in.position();
 
   bool error = false;
   FScriptLoader loader = {};
@@ -1315,7 +1315,7 @@ std::pair<TEditorId, TUniqueId> CStateManager::LoadScriptObject(TAreaId aid, ESc
 
   CEntity* ent = nullptr;
   if (loader) {
-    CEntityInfo info(aid, conns, id);
+    const CEntityInfo info(aid, std::move(conns), id);
     ent = loader(*this, in, propCount, info);
   } else {
     error = true;

--- a/Runtime/World/CEntityInfo.hpp
+++ b/Runtime/World/CEntityInfo.hpp
@@ -18,8 +18,8 @@ class CEntityInfo {
   TEditorId x14_editorId;
 
 public:
-  CEntityInfo(TAreaId aid, const std::vector<SConnection>& conns, TEditorId eid = kInvalidEditorId)
-  : x0_areaId(aid), x4_conns(conns), x14_editorId(eid) {}
+  CEntityInfo(TAreaId aid, std::vector<SConnection> conns, TEditorId eid = kInvalidEditorId)
+  : x0_areaId(aid), x4_conns(std::move(conns)), x14_editorId(eid) {}
   TAreaId GetAreaId() const { return x0_areaId; }
   std::vector<SConnection> GetConnectionList() const { return x4_conns; }
   TEditorId GetEditorId() const { return x14_editorId; }


### PR DESCRIPTION
Allows calling code to potentially avoid copies altogether by moving into the constructor. While we're in the same area, we can eliminate a sign mismatch warning in a loop conditional nearby.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/70)
<!-- Reviewable:end -->
