### PR TITLE
CPlayer: Use size_t with SfxIdFromMaterial

### DIFF
--- a/Runtime/World/CMorphBall.cpp
+++ b/Runtime/World/CMorphBall.cpp
@@ -401,7 +401,7 @@ void CMorphBall::SelectMorphBallSounds(const CMaterialList& mat) {
     else
       rollSfx = 1481;
   } else {
-    rollSfx = CPlayer::SfxIdFromMaterial(mat, skBallRollSfx.data(), 24, 0xffff);
+    rollSfx = CPlayer::SfxIdFromMaterial(mat, skBallRollSfx.data(), skBallRollSfx.size(), 0xffff);
   }
   x0_player.x9c5_30_selectFluidBallSound = false;
 
@@ -413,7 +413,7 @@ void CMorphBall::SelectMorphBallSounds(const CMaterialList& mat) {
     x1e34_rollSfx = rollSfx;
   }
 
-  x1e36_landSfx = CPlayer::SfxIdFromMaterial(mat, skBallLandSfx.data(), 24, 0xffff);
+  x1e36_landSfx = CPlayer::SfxIdFromMaterial(mat, skBallLandSfx.data(), skBallLandSfx.size(), 0xffff);
 }
 
 void CMorphBall::UpdateMorphBallSounds(float dt) {

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -2389,9 +2389,9 @@ void CPlayer::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CState
         float landVol = zeus::clamp(95.f, 1.6f * -x794_lastVelocity.z() + 95.f, 127.f) / 127.f;
         u16 landSfx;
         if (-x794_lastVelocity.z() < hardThres) {
-          landSfx = GetMaterialSoundUnderPlayer(mgr, skPlayerLandSfxSoft, 24, 0xffff);
+          landSfx = GetMaterialSoundUnderPlayer(mgr, skPlayerLandSfxSoft, std::size(skPlayerLandSfxSoft), 0xffff);
         } else {
-          landSfx = GetMaterialSoundUnderPlayer(mgr, skPlayerLandSfxHard, 24, 0xffff);
+          landSfx = GetMaterialSoundUnderPlayer(mgr, skPlayerLandSfxHard, std::size(skPlayerLandSfxHard), 0xffff);
           StartSamusVoiceSfx(SFXsam_voxland_02, 1.f, 5);
           x55c_damageAmt = 0.f;
           x560_prevDamageAmt = 10.f;
@@ -2645,10 +2645,11 @@ void CPlayer::UpdateFootstepSounds(const CFinalInput& input, CStateManager& mgr,
       }
     } else {
       u16 sfx;
-      if (x790_footstepSfxSel == EFootstepSfx::Left)
-        sfx = GetMaterialSoundUnderPlayer(mgr, skLeftStepSounds, 24, -1);
-      else
-        sfx = GetMaterialSoundUnderPlayer(mgr, skRightStepSounds, 24, -1);
+      if (x790_footstepSfxSel == EFootstepSfx::Left) {
+        sfx = GetMaterialSoundUnderPlayer(mgr, skLeftStepSounds, std::size(skLeftStepSounds), -1);
+      } else {
+        sfx = GetMaterialSoundUnderPlayer(mgr, skRightStepSounds, std::size(skRightStepSounds), -1);
+      }
       CSfxHandle hnd = CSfxManager::SfxStart(sfx, sfxVol, 0.f, true, 0x7f, false, kInvalidAreaId);
       ApplySubmergedPitchBend(hnd);
     }
@@ -2661,7 +2662,7 @@ void CPlayer::UpdateFootstepSounds(const CFinalInput& input, CStateManager& mgr,
   }
 }
 
-u16 CPlayer::GetMaterialSoundUnderPlayer(const CStateManager& mgr, const u16* table, u32 length, u16 defId) const {
+u16 CPlayer::GetMaterialSoundUnderPlayer(const CStateManager& mgr, const u16* table, size_t length, u16 defId) const {
   u16 ret = defId;
   zeus::CAABox aabb = GetBoundingBox();
   aabb.accumulateBounds(x34_transform.origin + zeus::skDown);
@@ -2675,9 +2676,9 @@ u16 CPlayer::GetMaterialSoundUnderPlayer(const CStateManager& mgr, const u16* ta
   return ret;
 }
 
-u16 CPlayer::SfxIdFromMaterial(const CMaterialList& mat, const u16* idList, u32 tableLen, u16 defId) {
+u16 CPlayer::SfxIdFromMaterial(const CMaterialList& mat, const u16* idList, size_t tableLen, u16 defId) {
   u16 id = defId;
-  for (u32 i = 0; i < tableLen; ++i) {
+  for (size_t i = 0; i < tableLen; ++i) {
     if (mat.HasMaterial(EMaterialTypes(i)) && idList[i] != 0xFFFF)
       id = idList[i];
   }

--- a/Runtime/World/CPlayer.hpp
+++ b/Runtime/World/CPlayer.hpp
@@ -432,8 +432,8 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void SetVisorSteam(float, float, float, CAssetId, bool);
   void UpdateFootstepSounds(const CFinalInput& input, CStateManager&, float);
-  u16 GetMaterialSoundUnderPlayer(const CStateManager& mgr, const u16*, u32, u16) const;
-  static u16 SfxIdFromMaterial(const CMaterialList&, const u16*, u32, u16);
+  u16 GetMaterialSoundUnderPlayer(const CStateManager& mgr, const u16* idList, size_t length, u16 defId) const;
+  static u16 SfxIdFromMaterial(const CMaterialList& mat, const u16* idList, size_t tableLen, u16 defId);
   void UpdateCrosshairsState(const CFinalInput&);
   void UpdateVisorTransition(float, CStateManager& mgr);
   void UpdateVisorState(const CFinalInput&, float, CStateManager& mgr);


### PR DESCRIPTION
Allows passing in sizes without potential truncation from size_t, allowing nicer use of std::size() to dehardcode some magic values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/73)
<!-- Reviewable:end -->
