### PR TITLE
CMaterialFilter/CMaterialList: Make interface constexpr

### DIFF
--- a/Runtime/Collision/CMaterialFilter.cpp
+++ b/Runtime/Collision/CMaterialFilter.cpp
@@ -1,4 +1,4 @@
-#include "CMaterialFilter.hpp"
+#include "Runtime/Collision/CMaterialFilter.hpp"
 
 namespace urde {
 const CMaterialFilter CMaterialFilter::skPassEverything({0x00000000FFFFFFFF}, {0},

--- a/Runtime/Collision/CMaterialFilter.cpp
+++ b/Runtime/Collision/CMaterialFilter.cpp
@@ -3,38 +3,4 @@
 namespace urde {
 const CMaterialFilter CMaterialFilter::skPassEverything({0x00000000FFFFFFFF}, {0},
                                                         CMaterialFilter::EFilterType::Always);
-
-CMaterialFilter::CMaterialFilter(const CMaterialList& include, const CMaterialList& exclude,
-                                 CMaterialFilter::EFilterType type)
-: x0_include(include), x8_exclude(exclude), x10_type(type) {}
-
-CMaterialFilter CMaterialFilter::MakeInclude(const CMaterialList& include) {
-  return CMaterialFilter(include, {0ull}, EFilterType::Include);
-}
-
-CMaterialFilter CMaterialFilter::MakeExclude(const CMaterialList& exclude) {
-  return CMaterialFilter({u64(0x00000000FFFFFFFF)}, exclude, EFilterType::Exclude);
-}
-
-CMaterialFilter CMaterialFilter::MakeIncludeExclude(const CMaterialList& include, const CMaterialList& exclude) {
-  return CMaterialFilter(include, exclude, EFilterType::IncludeExclude);
-}
-
-bool CMaterialFilter::Passes(const CMaterialList& list) const {
-  switch (x10_type) {
-  case EFilterType::Always:
-    return true;
-  case EFilterType::Include:
-    return (list.x0_list & x0_include.x0_list) != 0;
-  case EFilterType::Exclude:
-    return (list.x0_list & x8_exclude.x0_list) == 0;
-  case EFilterType::IncludeExclude:
-    if ((list.x0_list & x0_include.x0_list) == 0)
-      return false;
-    return (list.x0_list & x8_exclude.x0_list) == 0;
-  default:
-    return true;
-  }
-}
-
 } // namespace urde

--- a/Runtime/Collision/CMaterialFilter.hpp
+++ b/Runtime/Collision/CMaterialFilter.hpp
@@ -15,18 +15,42 @@ private:
 public:
   static const CMaterialFilter skPassEverything;
 
-  CMaterialFilter(const CMaterialList& include, const CMaterialList& exclude, EFilterType type);
+  constexpr CMaterialFilter(const CMaterialList& include, const CMaterialList& exclude, EFilterType type) noexcept
+  : x0_include(include), x8_exclude(exclude), x10_type(type) {}
 
-  static CMaterialFilter MakeInclude(const CMaterialList& include);
+  static constexpr CMaterialFilter MakeInclude(const CMaterialList& include) noexcept {
+    return CMaterialFilter(include, {}, EFilterType::Include);
+  }
 
-  static CMaterialFilter MakeExclude(const CMaterialList& exclude);
+  static constexpr CMaterialFilter MakeExclude(const CMaterialList& exclude) noexcept {
+    return CMaterialFilter({u64(0x00000000FFFFFFFF)}, exclude, EFilterType::Exclude);
+  }
 
-  static CMaterialFilter MakeIncludeExclude(const CMaterialList& include, const CMaterialList& exclude);
+  static constexpr CMaterialFilter MakeIncludeExclude(const CMaterialList& include,
+                                                      const CMaterialList& exclude) noexcept {
+    return CMaterialFilter(include, exclude, EFilterType::IncludeExclude);
+  }
 
-  const CMaterialList& GetIncludeList() const { return x0_include; }
-  const CMaterialList& GetExcludeList() const { return x8_exclude; }
-  CMaterialList& IncludeList() { return x0_include; }
-  CMaterialList& ExcludeList() { return x8_exclude; }
-  bool Passes(const CMaterialList&) const;
+  constexpr const CMaterialList& GetIncludeList() const noexcept { return x0_include; }
+  constexpr const CMaterialList& GetExcludeList() const noexcept { return x8_exclude; }
+  constexpr CMaterialList& IncludeList() noexcept { return x0_include; }
+  constexpr CMaterialList& ExcludeList() noexcept { return x8_exclude; }
+
+  constexpr bool Passes(const CMaterialList& list) const noexcept {
+    switch (x10_type) {
+    case EFilterType::Always:
+      return true;
+    case EFilterType::Include:
+      return (list.x0_list & x0_include.x0_list) != 0;
+    case EFilterType::Exclude:
+      return (list.x0_list & x8_exclude.x0_list) == 0;
+    case EFilterType::IncludeExclude:
+      if ((list.x0_list & x0_include.x0_list) == 0)
+        return false;
+      return (list.x0_list & x8_exclude.x0_list) == 0;
+    default:
+      return true;
+    }
+  }
 };
 } // namespace urde

--- a/Runtime/Collision/CMaterialFilter.hpp
+++ b/Runtime/Collision/CMaterialFilter.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "CMaterialList.hpp"
-#include "zeus/Math.hpp"
+#include "Runtime/Collision/CMaterialList.hpp"
+
 namespace urde {
 class CMaterialFilter {
 public:

--- a/Runtime/Collision/CMaterialList.hpp
+++ b/Runtime/Collision/CMaterialList.hpp
@@ -71,63 +71,69 @@ class CMaterialList {
   u64 x0_list = 0;
 
 public:
-  CMaterialList() = default;
-  CMaterialList(u64 flags) : x0_list(flags) {}
-  CMaterialList(EMaterialTypes t1, EMaterialTypes t2, EMaterialTypes t3, EMaterialTypes t4, EMaterialTypes t5,
-                EMaterialTypes t6)
+  constexpr CMaterialList() noexcept = default;
+  constexpr CMaterialList(u64 flags) noexcept : x0_list(flags) {}
+  constexpr CMaterialList(EMaterialTypes t1, EMaterialTypes t2, EMaterialTypes t3, EMaterialTypes t4, EMaterialTypes t5,
+                          EMaterialTypes t6) noexcept
   : CMaterialList(t1, t2, t3, t4, t5) {
-    x0_list |= 1ull << u64(t6);
+    x0_list |= u64{1} << u64(t6);
   }
 
-  CMaterialList(EMaterialTypes t1, EMaterialTypes t2, EMaterialTypes t3, EMaterialTypes t4, EMaterialTypes t5)
+  constexpr CMaterialList(EMaterialTypes t1, EMaterialTypes t2, EMaterialTypes t3, EMaterialTypes t4,
+                          EMaterialTypes t5) noexcept
   : CMaterialList(t1, t2, t3, t4) {
-    x0_list |= 1ull << u64(t5);
+    x0_list |= u64{1} << u64(t5);
   }
 
-  CMaterialList(EMaterialTypes t1, EMaterialTypes t2, EMaterialTypes t3, EMaterialTypes t4)
+  constexpr CMaterialList(EMaterialTypes t1, EMaterialTypes t2, EMaterialTypes t3, EMaterialTypes t4) noexcept
   : CMaterialList(t1, t2, t3) {
-    x0_list |= 1ull << u64(t4);
+    x0_list |= u64{1} << u64(t4);
   }
 
-  CMaterialList(EMaterialTypes t1, EMaterialTypes t2, EMaterialTypes t3) : CMaterialList(t1, t2) {
-    x0_list |= 1ull << u64(t3);
+  constexpr CMaterialList(EMaterialTypes t1, EMaterialTypes t2, EMaterialTypes t3) noexcept : CMaterialList(t1, t2) {
+    x0_list |= u64{1} << u64(t3);
   }
 
-  CMaterialList(EMaterialTypes t1, EMaterialTypes t2) : CMaterialList(t1) { x0_list |= 1ull << u64(t2); }
+  constexpr CMaterialList(EMaterialTypes t1, EMaterialTypes t2) noexcept : CMaterialList(t1) {
+    x0_list |= u64{1} << u64(t2);
+  }
 
-  CMaterialList(EMaterialTypes t1) : x0_list(1ull << u64(t1)) {}
+  constexpr CMaterialList(EMaterialTypes t1) noexcept : x0_list(u64{1} << u64(t1)) {}
 
-  u64 GetValue() const { return x0_list; }
+  constexpr u64 GetValue() const noexcept { return x0_list; }
 
-  static s32 BitPosition(u64 flag) {
-    for (u32 i = 0; i < 64; ++i)
-      if ((flag & (1ull << i)) != 0)
-        return i;
+  static constexpr s32 BitPosition(u64 flag) noexcept {
+    for (u32 i = 0; i < 64; ++i) {
+      if ((flag & (u64{1} << i)) != 0) {
+        return static_cast<s32>(i);
+      }
+    }
     return -1;
   }
 
-  void Add(EMaterialTypes type) { x0_list |= (1ull << u64(type)); }
+  constexpr void Add(EMaterialTypes type) noexcept { x0_list |= (u64{1} << u64(type)); }
 
-  void Add(const CMaterialList& l) { x0_list |= l.x0_list; }
+  constexpr void Add(const CMaterialList& l) noexcept { x0_list |= l.x0_list; }
 
-  void Remove(EMaterialTypes type) { x0_list &= ~(1ull << u64(type)); }
+  constexpr void Remove(EMaterialTypes type) noexcept { x0_list &= ~(u64{1} << u64(type)); }
 
-  void Remove(const CMaterialList& other) { x0_list &= ~(other.x0_list); }
+  constexpr void Remove(const CMaterialList& other) noexcept { x0_list &= ~(other.x0_list); }
 
-  bool HasMaterial(EMaterialTypes type) const { return (x0_list & (1ull << u64(type))) != 0; }
+  constexpr bool HasMaterial(EMaterialTypes type) const noexcept { return (x0_list & (u64{1} << u64(type))) != 0; }
 
-  bool SharesMaterials(const CMaterialList& other) const {
+  constexpr bool SharesMaterials(const CMaterialList& other) const noexcept {
     for (u32 i = 0; i < 64; i++) {
-      if ((x0_list & (1ull << i)) != 0 && (other.x0_list & (1ull << i)) != 0)
+      if ((x0_list & (u64{1} << i)) != 0 && (other.x0_list & (u64{1} << i)) != 0) {
         return true;
+      }
     }
 
     return false;
   }
 
-  u64 Intersection(const CMaterialList& other) const { return other.x0_list & x0_list; }
+  constexpr u64 Intersection(const CMaterialList& other) const noexcept { return other.x0_list & x0_list; }
 
-  u64 XOR(const CMaterialList& other) const { return x0_list ^ other.x0_list; }
+  constexpr u64 XOR(const CMaterialList& other) const noexcept { return x0_list ^ other.x0_list; }
 };
 
 } // namespace urde

--- a/Runtime/Collision/CMaterialList.hpp
+++ b/Runtime/Collision/CMaterialList.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "RetroTypes.hpp"
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 enum class EMaterialTypes {


### PR DESCRIPTION
A few instances of CMaterialFilter are constructed at file-scope using the Make* functions and the constructor. Given these aren't constexpr, this means these are technically runtime function calls. We can make these constexpr to allow the initialization to be done at compile-time, slightly improving startup time and eliminating some runtime global constructors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/75)
<!-- Reviewable:end -->
