### PR TITLE
CPlayer: Make file-scope CMaterialFilter instances constexpr

### DIFF
--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -37,17 +37,17 @@ namespace urde {
 namespace {
 logvisor::Module Log("urde::CPlayer");
 
-const CMaterialFilter SolidMaterialFilter = CMaterialFilter::MakeInclude(CMaterialList(EMaterialTypes::Solid));
+constexpr CMaterialFilter SolidMaterialFilter = CMaterialFilter::MakeInclude(CMaterialList(EMaterialTypes::Solid));
 
-const CMaterialFilter LineOfSightFilter = CMaterialFilter::MakeIncludeExclude(
+constexpr CMaterialFilter LineOfSightFilter = CMaterialFilter::MakeIncludeExclude(
     {EMaterialTypes::Solid},
     {EMaterialTypes::ProjectilePassthrough, EMaterialTypes::ScanPassthrough, EMaterialTypes::Player});
 
-const CMaterialFilter OccluderFilter = CMaterialFilter::MakeIncludeExclude(
+constexpr CMaterialFilter OccluderFilter = CMaterialFilter::MakeIncludeExclude(
     {EMaterialTypes::Solid, EMaterialTypes::Occluder},
     {EMaterialTypes::ProjectilePassthrough, EMaterialTypes::ScanPassthrough, EMaterialTypes::Player});
 
-const CMaterialFilter BallTransitionCollide = CMaterialFilter::MakeIncludeExclude(
+constexpr CMaterialFilter BallTransitionCollide = CMaterialFilter::MakeIncludeExclude(
     {EMaterialTypes::Solid}, {EMaterialTypes::ProjectilePassthrough, EMaterialTypes::Player, EMaterialTypes::Character,
                               EMaterialTypes::CameraPassthrough});
 


### PR DESCRIPTION
Now that the interface is constexpr, we can mark these as constexpr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/76)
<!-- Reviewable:end -->
