### PR TITLE
CPlayerState: Make use of std::array where applicable

### DIFF
--- a/Runtime/CPlayerState.cpp
+++ b/Runtime/CPlayerState.cpp
@@ -1,5 +1,8 @@
 #include "Runtime/CPlayerState.hpp"
 
+#include <algorithm>
+#include <array>
+
 #include "Runtime/CMemoryCardSys.hpp"
 #include "Runtime/CStateManager.hpp"
 #include "Runtime/GameGlobalObjects.hpp"
@@ -12,12 +15,12 @@
 
 namespace urde {
 namespace {
-constexpr u32 PowerUpMaxValues[41] = {
+constexpr std::array<u32, 41> PowerUpMaxValues{
     1, 1, 1, 1,  250, 1, 1, 8, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 14, 1,   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
 };
 
-[[maybe_unused]] constexpr const char* PowerUpNames[41] = {
+[[maybe_unused]] constexpr std::array<const char*, 41> PowerUpNames{
     "Power Beam",
     "Ice Beam",
     "Wave Beam",
@@ -61,11 +64,11 @@ constexpr u32 PowerUpMaxValues[41] = {
     "Artifact of Newborn",
 };
 
-constexpr u32 costs[] = {
+constexpr std::array<u32, 5> costs{
     5, 10, 10, 10, 1,
 };
 
-constexpr float ComboAmmoPeriods[] = {
+constexpr std::array<float, 5> ComboAmmoPeriods{
     0.2f, 0.1f, 0.2f, 0.2f, 1.f,
 };
 } // Anonymous namespace
@@ -87,12 +90,13 @@ CPlayerState::CPlayerState(CBitStreamReader& stream) : x188_staticIntf(5) {
   x8_currentBeam = EBeamId(stream.ReadEncoded(CBitStreamReader::GetBitCount(5)));
   x20_currentSuit = EPlayerSuit(stream.ReadEncoded(CBitStreamReader::GetBitCount(4)));
   x24_powerups.resize(41);
-  for (u32 i = 0; i < x24_powerups.size(); ++i) {
-    if (PowerUpMaxValues[i] == 0)
+  for (size_t i = 0; i < x24_powerups.size(); ++i) {
+    if (PowerUpMaxValues[i] == 0) {
       continue;
+    }
 
-    u32 a = u32(stream.ReadEncoded(CBitStreamReader::GetBitCount(PowerUpMaxValues[i])));
-    u32 b = u32(stream.ReadEncoded(CBitStreamReader::GetBitCount(PowerUpMaxValues[i])));
+    const u32 a = u32(stream.ReadEncoded(CBitStreamReader::GetBitCount(PowerUpMaxValues[i])));
+    const u32 b = u32(stream.ReadEncoded(CBitStreamReader::GetBitCount(PowerUpMaxValues[i])));
     x24_powerups[i] = CPowerUp(a, b);
   }
 
@@ -117,7 +121,7 @@ void CPlayerState::PutTo(CBitStreamWriter& stream) {
   stream.WriteEncoded(hp.iHP, 32);
   stream.WriteEncoded(u32(x8_currentBeam), CBitStreamWriter::GetBitCount(5));
   stream.WriteEncoded(u32(x20_currentSuit), CBitStreamWriter::GetBitCount(4));
-  for (u32 i = 0; i < x24_powerups.size(); ++i) {
+  for (size_t i = 0; i < x24_powerups.size(); ++i) {
     const CPowerUp& pup = x24_powerups[i];
     stream.WriteEncoded(pup.x0_amount, CBitStreamWriter::GetBitCount(PowerUpMaxValues[i]));
     stream.WriteEncoded(pup.x4_capacity, CBitStreamWriter::GetBitCount(PowerUpMaxValues[i]));
@@ -134,9 +138,9 @@ void CPlayerState::PutTo(CBitStreamWriter& stream) {
   stream.WriteEncoded(x180_scanCompletionRate.second, CBitStreamWriter::GetBitCount(0x100));
 }
 
-u32 CPlayerState::GetMissileCostForAltAttack() const { return costs[u32(x8_currentBeam)]; }
+u32 CPlayerState::GetMissileCostForAltAttack() const { return costs[size_t(x8_currentBeam)]; }
 
-float CPlayerState::GetComboFireAmmoPeriod() const { return ComboAmmoPeriods[u32(x8_currentBeam)]; }
+float CPlayerState::GetComboFireAmmoPeriod() const { return ComboAmmoPeriods[size_t(x8_currentBeam)]; }
 
 u32 CPlayerState::CalculateItemCollectionRate() const {
   u32 total = GetItemCapacity(EItemType::PowerBombs);
@@ -383,7 +387,7 @@ void CPlayerState::InitializeScanTimes() {
     x170_scanTimes.emplace_back(state.first, 0.f);
 }
 
-u32 CPlayerState::GetPowerUpMaxValue(EItemType type) { return PowerUpMaxValues[u32(type)]; }
+u32 CPlayerState::GetPowerUpMaxValue(EItemType type) { return PowerUpMaxValues[size_t(type)]; }
 
 const std::unordered_map<std::string_view, CPlayerState::EItemType> CPlayerState::g_TypeNameMap = {
     {"powerbeam"sv, EItemType::PowerBeam},

--- a/Runtime/CPlayerState.cpp
+++ b/Runtime/CPlayerState.cpp
@@ -11,10 +11,13 @@
 #include <zeus/Math.hpp>
 
 namespace urde {
-const u32 CPlayerState::PowerUpMaxValues[41] = {1, 1, 1, 1,  250, 1, 1, 8, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-                                                1, 1, 1, 14, 1,   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+namespace {
+constexpr u32 PowerUpMaxValues[41] = {
+    1, 1, 1, 1,  250, 1, 1, 8, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 14, 1,   0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+};
 
-const char* CPlayerState::PowerUpNames[41] = {
+[[maybe_unused]] constexpr const char* PowerUpNames[41] = {
     "Power Beam",
     "Ice Beam",
     "Wave Beam",
@@ -57,6 +60,15 @@ const char* CPlayerState::PowerUpNames[41] = {
     "Artifact of Spirit",
     "Artifact of Newborn",
 };
+
+constexpr u32 costs[] = {
+    5, 10, 10, 10, 1,
+};
+
+constexpr float ComboAmmoPeriods[] = {
+    0.2f, 0.1f, 0.2f, 0.2f, 1.f,
+};
+} // Anonymous namespace
 
 CPlayerState::CPlayerState() : x188_staticIntf(5) {
   x0_24_alive = true;
@@ -122,11 +134,7 @@ void CPlayerState::PutTo(CBitStreamWriter& stream) {
   stream.WriteEncoded(x180_scanCompletionRate.second, CBitStreamWriter::GetBitCount(0x100));
 }
 
-static const u32 costs[] = {5, 10, 10, 10, 1};
-
 u32 CPlayerState::GetMissileCostForAltAttack() const { return costs[u32(x8_currentBeam)]; }
-
-static const float ComboAmmoPeriods[] = {0.2f, 0.1f, 0.2f, 0.2f, 1.f};
 
 float CPlayerState::GetComboFireAmmoPeriod() const { return ComboAmmoPeriods[u32(x8_currentBeam)]; }
 
@@ -374,6 +382,8 @@ void CPlayerState::InitializeScanTimes() {
   for (const auto& state : scanStates)
     x170_scanTimes.emplace_back(state.first, 0.f);
 }
+
+u32 CPlayerState::GetPowerUpMaxValue(EItemType type) { return PowerUpMaxValues[u32(type)]; }
 
 const std::unordered_map<std::string_view, CPlayerState::EItemType> CPlayerState::g_TypeNameMap = {
     {"powerbeam"sv, EItemType::PowerBeam},

--- a/Runtime/CPlayerState.cpp
+++ b/Runtime/CPlayerState.cpp
@@ -1,12 +1,14 @@
-#include "CPlayerState.hpp"
-#include "IOStreams.hpp"
-#include "zeus/Math.hpp"
-#include "CStateManager.hpp"
-#include "Camera/CCameraManager.hpp"
-#include "Camera/CFirstPersonCamera.hpp"
-#include "CMemoryCardSys.hpp"
-#include "GameGlobalObjects.hpp"
-#include "TCastTo.hpp"
+#include "Runtime/CPlayerState.hpp"
+
+#include "Runtime/CMemoryCardSys.hpp"
+#include "Runtime/CStateManager.hpp"
+#include "Runtime/GameGlobalObjects.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/TCastTo.hpp"
+#include "Runtime/Camera/CCameraManager.hpp"
+#include "Runtime/Camera/CFirstPersonCamera.hpp"
+
+#include <zeus/Math.hpp>
 
 namespace urde {
 const u32 CPlayerState::PowerUpMaxValues[41] = {1, 1, 1, 1,  250, 1, 1, 8, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,

--- a/Runtime/CPlayerState.hpp
+++ b/Runtime/CPlayerState.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CBasics.hpp"
-#include "CStaticInterference.hpp"
-#include "IOStreams.hpp"
-#include "rstl.hpp"
-#include "World/CHealthInfo.hpp"
+#include <string_view>
 #include <unordered_map>
+#include <vector>
+
+#include "Runtime/CStaticInterference.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/World/CHealthInfo.hpp"
 
 namespace urde {
 

--- a/Runtime/CPlayerState.hpp
+++ b/Runtime/CPlayerState.hpp
@@ -90,8 +90,6 @@ public:
 
 private:
   static const std::unordered_map<std::string_view, EItemType> g_TypeNameMap;
-  static const u32 PowerUpMaxValues[41];
-  static const char* PowerUpNames[41];
   struct CPowerUp {
     u32 x0_amount = 0;
     u32 x4_capacity = 0;
@@ -176,7 +174,7 @@ public:
   CPlayerState();
   CPlayerState(CBitStreamReader& stream);
   void PutTo(CBitStreamWriter& stream);
-  static u32 GetPowerUpMaxValue(EItemType type) { return PowerUpMaxValues[u32(type)]; }
+  static u32 GetPowerUpMaxValue(EItemType type);
   static EItemType ItemNameToType(std::string_view name);
   bool CanTakeDamage() const { return m_canTakeDamage; }
   void SetCanTakeDamage(bool c) { m_canTakeDamage = c; }


### PR DESCRIPTION
Makes the arrays strongly-typed. While we're at it, we can make some private class arrays fully implementation details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/77)
<!-- Reviewable:end -->
