### PR TITLE
CGuiWidgetDrawParms: Mark Default instance as const

### DIFF
--- a/Runtime/GuiSys/CGuiWidgetDrawParms.cpp
+++ b/Runtime/GuiSys/CGuiWidgetDrawParms.cpp
@@ -1,5 +1,5 @@
 #include "CGuiWidgetDrawParms.hpp"
 
 namespace urde {
-CGuiWidgetDrawParms CGuiWidgetDrawParms::Default = {};
+const CGuiWidgetDrawParms CGuiWidgetDrawParms::Default = {};
 }

--- a/Runtime/GuiSys/CGuiWidgetDrawParms.hpp
+++ b/Runtime/GuiSys/CGuiWidgetDrawParms.hpp
@@ -11,7 +11,7 @@ struct CGuiWidgetDrawParms {
   CGuiWidgetDrawParms() = default;
   CGuiWidgetDrawParms(float alphaMod, const zeus::CVector3f& cameraOff)
   : x0_alphaMod(alphaMod), x4_cameraOffset(cameraOff) {}
-  static CGuiWidgetDrawParms Default;
+  static const CGuiWidgetDrawParms Default;
 };
 
 } // namespace urde


### PR DESCRIPTION
This isn't ever modified, so it can be made const to prevent unintentional modification (and allow it to be placed within the RO segment).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/78)
<!-- Reviewable:end -->
