### PR TITLE
CAuiEnergyBarT01: Prevent truncation within DownloadBarCoordFunc

### DIFF
--- a/Runtime/GuiSys/CAuiEnergyBarT01.cpp
+++ b/Runtime/GuiSys/CAuiEnergyBarT01.cpp
@@ -12,7 +12,7 @@ CAuiEnergyBarT01::CAuiEnergyBarT01(const CGuiWidgetParms& parms, CSimplePool* sp
 }
 
 std::pair<zeus::CVector3f, zeus::CVector3f> CAuiEnergyBarT01::DownloadBarCoordFunc(float t) {
-  float x = 12.5 * t - 6.25;
+  const float x = 12.5f * t - 6.25f;
   return {zeus::CVector3f{x, 0.f, -0.2f}, zeus::CVector3f{x, 0.f, 0.2f}};
 }
 


### PR DESCRIPTION
Without float literals, the calculation is performed in double precision and then truncated down to float implicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/79)
<!-- Reviewable:end -->
