### PR TITLE
CBurstFire: Use std::array where applicable

### DIFF
--- a/Runtime/Weapon/CBurstFire.cpp
+++ b/Runtime/Weapon/CBurstFire.cpp
@@ -1,5 +1,12 @@
-#include "CBurstFire.hpp"
-#include "GameGlobalObjects.hpp"
+#include "Runtime/Weapon/CBurstFire.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+#include "Runtime/GameGlobalObjects.hpp"
+#include "Runtime/CStateManager.hpp"
+
+#include <zeus/Math.hpp>
 
 namespace urde {
 CBurstFire::CBurstFire(const SBurst** burstDefs, s32 firstBurstCount) : x10_firstBurstCounter(firstBurstCount) {

--- a/Runtime/Weapon/CBurstFire.hpp
+++ b/Runtime/Weapon/CBurstFire.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <array>
+
 #include "Runtime/GCNTypes.hpp"
 #include "Runtime/rstl.hpp"
+
 #include <zeus/CVector3f.hpp>
 
 namespace urde {
@@ -9,7 +12,7 @@ class CStateManager;
 
 struct SBurst {
   s32 x0_randomSelectionWeight;
-  s32 x4_shotAngles[8];
+  std::array<s32, 8> x4_shotAngles;
   float x24_timeToNextShot;
   float x28_timeToNextShotVariance;
 };

--- a/Runtime/Weapon/CBurstFire.hpp
+++ b/Runtime/Weapon/CBurstFire.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
-#include "CStateManager.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
+class CStateManager;
+
 struct SBurst {
   s32 x0_randomSelectionWeight;
   s32 x4_shotAngles[8];

--- a/Runtime/World/CScriptGunTurret.cpp
+++ b/Runtime/World/CScriptGunTurret.cpp
@@ -1,17 +1,20 @@
-#include "CScriptGunTurret.hpp"
-#include "GameGlobalObjects.hpp"
-#include "CSimplePool.hpp"
-#include "Particle/CGenDescription.hpp"
-#include "Particle/CElementGen.hpp"
-#include "Weapon/CGameProjectile.hpp"
-#include "World/CGameLight.hpp"
-#include "Collision/CCollisionActorManager.hpp"
-#include "Collision/CCollisionActor.hpp"
-#include "CPlayer.hpp"
-#include "Character/CPASAnimParmData.hpp"
-#include "Graphics/CBooRenderer.hpp"
+#include "Runtime/World/CScriptGunTurret.hpp"
+
+#include "Runtime/CSimplePool.hpp"
+#include "Runtime/GameGlobalObjects.hpp"
+#include "Runtime/Character/CPASAnimParmData.hpp"
+#include "Runtime/Collision/CCollisionActor.hpp"
+#include "Runtime/Collision/CCollisionActorManager.hpp"
+#include "Runtime/Graphics/CBooRenderer.hpp"
+#include "Runtime/Particle/CElementGen.hpp"
+#include "Runtime/Particle/CGenDescription.hpp"
+#include "Runtime/Weapon/CEnergyProjectile.hpp"
+#include "Runtime/Weapon/CGameProjectile.hpp"
+#include "Runtime/World/CAiFuncMap.hpp"
+#include "Runtime/World/CGameLight.hpp"
+#include "Runtime/World/CPlayer.hpp"
+
 #include "TCastTo.hpp" // Generated file, do not modify include path
-#include "Weapon/CEnergyProjectile.hpp"
 
 namespace urde {
 
@@ -149,6 +152,8 @@ CScriptGunTurret::CScriptGunTurret(TUniqueId uid, std::string_view name, ETurret
 
   x37c_projectileInfo.Token().Lock();
 }
+
+CScriptGunTurret::~CScriptGunTurret() = default;
 
 void CScriptGunTurret::Accept(IVisitor& visitor) { visitor.Visit(this); }
 

--- a/Runtime/World/CScriptGunTurret.hpp
+++ b/Runtime/World/CScriptGunTurret.hpp
@@ -1,15 +1,24 @@
 #pragma once
 
-#include <Runtime/Weapon/CBurstFire.hpp>
+#include <memory>
+#include <optional>
+#include <string_view>
 
-#include "CPhysicsActor.hpp"
-#include "CDamageInfo.hpp"
-#include "CDamageVulnerability.hpp"
-#include "Weapon/CProjectileInfo.hpp"
-#include "Weapon/CBurstFire.hpp"
+#include "Runtime/Weapon/CBurstFire.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CDamageInfo.hpp"
+#include "Runtime/World/CDamageVulnerability.hpp"
+#include "Runtime/World/CPhysicsActor.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CCollisionActorManager;
+class CElementGen;
+
+enum class EStateMsg;
+
 class CScriptGunTurretData {
   float x0_intoDeactivateDelay;
   float x4_intoActivateDelay;
@@ -220,6 +229,7 @@ public:
                    const zeus::CTransform& xf, CModelData&& mData, const zeus::CAABox& aabb, const CHealthInfo& hInfo,
                    const CDamageVulnerability& dVuln, const CActorParameters& aParms,
                    const CScriptGunTurretData& turretData);
+  ~CScriptGunTurret() override;
 
   void Accept(IVisitor&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;


### PR DESCRIPTION
Makes the array type strongly typed and prevents implicit array to pointer decay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/80)
<!-- Reviewable:end -->
