### PR TITLE
CCameraManager: Collapse private static variables into functions

### DIFF
--- a/Runtime/Camera/CCameraManager.cpp
+++ b/Runtime/Camera/CCameraManager.cpp
@@ -15,11 +15,7 @@
 #include "World/CExplosion.hpp"
 
 namespace urde {
-float CCameraManager::sAspect = 1.42f;
-float CCameraManager::sFarPlane = 750.f;
-float CCameraManager::sNearPlane = 0.2f;
 float CCameraManager::sFirstPersonFOV = 55.f;
-float CCameraManager::sThirdPersonFOV = 60.f;
 
 CCameraManager::CCameraManager(TUniqueId curCameraId) : x0_curCameraId(curCameraId) {
   CSfxManager::AddListener(CSfxManager::ESfxChannels::Game, zeus::skZero3f, zeus::skZero3f,
@@ -135,13 +131,13 @@ void CCameraManager::CreateStandardCameras(CStateManager& stateMgr) {
   TUniqueId fpId = stateMgr.AllocateUniqueId();
   x7c_fpCamera =
       new CFirstPersonCamera(fpId, zeus::CTransform(), stateMgr.Player()->GetUniqueId(),
-                             g_tweakPlayer->GetOrbitCameraSpeed(), sFirstPersonFOV, sNearPlane, sFarPlane, sAspect);
+                             g_tweakPlayer->GetOrbitCameraSpeed(), sFirstPersonFOV, NearPlane(), FarPlane(), Aspect());
   stateMgr.AddObject(x7c_fpCamera);
   stateMgr.Player()->SetCameraState(CPlayer::EPlayerCameraState::FirstPerson, stateMgr);
   SetCurrentCameraId(fpId, stateMgr);
 
-  x80_ballCamera = new CBallCamera(stateMgr.AllocateUniqueId(), stateMgr.Player()->GetUniqueId(),
-                                   zeus::CTransform(), sThirdPersonFOV, sNearPlane, sFarPlane, sAspect);
+  x80_ballCamera = new CBallCamera(stateMgr.AllocateUniqueId(), stateMgr.Player()->GetUniqueId(), zeus::CTransform(),
+                                   ThirdPersonFOV(), NearPlane(), FarPlane(), Aspect());
   stateMgr.AddObject(x80_ballCamera);
 
   x88_interpCamera = new CInterpolationCamera(stateMgr.AllocateUniqueId(), zeus::CTransform());

--- a/Runtime/Camera/CCameraManager.hpp
+++ b/Runtime/Camera/CCameraManager.hpp
@@ -17,11 +17,7 @@ class CScriptCameraHint;
 class CCinematicCamera;
 
 class CCameraManager {
-  static float sAspect;
-  static float sFarPlane;
-  static float sNearPlane;
   static float sFirstPersonFOV;
-  static float sThirdPersonFOV;
   TUniqueId x0_curCameraId;
   std::vector<TUniqueId> x4_cineCameras;
   std::list<CCameraShakeData> x14_shakers;
@@ -80,11 +76,11 @@ class CCameraManager {
 public:
   CCameraManager(TUniqueId curCameraId = kInvalidUniqueId);
 
-  static float Aspect() { return sAspect; }
-  static float FarPlane() { return sFarPlane; }
-  static float NearPlane() { return sNearPlane; }
+  static float Aspect() { return 1.42f; }
+  static float FarPlane() { return 750.0f; }
+  static float NearPlane() { return 0.2f; }
   static float FirstPersonFOV() { return sFirstPersonFOV; }
-  static float ThirdPersonFOV() { return sThirdPersonFOV; }
+  static float ThirdPersonFOV() { return 60.0f; }
 
   void ResetCameras(CStateManager& mgr);
   void SetSpecialCameras(CFirstPersonCamera& fp, CBallCamera& ball);


### PR DESCRIPTION
Four of the five variables aren't modified, so they can be specified directly within the functions and just be reused in place of the variable names. This allows the constants to be elided or put into read-only memory if necessary. It also makes the mutable value explicit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/85)
<!-- Reviewable:end -->
