### PR TITLE
General: Normalize RuntimeCommon include paths

### DIFF
--- a/Editor/ProjectResourceFactoryBase.hpp
+++ b/Editor/ProjectResourceFactoryBase.hpp
@@ -1,15 +1,20 @@
 #pragma once
 
-#include "hecl/ClientProcess.hpp"
-#include "hecl/Database.hpp"
-#include "Runtime/IFactory.hpp"
+#include <list>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <unordered_map>
+
+#include "DataSpec/SpecBase.hpp"
+
 #include "Runtime/CFactoryMgr.hpp"
 #include "Runtime/CResFactory.hpp"
-#include "DataSpec/SpecBase.hpp"
-#include <optional>
+#include "Runtime/IFactory.hpp"
 
-#include <thread>
-#include <mutex>
+#include <hecl/ClientProcess.hpp>
+#include <hecl/Database.hpp>
 
 namespace urde {
 

--- a/Editor/ProjectResourceFactoryMP1.hpp
+++ b/Editor/ProjectResourceFactoryMP1.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "ProjectResourceFactoryBase.hpp"
-#include "CToken.hpp"
+#include "Editor/ProjectResourceFactoryBase.hpp"
+#include "Runtime/CToken.hpp"
 
 namespace urde {
 class MP1OriginalIDs;

--- a/Runtime/Audio/CAudioGroupSet.hpp
+++ b/Runtime/Audio/CAudioGroupSet.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CFactoryMgr.hpp"
-#include "IObj.hpp"
-#include "CToken.hpp"
-#include "IOStreams.hpp"
-#include "amuse/AudioGroupData.hpp"
+#include <memory>
+#include <string>
+
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/IObj.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <amuse/AudioGroupData.hpp>
 
 namespace urde {
 

--- a/Runtime/Audio/CAudioSys.hpp
+++ b/Runtime/Audio/CAudioSys.hpp
@@ -1,15 +1,16 @@
 #pragma once
 
-#include "../GCNTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "amuse/amuse.hpp"
-#include "boo/audiodev/IAudioVoiceEngine.hpp"
-#include "RetroTypes.hpp"
-#include "CToken.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <amuse/amuse.hpp>
+#include <boo/audiodev/IAudioVoiceEngine.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CSimplePool;
 class CAudioGroupSet;
+class CSimplePool;
 
 CFactoryFnReturn FAudioTranslationTableFactory(const SObjectTag& tag, CInputStream& in, const CVParamTransfer& vparms,
                                                CObjectReference* selfRef);

--- a/Runtime/Audio/CMidiManager.hpp
+++ b/Runtime/Audio/CMidiManager.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "CSfxManager.hpp"
+#include <memory>
+
+#include "Runtime/Audio/CSfxManager.hpp"
 
 namespace urde {
 

--- a/Runtime/Audio/CSfxManager.hpp
+++ b/Runtime/Audio/CSfxManager.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
+#include <memory>
+#include <unordered_set>
 #include <vector>
-#include "../RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "CAudioSys.hpp"
+
 #include "DNAMP1/SFX/SFX.h"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Audio/CAudioSys.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Audio/CStaticAudioPlayer.hpp
+++ b/Runtime/Audio/CStaticAudioPlayer.hpp
@@ -1,10 +1,17 @@
 #pragma once
 
-#include "CAudioSys.hpp"
-#include "RetroTypes.hpp"
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Audio/CAudioSys.hpp"
+
 #include "g721.h"
-#include "boo/audiodev/IAudioVoice.hpp"
-#include "boo/audiodev/IAudioVoiceEngine.hpp"
+
+#include <boo/audiodev/IAudioVoice.hpp>
+#include <boo/audiodev/IAudioVoiceEngine.hpp>
 
 namespace urde {
 class IDvdRequest;

--- a/Runtime/Audio/CStreamAudioManager.hpp
+++ b/Runtime/Audio/CStreamAudioManager.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "RetroTypes.hpp"
+#include <string_view>
+
+#include "Runtime/GCNTypes.hpp"
 
 namespace urde {
 

--- a/Runtime/AutoMapper/CAutoMapper.hpp
+++ b/Runtime/AutoMapper/CAutoMapper.hpp
@@ -1,18 +1,28 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CInGameTweakManagerBase.hpp"
-#include "zeus/CQuaternion.hpp"
-#include "zeus/CTransform.hpp"
-#include "zeus/CVector3f.hpp"
-#include "MP1/CInGameGuiManager.hpp"
+#include <list>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "Runtime/CInGameTweakManagerBase.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/MP1/CInGameGuiManager.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector2f.hpp>
+#include <zeus/CVector2i.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-struct CFinalInput;
-class IWorld;
+class CMapUniverse;
 class CMapWorldInfo;
 class CStateManager;
-class CMapUniverse;
+class IWorld;
+
+struct CFinalInput;
 
 class CAutoMapper {
 public:

--- a/Runtime/AutoMapper/CMapArea.hpp
+++ b/Runtime/AutoMapper/CMapArea.hpp
@@ -1,13 +1,18 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CResFactory.hpp"
-#include "zeus/CAABox.hpp"
-#include "zeus/CVector3f.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "Graphics/CLineRenderer.hpp"
-#include "Graphics/Shaders/CMapSurfaceShader.hpp"
-#include "CMappableObject.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/CResFactory.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/AutoMapper/CMappableObject.hpp"
+#include "Runtime/Graphics/CLineRenderer.hpp"
+#include "Runtime/Graphics/Shaders/CMapSurfaceShader.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class IWorld;

--- a/Runtime/AutoMapper/CMapUniverse.hpp
+++ b/Runtime/AutoMapper/CMapUniverse.hpp
@@ -1,12 +1,16 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CTransform.hpp"
-#include "IFactory.hpp"
-#include "CToken.hpp"
-#include "CMapArea.hpp"
+#include <string>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/IFactory.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/AutoMapper/CMapArea.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CStateManager;

--- a/Runtime/AutoMapper/CMapWorld.hpp
+++ b/Runtime/AutoMapper/CMapWorld.hpp
@@ -1,16 +1,21 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CToken.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/CTransform.hpp"
-#include "CMapArea.hpp"
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/AutoMapper/CMapArea.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class IWorld;
 class CMapWorldInfo;
 class CStateManager;
+class IWorld;
+
 class CMapWorld {
 public:
   /* skDrawProfileItemNames; */

--- a/Runtime/AutoMapper/CMapWorldInfo.hpp
+++ b/Runtime/AutoMapper/CMapWorldInfo.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "RetroTypes.hpp"
+#include <map>
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 class CSaveWorld;

--- a/Runtime/AutoMapper/CMappableObject.hpp
+++ b/Runtime/AutoMapper/CMappableObject.hpp
@@ -1,16 +1,20 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CAABox.hpp"
-#include "zeus/CTransform.hpp"
-#include "GameGlobalObjects.hpp"
-#include "Graphics/Shaders/CMapSurfaceShader.hpp"
-#include "Graphics/Shaders/CTexturedQuadFilter.hpp"
-#include "Graphics/CLineRenderer.hpp"
+#include <optional>
+#include <utility>
+
+#include "Runtime/GameGlobalObjects.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Graphics/CLineRenderer.hpp"
+#include "Runtime/Graphics/Shaders/CMapSurfaceShader.hpp"
+#include "Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CTransform.hpp>
 
 namespace urde {
-class CStateManager;
 class CMapWorldInfo;
+class CStateManager;
 
 class CMappableObject {
   static boo::ObjToken<boo::IGraphicsBufferS> g_doorVbo;

--- a/Runtime/Camera/CBallCamera.hpp
+++ b/Runtime/Camera/CBallCamera.hpp
@@ -1,7 +1,15 @@
 #pragma once
 
-#include "CGameCamera.hpp"
-#include "CCameraSpline.hpp"
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include "Runtime/Camera/CCameraSpline.hpp"
+#include "Runtime/Camera/CGameCamera.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CPlayer;

--- a/Runtime/Camera/CCameraFilter.hpp
+++ b/Runtime/Camera/CCameraFilter.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include "zeus/CColor.hpp"
-#include "RetroTypes.hpp"
-#include "CToken.hpp"
-#include "Graphics/Shaders/CCameraBlurFilter.hpp"
-#include "Graphics/Shaders/CXRayBlurFilter.hpp"
+#include <memory>
+#include <optional>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Graphics/Shaders/CCameraBlurFilter.hpp"
+#include "Runtime/Graphics/Shaders/CXRayBlurFilter.hpp"
+
+#include <zeus/CColor.hpp>
 
 namespace urde {
 class CTexture;

--- a/Runtime/Camera/CCameraManager.hpp
+++ b/Runtime/Camera/CCameraManager.hpp
@@ -1,20 +1,26 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "World/CGameArea.hpp"
+#include <list>
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/World/CGameArea.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CFirstPersonCamera;
 class CBallCamera;
-class CStateManager;
-class CGameCamera;
 class CCameraShakeData;
-class CScriptWater;
-class CInterpolationCamera;
-struct CFinalInput;
-class CScriptCameraHint;
 class CCinematicCamera;
+class CFirstPersonCamera;
+class CGameCamera;
+class CInterpolationCamera;
+class CScriptCameraHint;
+class CScriptWater;
+class CStateManager;
+
+struct CFinalInput;
 
 class CCameraManager {
   static float sAspect;

--- a/Runtime/Camera/CCameraShakeData.hpp
+++ b/Runtime/Camera/CCameraShakeData.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "zeus/CVector3f.hpp"
-#include "RetroTypes.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CRandom16;

--- a/Runtime/Camera/CCinematicCamera.hpp
+++ b/Runtime/Camera/CCinematicCamera.hpp
@@ -1,6 +1,13 @@
 #pragma once
 
-#include "CGameCamera.hpp"
+#include <string_view>
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Camera/CGameCamera.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Camera/CFirstPersonCamera.hpp
+++ b/Runtime/Camera/CFirstPersonCamera.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "CGameCamera.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Camera/CGameCamera.hpp"
+
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Camera/CGameCamera.hpp
+++ b/Runtime/Camera/CGameCamera.hpp
@@ -1,14 +1,17 @@
 #pragma once
 
-#include "World/CActor.hpp"
-#include "zeus/CTransform.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/World/CActor.hpp"
+
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CTransform.hpp>
 
 namespace urde {
 struct CFinalInput;
 
 class CGameCamera : public CActor {
-  friend class CStateManager;
   friend class CCameraManager;
+  friend class CStateManager;
 
 protected:
   TUniqueId xe8_watchedObject;

--- a/Runtime/Camera/CInterpolationCamera.hpp
+++ b/Runtime/Camera/CInterpolationCamera.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "CGameCamera.hpp"
+#include "Runtime/Camera/CGameCamera.hpp"
+
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Camera/CPathCamera.hpp
+++ b/Runtime/Camera/CPathCamera.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "CGameCamera.hpp"
-#include "CCameraSpline.hpp"
+#include "Runtime/Camera/CCameraSpline.hpp"
+#include "Runtime/Camera/CGameCamera.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CActorLights.hpp
+++ b/Runtime/Character/CActorLights.hpp
@@ -1,15 +1,18 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CAABox.hpp"
-#include "Graphics/CLight.hpp"
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Graphics/CLight.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CBooModel;
-class CStateManager;
 class CGameArea;
+class CStateManager;
 
 class CActorLights {
   static s32 sFrameSchedulerCount;

--- a/Runtime/Character/CAdditiveAnimPlayback.hpp
+++ b/Runtime/Character/CAdditiveAnimPlayback.hpp
@@ -1,12 +1,13 @@
 #pragma once
 
-#include "RetroTypes.hpp"
+#include <memory>
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
-class CAnimTreeNode;
 class CAdditiveAnimationInfo;
-class CSegIdList;
+class CAnimTreeNode;
 class CCharLayoutInfo;
+class CSegIdList;
 class CSegStatementSet;
 
 class CAdditiveAnimationInfo {

--- a/Runtime/Character/CAdditiveBodyState.hpp
+++ b/Runtime/Character/CAdditiveBodyState.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CharacterCommon.hpp"
-#include "CBodyStateCmdMgr.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CBodyStateCmdMgr.hpp"
+#include "Runtime/Character/CharacterCommon.hpp"
 
 namespace urde {
+class CActor;
 class CBodyController;
 class CStateManager;
-class CActor;
+
 class CAdditiveBodyState {
 public:
   virtual ~CAdditiveBodyState() = default;

--- a/Runtime/Character/CAllFormatsAnimSource.hpp
+++ b/Runtime/Character/CAllFormatsAnimSource.hpp
@@ -1,14 +1,18 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "CAnimSource.hpp"
-#include "CFBStreamedCompression.hpp"
-#include "CFactoryMgr.hpp"
+#include <algorithm>
+#include <memory>
+
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CAnimSource.hpp"
+#include "Runtime/Character/CFBStreamedCompression.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class IObjectStore;
 class IAnimReader;
+class IObjectStore;
 
 enum class EAnimFormat { Uncompressed, Unknown, BitstreamCompressed, BitstreamCompressed24 };
 

--- a/Runtime/Character/CAnimCharacterSet.hpp
+++ b/Runtime/Character/CAnimCharacterSet.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "CFactoryMgr.hpp"
-#include "CCharacterSet.hpp"
-#include "CAnimationSet.hpp"
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/Character/CAnimationSet.hpp"
+#include "Runtime/Character/CCharacterSet.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimData.hpp
+++ b/Runtime/Character/CAnimData.hpp
@@ -1,16 +1,24 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CToken.hpp"
-#include "CCharacterInfo.hpp"
-#include "CParticleDatabase.hpp"
-#include "CPoseAsTransforms.hpp"
-#include "CHierarchyPoseBuilder.hpp"
-#include "CAdditiveAnimPlayback.hpp"
-#include "CCharLayoutInfo.hpp"
-#include "CAnimPlaybackParms.hpp"
-#include "IAnimReader.hpp"
+#include <memory>
 #include <set>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CAdditiveAnimPlayback.hpp"
+#include "Runtime/Character/CAnimPlaybackParms.hpp"
+#include "Runtime/Character/CCharLayoutInfo.hpp"
+#include "Runtime/Character/CCharacterInfo.hpp"
+#include "Runtime/Character/CHierarchyPoseBuilder.hpp"
+#include "Runtime/Character/CParticleDatabase.hpp"
+#include "Runtime/Character/CPoseAsTransforms.hpp"
+#include "Runtime/Character/IAnimReader.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 enum class EUserEventType {
   Projectile = 0,
@@ -51,30 +59,31 @@ enum class EUserEventType {
 };
 
 namespace urde {
-class CCharLayoutInfo;
-class CSkinnedModel;
-class CMorphableSkinnedModel;
-struct CAnimSysContext;
+class CAnimTreeNode;
 class CAnimationManager;
-class CTransitionManager;
+class CBoolPOINode;
+class CCharAnimTime;
+class CCharLayoutInfo;
 class CCharacterFactory;
-class IMetaAnim;
-struct CModelFlags;
-class CVertexMorphEffect;
+class CInt32POINode;
+class CModel;
+class CMorphableSkinnedModel;
+class CParticlePOINode;
 class CPrimitive;
 class CRandom16;
-class CStateManager;
-class CCharAnimTime;
-class CModel;
-class CSkinRules;
-class CAnimTreeNode;
 class CSegIdList;
 class CSegStatementSet;
-class CBoolPOINode;
-class CInt32POINode;
-class CParticlePOINode;
+class CSkinRules;
+class CSkinnedModel;
 class CSoundPOINode;
+class CStateManager;
+class CTransitionManager;
+class CVertexMorphEffect;
 class IAnimReader;
+class IMetaAnim;
+
+struct CAnimSysContext;
+struct CModelFlags;
 struct SAdvancementDeltas;
 struct SAdvancementResults;
 

--- a/Runtime/Character/CAnimPOIData.hpp
+++ b/Runtime/Character/CAnimPOIData.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
-#include "CFactoryMgr.hpp"
-#include "CBoolPOINode.hpp"
-#include "CInt32POINode.hpp"
-#include "CParticlePOINode.hpp"
-#include "CSoundPOINode.hpp"
+#include <vector>
+
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Character/CBoolPOINode.hpp"
+#include "Runtime/Character/CInt32POINode.hpp"
+#include "Runtime/Character/CParticlePOINode.hpp"
+#include "Runtime/Character/CSoundPOINode.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimPerSegmentData.hpp
+++ b/Runtime/Character/CAnimPerSegmentData.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "zeus/CQuaternion.hpp"
-#include "zeus/CVector3f.hpp"
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Character/CAnimPlaybackParms.hpp
+++ b/Runtime/Character/CAnimPlaybackParms.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CQuaternion.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CAnimPlaybackParms {

--- a/Runtime/Character/CAnimSource.hpp
+++ b/Runtime/Character/CAnimSource.hpp
@@ -1,22 +1,26 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CCharAnimTime.hpp"
-#include "zeus/CQuaternion.hpp"
-#include "zeus/CVector3f.hpp"
-#include "CSegId.hpp"
-#include "CToken.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CCharAnimTime.hpp"
+#include "Runtime/Character/CSegId.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class IObjectStore;
-class CSegIdList;
-class CSegStatementSet;
-class CSegId;
 class CAnimPOIData;
 class CBoolPOINode;
 class CInt32POINode;
 class CParticlePOINode;
+class CSegId;
+class CSegIdList;
+class CSegStatementSet;
 class CSoundPOINode;
+class IObjectStore;
 
 class RotationAndOffsetStorage {
   friend class CAnimSource;

--- a/Runtime/Character/CAnimSourceReader.hpp
+++ b/Runtime/Character/CAnimSourceReader.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
-#include "IAnimReader.hpp"
-#include "CToken.hpp"
-#include "CAnimSource.hpp"
-#include "CParticleData.hpp"
+#include <memory>
 #include <set>
+#include <utility>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Character/CAnimSource.hpp"
+#include "Runtime/Character/CParticleData.hpp"
+#include "Runtime/Character/IAnimReader.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimSysContext.hpp
+++ b/Runtime/Character/CAnimSysContext.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#include "CToken.hpp"
-#include "CRandom16.hpp"
+#include <memory>
+
+#include "Runtime/CRandom16.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/GCNTypes.hpp"
 
 namespace urde {
-class CTransitionDatabaseGame;
 class CSimplePool;
+class CTransitionDatabaseGame;
 
 struct CAnimSysContext {
   TToken<CTransitionDatabaseGame> x0_transDB;

--- a/Runtime/Character/CAnimTreeAnimReaderContainer.hpp
+++ b/Runtime/Character/CAnimTreeAnimReaderContainer.hpp
@@ -1,6 +1,12 @@
 #pragma once
 
-#include "CAnimTreeNode.hpp"
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CAnimTreeNode.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimTreeBlend.hpp
+++ b/Runtime/Character/CAnimTreeBlend.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "CAnimTreeTweenBase.hpp"
+#include <memory>
+#include <string>
+
+#include "Runtime/Character/CAnimTreeTweenBase.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimTreeDoubleChild.hpp
+++ b/Runtime/Character/CAnimTreeDoubleChild.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "CAnimTreeNode.hpp"
+#include <memory>
+#include <string_view>
+
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CAnimTreeNode.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimTreeLoopIn.hpp
+++ b/Runtime/Character/CAnimTreeLoopIn.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
-#include "CAnimTreeSingleChild.hpp"
-#include "CAnimSysContext.hpp"
-#include "CSequenceHelper.hpp"
+#include <memory>
+#include <string>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Character/CAnimSysContext.hpp"
+#include "Runtime/Character/CAnimTreeSingleChild.hpp"
+#include "Runtime/Character/CSequenceHelper.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimTreeNode.hpp
+++ b/Runtime/Character/CAnimTreeNode.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
-#include "IAnimReader.hpp"
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Character/IAnimReader.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimTreeSequence.hpp
+++ b/Runtime/Character/CAnimTreeSequence.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
-#include "CAnimTreeSingleChild.hpp"
-#include "CAnimSysContext.hpp"
-#include "CSequenceHelper.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Character/CAnimSysContext.hpp"
+#include "Runtime/Character/CAnimTreeSingleChild.hpp"
+#include "Runtime/Character/CSequenceHelper.hpp"
 
 namespace urde {
 class IMetaAnim;

--- a/Runtime/Character/CAnimTreeSingleChild.hpp
+++ b/Runtime/Character/CAnimTreeSingleChild.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "CAnimTreeNode.hpp"
+#include <memory>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CAnimTreeNode.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimTreeTimeScale.hpp
+++ b/Runtime/Character/CAnimTreeTimeScale.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "CAnimTreeSingleChild.hpp"
-#include "CTimeScaleFunctions.hpp"
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Character/CAnimTreeSingleChild.hpp"
+#include "Runtime/Character/CTimeScaleFunctions.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimTreeTransition.hpp
+++ b/Runtime/Character/CAnimTreeTransition.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CAnimTreeTweenBase.hpp"
+#include <memory>
+#include <string_view>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CAnimTreeTweenBase.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimTreeTweenBase.hpp
+++ b/Runtime/Character/CAnimTreeTweenBase.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "CAnimTreeDoubleChild.hpp"
+#include <memory>
+#include <utility>
+
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CAnimTreeDoubleChild.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAnimation.hpp
+++ b/Runtime/Character/CAnimation.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CMetaAnimFactory.hpp"
+#include <memory>
+#include <string>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CMetaAnimFactory.hpp"
 
 namespace urde {
 class IMetaAnim;

--- a/Runtime/Character/CAnimationDatabase.hpp
+++ b/Runtime/Character/CAnimationDatabase.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
-#include "../RetroTypes.hpp"
-#include <vector>
 #include <set>
-#include <string>
+#include <string_view>
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
-class IMetaAnim;
 class CPrimitive;
+class IMetaAnim;
 
 class CAnimationDatabase {
 public:

--- a/Runtime/Character/CAnimationDatabaseGame.hpp
+++ b/Runtime/Character/CAnimationDatabaseGame.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "CAnimationDatabase.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/Character/CAnimationDatabase.hpp"
 
 namespace urde {
 class CAnimation;

--- a/Runtime/Character/CAnimationManager.hpp
+++ b/Runtime/Character/CAnimationManager.hpp
@@ -1,15 +1,18 @@
 #pragma once
 
-#include "CToken.hpp"
-#include "CAnimSysContext.hpp"
+#include <memory>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/Character/CAnimSysContext.hpp"
 
 namespace urde {
-class CAnimationDatabaseGame;
-class CTransitionDatabaseGame;
-class CSimplePool;
 class CAnimTreeNode;
-struct CMetaAnimTreeBuildOrders;
+class CAnimationDatabaseGame;
+class CSimplePool;
+class CTransitionDatabaseGame;
 class IMetaAnim;
+
+struct CMetaAnimTreeBuildOrders;
 
 class CAnimationManager {
   TToken<CAnimationDatabaseGame> x0_animDB;

--- a/Runtime/Character/CAnimationSet.hpp
+++ b/Runtime/Character/CAnimationSet.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CAnimation.hpp"
-#include "CTransition.hpp"
-#include "CHalfTransition.hpp"
-#include "CAdditiveAnimPlayback.hpp"
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CAdditiveAnimPlayback.hpp"
+#include "Runtime/Character/CAnimation.hpp"
+#include "Runtime/Character/CHalfTransition.hpp"
+#include "Runtime/Character/CTransition.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CAssetFactory.hpp
+++ b/Runtime/Character/CAssetFactory.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "IFactory.hpp"
-#include "IObj.hpp"
-#include "CToken.hpp"
-#include "CSimplePool.hpp"
+#include <functional>
+#include <memory>
+
+#include "Runtime/CSimplePool.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/IFactory.hpp"
+#include "Runtime/IObj.hpp"
 
 namespace urde {
 class CCharacterFactory;

--- a/Runtime/Character/CBodyController.hpp
+++ b/Runtime/Character/CBodyController.hpp
@@ -1,20 +1,22 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CQuaternion.hpp"
-#include "CharacterCommon.hpp"
-#include "CBodyStateCmdMgr.hpp"
-#include "CBodyStateInfo.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CBodyStateCmdMgr.hpp"
+#include "Runtime/Character/CBodyStateInfo.hpp"
+#include "Runtime/Character/CharacterCommon.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-
 class CActor;
 class CAnimPlaybackParms;
-struct CFinalInput;
 class CPASAnimParmData;
+class CPASDatabase;
 class CRandom16;
 class CStateManager;
-class CPASDatabase;
+
+struct CFinalInput;
 
 class CBodyController {
   CActor& x0_actor;

--- a/Runtime/Character/CBodyState.hpp
+++ b/Runtime/Character/CBodyState.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CharacterCommon.hpp"
-#include "CBodyStateCmdMgr.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CBodyStateCmdMgr.hpp"
+#include "Runtime/Character/CharacterCommon.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CBodyController;

--- a/Runtime/Character/CBodyStateCmdMgr.hpp
+++ b/Runtime/Character/CBodyStateCmdMgr.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CharacterCommon.hpp"
-#include "zeus/CVector3f.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CharacterCommon.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Character/CBodyStateInfo.hpp
+++ b/Runtime/Character/CBodyStateInfo.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CharacterCommon.hpp"
-#include "CBodyState.hpp"
-#include "CAdditiveBodyState.hpp"
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CAdditiveBodyState.hpp"
+#include "Runtime/Character/CBodyState.hpp"
+#include "Runtime/Character/CharacterCommon.hpp"
 
 namespace urde {
 class CActor;

--- a/Runtime/Character/CBoneTracking.hpp
+++ b/Runtime/Character/CBoneTracking.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#include "Character/CSegId.hpp"
+#include <optional>
+#include <string_view>
 
-#include "zeus/CTransform.hpp"
-#include "zeus/CQuaternion.hpp"
-#include "zeus/CVector3f.hpp"
-#include "RetroTypes.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CSegId.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CAnimData;

--- a/Runtime/Character/CBoolPOINode.hpp
+++ b/Runtime/Character/CBoolPOINode.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "CPOINode.hpp"
+#include "Runtime/Character/CPOINode.hpp"
 
 namespace urde {
 class IAnimSourceInfo;

--- a/Runtime/Character/CCharAnimTime.hpp
+++ b/Runtime/Character/CCharAnimTime.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "IOStreams.hpp"
+#include "Runtime/IOStreams.hpp"
 
 #undef min
 #undef max

--- a/Runtime/Character/CCharLayoutInfo.hpp
+++ b/Runtime/Character/CCharLayoutInfo.hpp
@@ -1,10 +1,17 @@
 #pragma once
 
-#include "CFactoryMgr.hpp"
-#include "IOStreams.hpp"
-#include "CSegIdList.hpp"
-#include "CSegId.hpp"
-#include "TSegIdMap.hpp"
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CSegId.hpp"
+#include "Runtime/Character/CSegIdList.hpp"
+#include "Runtime/Character/TSegIdMap.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Character/CCharacterInfo.hpp
+++ b/Runtime/Character/CCharacterInfo.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CPASDatabase.hpp"
-#include "zeus/CAABox.hpp"
-#include "CEffectComponent.hpp"
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CEffectComponent.hpp"
+#include "Runtime/Character/CPASDatabase.hpp"
+
+#include <zeus/CAABox.hpp>
 
 namespace urde {
 

--- a/Runtime/Character/CCharacterSet.hpp
+++ b/Runtime/Character/CCharacterSet.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CCharacterInfo.hpp"
+#include <map>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Character/CCharacterInfo.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CEffectComponent.hpp
+++ b/Runtime/Character/CEffectComponent.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "RetroTypes.hpp"
-#include "CParticleData.hpp"
+#include <string>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CParticleData.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CFBStreamedAnimReader.hpp
+++ b/Runtime/Character/CFBStreamedAnimReader.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "CAnimSourceReader.hpp"
-#include "CFBStreamedCompression.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/Character/CAnimSourceReader.hpp"
+#include "Runtime/Character/CFBStreamedCompression.hpp"
 
 namespace urde {
 class CBitLevelLoader;

--- a/Runtime/Character/CFBStreamedCompression.hpp
+++ b/Runtime/Character/CFBStreamedCompression.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CToken.hpp"
-#include "CAnimPOIData.hpp"
-#include "zeus/CVector3f.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CAnimPOIData.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class IObjectStore;

--- a/Runtime/Character/CGroundMovement.hpp
+++ b/Runtime/Character/CGroundMovement.hpp
@@ -1,14 +1,19 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "Collision/CCollisionInfo.hpp"
+#include <optional>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Collision/CCollisionInfo.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
+class CAreaCollisionCache;
+class CCollisionInfoList;
+class CMaterialFilter;
 class CPhysicsActor;
 class CStateManager;
-class CAreaCollisionCache;
-class CMaterialFilter;
-class CCollisionInfoList;
 
 class CGroundMovement {
 public:

--- a/Runtime/Character/CHalfTransition.hpp
+++ b/Runtime/Character/CHalfTransition.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "IMetaTrans.hpp"
+#include <memory>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/IMetaTrans.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CHierarchyPoseBuilder.hpp
+++ b/Runtime/Character/CHierarchyPoseBuilder.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include "CSegId.hpp"
-#include "TSegIdMap.hpp"
-#include "zeus/CQuaternion.hpp"
-#include "CLayoutDescription.hpp"
+#include "Runtime/Character/CLayoutDescription.hpp"
+#include "Runtime/Character/CSegId.hpp"
+#include "Runtime/Character/TSegIdMap.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CLayoutDescription;
 class CCharLayoutInfo;
+class CLayoutDescription;
 class CPoseAsTransforms;
 
 class CHierarchyPoseBuilder {

--- a/Runtime/Character/CIkChain.hpp
+++ b/Runtime/Character/CIkChain.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CTransform.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/CQuaternion.hpp"
-#include "Character/CSegId.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CSegId.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CAnimData;

--- a/Runtime/Character/CInt32POINode.hpp
+++ b/Runtime/Character/CInt32POINode.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "CPOINode.hpp"
+#include <string>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Character/CPOINode.hpp"
 
 namespace urde {
 class IAnimSourceInfo;

--- a/Runtime/Character/CLayoutDescription.hpp
+++ b/Runtime/Character/CLayoutDescription.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <optional>
-#include "CToken.hpp"
-#include "zeus/CVector3f.hpp"
+
+#include "Runtime/CToken.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CCharLayoutInfo;

--- a/Runtime/Character/CMetaAnimBlend.hpp
+++ b/Runtime/Character/CMetaAnimBlend.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "IMetaAnim.hpp"
-#include "IOStreams.hpp"
+#include <memory>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/IMetaAnim.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaAnimFactory.hpp
+++ b/Runtime/Character/CMetaAnimFactory.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "IMetaAnim.hpp"
+#include <memory>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/IMetaAnim.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaAnimPhaseBlend.hpp
+++ b/Runtime/Character/CMetaAnimPhaseBlend.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "IMetaAnim.hpp"
-#include "IOStreams.hpp"
+#include <memory>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/IMetaAnim.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaAnimPlay.hpp
+++ b/Runtime/Character/CMetaAnimPlay.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "IMetaAnim.hpp"
-#include "CPrimitive.hpp"
-#include "IOStreams.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CPrimitive.hpp"
+#include "Runtime/Character/IMetaAnim.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaAnimRandom.hpp
+++ b/Runtime/Character/CMetaAnimRandom.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "IMetaAnim.hpp"
-#include "IOStreams.hpp"
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/IMetaAnim.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaAnimSequence.hpp
+++ b/Runtime/Character/CMetaAnimSequence.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "IMetaAnim.hpp"
-#include "IOStreams.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/IMetaAnim.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaTransFactory.hpp
+++ b/Runtime/Character/CMetaTransFactory.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "IMetaTrans.hpp"
+#include <memory>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/IMetaTrans.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaTransMetaAnim.hpp
+++ b/Runtime/Character/CMetaTransMetaAnim.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "IMetaTrans.hpp"
-#include "IMetaAnim.hpp"
-#include "IOStreams.hpp"
+#include <memory>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/IMetaAnim.hpp"
+#include "Runtime/Character/IMetaTrans.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaTransPhaseTrans.hpp
+++ b/Runtime/Character/CMetaTransPhaseTrans.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "IMetaTrans.hpp"
-#include "IOStreams.hpp"
-#include "CCharAnimTime.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CCharAnimTime.hpp"
+#include "Runtime/Character/IMetaTrans.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaTransSnap.hpp
+++ b/Runtime/Character/CMetaTransSnap.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "IMetaTrans.hpp"
-#include "IOStreams.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/IMetaTrans.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CMetaTransTrans.hpp
+++ b/Runtime/Character/CMetaTransTrans.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "IMetaTrans.hpp"
-#include "IOStreams.hpp"
-#include "CCharAnimTime.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CCharAnimTime.hpp"
+#include "Runtime/Character/IMetaTrans.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CModelData.hpp
+++ b/Runtime/Character/CModelData.hpp
@@ -1,22 +1,25 @@
 #pragma once
 
-#include "zeus/CVector3f.hpp"
-#include "zeus/CAABox.hpp"
-#include "zeus/CColor.hpp"
-#include "RetroTypes.hpp"
-#include "CToken.hpp"
-#include "CAnimData.hpp"
-#include "Graphics/CModel.hpp"
+#include <memory>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CAnimData.hpp"
+#include "Runtime/Graphics/CModel.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CCharAnimTime;
-class CStateManager;
 class CActorLights;
-struct CModelFlags;
-class CRandom16;
 class CAnimData;
+class CCharAnimTime;
 class CModel;
+class CRandom16;
 class CSkinnedModel;
+class CStateManager;
+struct CModelFlags;
 struct SAdvancementDeltas;
 
 class CStaticRes {

--- a/Runtime/Character/CPASAnimInfo.hpp
+++ b/Runtime/Character/CPASAnimInfo.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "rstl.hpp"
-#include "CPASAnimParm.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CPASAnimParm.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CPASAnimParm.hpp
+++ b/Runtime/Character/CPASAnimParm.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "RetroTypes.hpp"
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CPASAnimParmData.hpp
+++ b/Runtime/Character/CPASAnimParmData.hpp
@@ -1,6 +1,8 @@
 #pragma once
-#include "RetroTypes.hpp"
-#include "CPASAnimParm.hpp"
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CPASAnimParm.hpp"
 
 namespace urde {
 class CPASAnimParmData {

--- a/Runtime/Character/CPASAnimState.hpp
+++ b/Runtime/Character/CPASAnimState.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CPASParmInfo.hpp"
-#include "CPASAnimInfo.hpp"
+#include <utility>
+#include <vector>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CPASAnimInfo.hpp"
+#include "Runtime/Character/CPASParmInfo.hpp"
 
 namespace urde {
 class CRandom16;

--- a/Runtime/Character/CPASDatabase.hpp
+++ b/Runtime/Character/CPASDatabase.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CPASAnimState.hpp"
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CPASAnimState.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CPASParmInfo.hpp
+++ b/Runtime/Character/CPASParmInfo.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CPASAnimParm.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CPASAnimParm.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CPOINode.hpp
+++ b/Runtime/Character/CPOINode.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CCharAnimTime.hpp"
+#include <string>
+#include <vector>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CCharAnimTime.hpp"
 
 namespace urde {
 class IAnimSourceInfo;

--- a/Runtime/Character/CParticleData.hpp
+++ b/Runtime/Character/CParticleData.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
+#include <string>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Character/CParticleDatabase.hpp
+++ b/Runtime/Character/CParticleDatabase.hpp
@@ -1,17 +1,22 @@
 #pragma once
 
-#include "CCharacterInfo.hpp"
-#include "CParticleGenInfo.hpp"
-#include "zeus/CFrustum.hpp"
-#include "CToken.hpp"
-#include "Particle/CGenDescription.hpp"
-#include "Particle/CSwooshDescription.hpp"
-#include "Particle/CElectricDescription.hpp"
 #include <map>
+#include <memory>
+#include <string>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/Character/CCharacterInfo.hpp"
+#include "Runtime/Character/CParticleGenInfo.hpp"
+#include "Runtime/Particle/CGenDescription.hpp"
+#include "Runtime/Particle/CSwooshDescription.hpp"
+#include "Runtime/Particle/CElectricDescription.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CFrustum.hpp>
 
 namespace urde {
-class CPoseAsTransforms;
 class CCharLayoutInfo;
+class CPoseAsTransforms;
 
 class CParticleDatabase {
   std::map<CAssetId, std::shared_ptr<TLockedToken<CGenDescription>>> x0_particleDescs;

--- a/Runtime/Character/CParticleGenInfo.hpp
+++ b/Runtime/Character/CParticleGenInfo.hpp
@@ -1,14 +1,18 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CParticleData.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/CAABox.hpp"
+#include <memory>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CParticleData.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-struct SObjectTag;
 class CParticleGen;
 class CStateManager;
+struct SObjectTag;
 
 enum class EParticleGenType { Normal, Auxiliary };
 

--- a/Runtime/Character/CParticlePOINode.hpp
+++ b/Runtime/Character/CParticlePOINode.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "CPOINode.hpp"
-#include "CParticleData.hpp"
+#include "Runtime/Character/CParticleData.hpp"
+#include "Runtime/Character/CPOINode.hpp"
 
 namespace urde {
 class IAnimSourceInfo;

--- a/Runtime/Character/CPoseAsTransforms.hpp
+++ b/Runtime/Character/CPoseAsTransforms.hpp
@@ -1,8 +1,14 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CSegId.hpp"
-#include "zeus/CTransform.hpp"
+#include <memory>
+#include <utility>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CSegId.hpp"
+
+#include <zeus/CMatrix3f.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CCharLayoutInfo;

--- a/Runtime/Character/CPrimitive.hpp
+++ b/Runtime/Character/CPrimitive.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "RetroTypes.hpp"
+#include <string>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CRagDoll.hpp
+++ b/Runtime/Character/CRagDoll.hpp
@@ -1,13 +1,17 @@
 #pragma once
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/CQuaternion.hpp"
-#include "zeus/CAABox.hpp"
-#include "CSegId.hpp"
+
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CSegId.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CHierarchyPoseBuilder;
 class CCharLayoutInfo;
+class CHierarchyPoseBuilder;
 class CModelData;
 class CStateManager;
 

--- a/Runtime/Character/CSegId.hpp
+++ b/Runtime/Character/CSegId.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "IOStreams.hpp"
-#include "zeus/CVector3f.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Character/CSegIdList.hpp
+++ b/Runtime/Character/CSegIdList.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CSegId.hpp"
+#include <vector>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CSegId.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CSegStatementSet.hpp
+++ b/Runtime/Character/CSegStatementSet.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "CAnimPerSegmentData.hpp"
-#include "CSegId.hpp"
+#include "Runtime/Character/CAnimPerSegmentData.hpp"
+#include "Runtime/Character/CSegId.hpp"
 
 namespace urde {
-class CSegIdList;
 class CCharLayoutInfo;
+class CSegIdList;
 
 class CSegStatementSet {
 public:

--- a/Runtime/Character/CSequenceHelper.hpp
+++ b/Runtime/Character/CSequenceHelper.hpp
@@ -1,15 +1,18 @@
 #pragma once
 
-#include "CAnimTreeNode.hpp"
-#include "CBoolPOINode.hpp"
-#include "CInt32POINode.hpp"
-#include "CParticlePOINode.hpp"
-#include "CSoundPOINode.hpp"
-#include "CAnimSysContext.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/Character/CAnimSysContext.hpp"
+#include "Runtime/Character/CAnimTreeNode.hpp"
+#include "Runtime/Character/CBoolPOINode.hpp"
+#include "Runtime/Character/CInt32POINode.hpp"
+#include "Runtime/Character/CParticlePOINode.hpp"
+#include "Runtime/Character/CSoundPOINode.hpp"
 
 namespace urde {
-class IMetaAnim;
 class CTransitionDatabaseGame;
+class IMetaAnim;
 
 class CSequenceFundamentals {
   CSteadyStateAnimInfo x0_ssInfo;

--- a/Runtime/Character/CSkinBank.hpp
+++ b/Runtime/Character/CSkinBank.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CSegId.hpp"
+#include <vector>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CSegId.hpp"
 
 namespace urde {
 class CPoseAsTransforms;

--- a/Runtime/Character/CSkinRules.hpp
+++ b/Runtime/Character/CSkinRules.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "RetroTypes.hpp"
-#include "CSkinBank.hpp"
-#include "CFactoryMgr.hpp"
+#include <vector>
+
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CSkinBank.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CPoseAsTransforms;

--- a/Runtime/Character/CSoundPOINode.hpp
+++ b/Runtime/Character/CSoundPOINode.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "CPOINode.hpp"
-#include "CCharAnimTime.hpp"
+#include "Runtime/Character/CCharAnimTime.hpp"
+#include "Runtime/Character/CPOINode.hpp"
 
 namespace urde {
 class IAnimSourceInfo;

--- a/Runtime/Character/CSteeringBehaviors.hpp
+++ b/Runtime/Character/CSteeringBehaviors.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+
+#include <zeus/CVector2f.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CPhysicsActor;

--- a/Runtime/Character/CTimeScaleFunctions.hpp
+++ b/Runtime/Character/CTimeScaleFunctions.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CCharAnimTime.hpp"
+#include <memory>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CCharAnimTime.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CTransition.hpp
+++ b/Runtime/Character/CTransition.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CMetaTransFactory.hpp"
+#include <memory>
+#include <utility>
+
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Character/CMetaTransFactory.hpp"
 
 namespace urde {
 

--- a/Runtime/Character/CTransitionDatabase.hpp
+++ b/Runtime/Character/CTransitionDatabase.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "../RetroTypes.hpp"
+#include <memory>
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 class IMetaTrans;

--- a/Runtime/Character/CTransitionDatabaseGame.hpp
+++ b/Runtime/Character/CTransitionDatabaseGame.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
-#include "CTransitionDatabase.hpp"
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Runtime/Character/CTransitionDatabase.hpp"
 
 namespace urde {
 class CTransition;

--- a/Runtime/Character/CTransitionManager.hpp
+++ b/Runtime/Character/CTransitionManager.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include "CToken.hpp"
-#include "CAnimSysContext.hpp"
+#include <memory>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/Character/CAnimSysContext.hpp"
 
 namespace urde {
-class CTransitionDatabaseGame;
+class CAnimTreeNode;
 class CRandom16;
 class CSimplePool;
-class CAnimTreeNode;
+class CTransitionDatabaseGame;
 
 class CTransitionManager {
   CAnimSysContext x0_animCtx;

--- a/Runtime/Character/CTreeUtils.hpp
+++ b/Runtime/Character/CTreeUtils.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "RetroTypes.hpp"
+#include <memory>
+
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 class CAnimTreeNode;

--- a/Runtime/Character/IAnimReader.hpp
+++ b/Runtime/Character/IAnimReader.hpp
@@ -1,21 +1,25 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CCharAnimTime.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/CQuaternion.hpp"
-#include "CParticleData.hpp"
-#include "CToken.hpp"
-#include "CAllFormatsAnimSource.hpp"
+#include <memory>
+#include <optional>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CAllFormatsAnimSource.hpp"
+#include "Runtime/Character/CCharAnimTime.hpp"
+#include "Runtime/Character/CParticleData.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CSegId;
 class CBoolPOINode;
 class CInt32POINode;
 class CParticlePOINode;
-class CSoundPOINode;
+class CSegId;
 class CSegIdList;
 class CSegStatementSet;
+class CSoundPOINode;
 
 struct SAdvancementDeltas {
   zeus::CVector3f x0_posDelta;

--- a/Runtime/Character/IMetaAnim.hpp
+++ b/Runtime/Character/IMetaAnim.hpp
@@ -1,15 +1,18 @@
 #pragma once
 
-#include "../RetroTypes.hpp"
-#include "CCharAnimTime.hpp"
+#include <memory>
+#include <optional>
 #include <set>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CCharAnimTime.hpp"
 
 namespace urde {
 class CAnimTreeNode;
-struct CAnimSysContext;
-struct CMetaAnimTreeBuildOrders;
 class CPrimitive;
 class IAnimReader;
+struct CAnimSysContext;
+struct CMetaAnimTreeBuildOrders;
 
 enum class EMetaAnimType { Play, Blend, PhaseBlend, Random, Sequence };
 

--- a/Runtime/Character/IMetaTrans.hpp
+++ b/Runtime/Character/IMetaTrans.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "../RetroTypes.hpp"
+#include <memory>
+
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 class CAnimTreeNode;

--- a/Runtime/Character/IVaryingAnimationTimeScale.hpp
+++ b/Runtime/Character/IVaryingAnimationTimeScale.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "CCharAnimTime.hpp"
+#include <memory>
+
+#include "Runtime/Character/CCharAnimTime.hpp"
 
 namespace urde {
 class IVaryingAnimationTimeScale {

--- a/Runtime/Character/TSegIdMap.hpp
+++ b/Runtime/Character/TSegIdMap.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <map>
-#include "CSegId.hpp"
+#include <memory>
+#include <utility>
+
+#include "Runtime/Character/CSegId.hpp"
 
 namespace urde {
 

--- a/Runtime/Collision/CAABoxFilter.hpp
+++ b/Runtime/Collision/CAABoxFilter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ICollisionFilter.hpp"
+#include "Runtime/Collision/ICollisionFilter.hpp"
 
 namespace urde {
 

--- a/Runtime/Collision/CAreaOctTree.hpp
+++ b/Runtime/Collision/CAreaOctTree.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CAABox.hpp"
-#include "Collision/CCollisionEdge.hpp"
-#include "Collision/CCollisionSurface.hpp"
-#include "zeus/CLine.hpp"
+#include <optional>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Collision/CCollisionEdge.hpp"
+#include "Runtime/Collision/CCollisionSurface.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CLine.hpp>
+#include <zeus/CPlane.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CMaterialFilter;

--- a/Runtime/Collision/CBallFilter.hpp
+++ b/Runtime/Collision/CBallFilter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ICollisionFilter.hpp"
+#include "Runtime/Collision/ICollisionFilter.hpp"
 
 namespace urde {
 class CPhysicsActor;

--- a/Runtime/Collision/CCollidableAABox.hpp
+++ b/Runtime/Collision/CCollidableAABox.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "CCollisionPrimitive.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Collision/CCollisionPrimitive.hpp"
+
+#include <zeus/CAABox.hpp>
 
 namespace urde {
 namespace Collide {

--- a/Runtime/Collision/CCollidableCollisionSurface.hpp
+++ b/Runtime/Collision/CCollidableCollisionSurface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "CCollisionPrimitive.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Collision/CCollisionPrimitive.hpp"
 
 namespace urde {
 class CCollidableCollisionSurface {

--- a/Runtime/Collision/CCollidableOBBTree.hpp
+++ b/Runtime/Collision/CCollidableOBBTree.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "Collision/CCollisionPrimitive.hpp"
-#include "COBBTree.hpp"
-#include "zeus/COBBox.hpp"
-#include "CMetroidAreaCollider.hpp"
+#include "Runtime/Collision/CCollisionPrimitive.hpp"
+#include "Runtime/Collision/CMetroidAreaCollider.hpp"
+#include "Runtime/Collision/COBBTree.hpp"
+
+#include <zeus/CMRay.hpp>
+#include <zeus/COBBox.hpp>
+#include <zeus/CPlane.hpp>
 
 namespace urde {
 class CRayCastInfo {

--- a/Runtime/Collision/CCollidableOBBTreeGroup.hpp
+++ b/Runtime/Collision/CCollidableOBBTreeGroup.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
-#include "IOStreams.hpp"
-#include "CFactoryMgr.hpp"
-#include "COBBTree.hpp"
-#include "zeus/CAABox.hpp"
-#include "CCollisionPrimitive.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Collision/COBBTree.hpp"
+#include "Runtime/Collision/CCollisionPrimitive.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CCollidableOBBTreeGroupContainer {

--- a/Runtime/Collision/CCollidableSphere.hpp
+++ b/Runtime/Collision/CCollidableSphere.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "CCollisionPrimitive.hpp"
-#include "zeus/CSphere.hpp"
+#include "Runtime/Collision/CCollisionPrimitive.hpp"
+
+#include <zeus/CSphere.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 namespace Collide {

--- a/Runtime/Collision/CCollisionActor.hpp
+++ b/Runtime/Collision/CCollisionActor.hpp
@@ -1,12 +1,19 @@
 #pragma once
 
-#include "World/CPhysicsActor.hpp"
-#include "World/CHealthInfo.hpp"
-#include "World/CDamageVulnerability.hpp"
+#include <memory>
+#include <string_view>
+
+#include "Runtime/World/CDamageVulnerability.hpp"
+#include "Runtime/World/CHealthInfo.hpp"
+#include "Runtime/World/CPhysicsActor.hpp"
+
+#include <zeus/CVector3f.hpp>
+
 namespace urde {
 class CCollidableSphere;
 class CCollidableOBBTreeGroup;
 class CCollidableOBBTreeGroupContainer;
+
 class CCollisionActor : public CPhysicsActor {
   enum class EPrimitiveType { OBBTreeGroup, AABox, Sphere };
 

--- a/Runtime/Collision/CCollisionActorManager.hpp
+++ b/Runtime/Collision/CCollisionActorManager.hpp
@@ -1,14 +1,20 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CAABox.hpp"
-#include "Collision/CJointCollisionDescription.hpp"
+#include <optional>
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Collision/CJointCollisionDescription.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CMaterialList;
 class CAnimData;
 class CCollisionActor;
+class CMaterialList;
 class CStateManager;
+
 class CCollisionActorManager {
 public:
   enum class EUpdateOptions { ObjectSpace, WorldSpace };

--- a/Runtime/Collision/CCollisionEdge.hpp
+++ b/Runtime/Collision/CCollisionEdge.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "RetroTypes.hpp"
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 class CCollisionEdge {

--- a/Runtime/Collision/CCollisionInfo.hpp
+++ b/Runtime/Collision/CCollisionInfo.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CMaterialList.hpp"
-#include "zeus/CAABox.hpp"
-#include "zeus/CMatrix3f.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Collision/CMaterialList.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CMatrix3f.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CCollisionInfo {

--- a/Runtime/Collision/CCollisionInfoList.hpp
+++ b/Runtime/Collision/CCollisionInfoList.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CCollisionInfo.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Collision/CCollisionInfo.hpp"
 
 namespace urde {
 class CCollisionInfoList {

--- a/Runtime/Collision/CCollisionPrimitive.hpp
+++ b/Runtime/Collision/CCollisionPrimitive.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
-#include "Collision/CMaterialList.hpp"
-#include "CRayCastResult.hpp"
-#include "zeus/CAABox.hpp"
-
 #include <functional>
+#include <memory>
+#include <vector>
+
+#include "Runtime/Collision/CMaterialList.hpp"
+#include "Runtime/Collision/CRayCastResult.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CCollisionPrimitive;

--- a/Runtime/Collision/CCollisionResponseData.hpp
+++ b/Runtime/Collision/CCollisionResponseData.hpp
@@ -1,16 +1,19 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "Collision/CMaterialList.hpp"
-#include "CFactoryMgr.hpp"
-#include "IObj.hpp"
-#include "CToken.hpp"
-#include "IOStreams.hpp"
+#include <optional>
+#include <vector>
+
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/IObj.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Collision/CMaterialList.hpp"
 
 namespace urde {
-class CSimplePool;
-class CGenDescription;
 class CDecalDescription;
+class CGenDescription;
+class CSimplePool;
 
 enum class EWeaponCollisionResponseTypes {
   None,

--- a/Runtime/Collision/CCollisionSurface.cpp
+++ b/Runtime/Collision/CCollisionSurface.cpp
@@ -1,4 +1,6 @@
-#include "CCollisionSurface.hpp"
+#include "Runtime/Collision/CCollisionSurface.hpp"
+
+#include <zeus/CUnitVector.hpp>
 
 namespace urde {
 CCollisionSurface::CCollisionSurface(const zeus::CVector3f& a, const zeus::CVector3f& b, const zeus::CVector3f& c,

--- a/Runtime/Collision/CCollisionSurface.hpp
+++ b/Runtime/Collision/CCollisionSurface.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "zeus/zeus.hpp"
-#include "RetroTypes.hpp"
+#include "Runtime/GCNTypes.hpp"
+
+#include <zeus/CPlane.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CCollisionSurface {

--- a/Runtime/Collision/CGameCollision.hpp
+++ b/Runtime/Collision/CGameCollision.hpp
@@ -1,11 +1,15 @@
 #pragma once
-#include "zeus/CVector3f.hpp"
-#include "zeus/CPlane.hpp"
-#include "rstl.hpp"
-#include "RetroTypes.hpp"
-#include "CRayCastResult.hpp"
-#include "CMetroidAreaCollider.hpp"
-#include "CCollisionPrimitive.hpp"
+
+#include <optional>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Collision/CCollisionPrimitive.hpp"
+#include "Runtime/Collision/CMetroidAreaCollider.hpp"
+#include "Runtime/Collision/CRayCastResult.hpp"
+
+#include <zeus/CPlane.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Collision/CInternalRayCastStructure.hpp
+++ b/Runtime/Collision/CInternalRayCastStructure.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "zeus/CTransform.hpp"
-#include "zeus/CMRay.hpp"
-#include "CMaterialFilter.hpp"
+#include "Runtime/Collision/CMaterialFilter.hpp"
+
+#include <zeus/CMRay.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
+
 namespace urde {
 class CInternalRayCastStructure {
   zeus::CMRay x0_ray;

--- a/Runtime/Collision/CJointCollisionDescription.hpp
+++ b/Runtime/Collision/CJointCollisionDescription.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "Character/CSegId.hpp"
-#include "zeus/CAABox.hpp"
+#include <string>
+
+#include "Runtime/Character/CSegId.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 struct SJointInfo {

--- a/Runtime/Collision/CMetroidAreaCollider.hpp
+++ b/Runtime/Collision/CMetroidAreaCollider.hpp
@@ -1,12 +1,17 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CAABox.hpp"
-#include "CAreaOctTree.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Collision/CAreaOctTree.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CLineSeg.hpp>
+#include <zeus/CVector3d.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CCollisionInfoList;
 class CCollisionInfo;
+class CCollisionInfoList;
 class CMaterialList;
 
 class CAABoxAreaCache {

--- a/Runtime/Collision/COBBTree.hpp
+++ b/Runtime/Collision/COBBTree.hpp
@@ -1,9 +1,14 @@
 #pragma once
-#include "RetroTypes.hpp"
-#include "CCollisionEdge.hpp"
-#include "CCollisionSurface.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/COBBox.hpp"
+
+#include <memory>
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Collision/CCollisionEdge.hpp"
+#include "Runtime/Collision/CCollisionSurface.hpp"
+
+#include <zeus/COBBox.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CCollidableOBBTreeGroupContainer;

--- a/Runtime/Collision/CRayCastResult.hpp
+++ b/Runtime/Collision/CRayCastResult.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "CMaterialList.hpp"
-#include "zeus/zeus.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Collision/CMaterialList.hpp"
+
+#include <zeus/CPlane.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CRayCastResult {

--- a/Runtime/Collision/CollisionUtil.cpp
+++ b/Runtime/Collision/CollisionUtil.cpp
@@ -1,6 +1,9 @@
-#include "CollisionUtil.hpp"
-#include "CCollisionInfo.hpp"
-#include "CCollisionInfoList.hpp"
+#include "Runtime/Collision/CollisionUtil.hpp"
+
+#include "Runtime/Collision/CCollisionInfo.hpp"
+#include "Runtime/Collision/CCollisionInfoList.hpp"
+
+#include <zeus/CVector3d.hpp>
 
 namespace urde::CollisionUtil {
 bool LineIntersectsOBBox(const zeus::COBBox& obb, const zeus::CMRay& ray, float& d) {

--- a/Runtime/Collision/CollisionUtil.hpp
+++ b/Runtime/Collision/CollisionUtil.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "GCNTypes.hpp"
-#include "zeus/zeus.hpp"
-#include "CMaterialList.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Collision/CMaterialList.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CMRay.hpp>
+#include <zeus/COBBox.hpp>
+#include <zeus/CSphere.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CCollisionInfoList;

--- a/Runtime/Collision/ICollisionFilter.hpp
+++ b/Runtime/Collision/ICollisionFilter.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "CCollisionInfoList.hpp"
+#include "Runtime/Collision/CCollisionInfoList.hpp"
 
 namespace urde {
 class CActor;

--- a/Runtime/Graphics/CBooRenderer.hpp
+++ b/Runtime/Graphics/CBooRenderer.hpp
@@ -1,29 +1,42 @@
 #pragma once
 
 #include <functional>
-#include "IRenderer.hpp"
-#include "CDrawable.hpp"
-#include "CDrawablePlaneObject.hpp"
-#include "Shaders/CThermalColdFilter.hpp"
-#include "Shaders/CThermalHotFilter.hpp"
-#include "Shaders/CSpaceWarpFilter.hpp"
-#include "Shaders/CFogVolumePlaneShader.hpp"
-#include "Shaders/CFogVolumeFilter.hpp"
-#include "Shaders/CPhazonSuitFilter.hpp"
-#include "CTexture.hpp"
-#include "CRandom16.hpp"
-#include "CPVSVisSet.hpp"
-#include "zeus/CRectangle.hpp"
-#include "World/CGameArea.hpp"
-#include "zeus/CPlane.hpp"
+#include <list>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "Runtime/CRandom16.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Graphics/CDrawable.hpp"
+#include "Runtime/Graphics/CDrawablePlaneObject.hpp"
+#include "Runtime/Graphics/CPVSVisSet.hpp"
+#include "Runtime/Graphics/CTexture.hpp"
+#include "Runtime/Graphics/IRenderer.hpp"
+#include "Runtime/Graphics/Shaders/CFogVolumeFilter.hpp"
+#include "Runtime/Graphics/Shaders/CFogVolumePlaneShader.hpp"
+#include "Runtime/Graphics/Shaders/CPhazonSuitFilter.hpp"
+#include "Runtime/Graphics/Shaders/CSpaceWarpFilter.hpp"
+#include "Runtime/Graphics/Shaders/CThermalColdFilter.hpp"
+#include "Runtime/Graphics/Shaders/CThermalHotFilter.hpp"
+#include "Runtime/World/CGameArea.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/CFrustum.hpp>
+#include <zeus/CPlane.hpp>
+#include <zeus/CRectangle.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class IObjectStore;
-class CMemorySys;
-class IFactory;
-class CTexture;
-class CParticleGen;
 class CBooModel;
+class CMemorySys;
+class CParticleGen;
+class CTexture;
+class IFactory;
+class IObjectStore;
 
 class Buckets {
   friend class CBooRenderer;
@@ -57,10 +70,10 @@ enum class EWorldShadowMode {
 
 class CBooRenderer final : public IRenderer {
   friend class CBooModel;
-  friend class CModel;
   friend class CGameArea;
-  friend class CWorldTransManager;
+  friend class CModel;
   friend class CMorphBallShadow;
+  friend class CWorldTransManager;
 
   struct CAreaListItem {
     const std::vector<CMetroidModelInstance>* x0_geometry;

--- a/Runtime/Graphics/CDrawable.hpp
+++ b/Runtime/Graphics/CDrawable.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "GCNTypes.hpp"
-#include "zeus/CAABox.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include <zeus/CAABox.hpp>
 
 namespace urde {
 enum class EDrawableType : u16 { WorldSurface, Particle, Actor, SimpleShadow, Decal };

--- a/Runtime/Graphics/CDrawablePlaneObject.hpp
+++ b/Runtime/Graphics/CDrawablePlaneObject.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "CDrawable.hpp"
-#include "zeus/CPlane.hpp"
+#include "Runtime/Graphics/CDrawable.hpp"
+#include <zeus/CPlane.hpp>
 
 namespace urde {
 class CDrawablePlaneObject : public CDrawable {

--- a/Runtime/Graphics/CGraphics.hpp
+++ b/Runtime/Graphics/CGraphics.hpp
@@ -1,15 +1,19 @@
 #pragma once
 
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "boo/graphicsdev/IGraphicsCommandQueue.hpp"
+#include <vector>
 
-#include "RetroTypes.hpp"
-#include "zeus/CTransform.hpp"
-#include "zeus/CVector2i.hpp"
-#include "zeus/CColor.hpp"
+#include "Runtime/RetroTypes.hpp"
 
-#include "hecl/Runtime.hpp"
-#include "hecl/CVar.hpp"
+#include <boo/graphicsdev/IGraphicsCommandQueue.hpp>
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <hecl/CVar.hpp>
+#include <hecl/Runtime.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector2i.hpp>
+#include <zeus/CVector2f.hpp>
 
 namespace urde {
 extern hecl::CVar* g_disableLighting;

--- a/Runtime/Graphics/CGraphicsPalette.hpp
+++ b/Runtime/Graphics/CGraphicsPalette.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include "RetroTypes.hpp"
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 

--- a/Runtime/Graphics/CLight.hpp
+++ b/Runtime/Graphics/CLight.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "zeus/CVector3f.hpp"
-#include "zeus/CColor.hpp"
-#include "RetroTypes.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/CLineRenderer.hpp
+++ b/Runtime/Graphics/CLineRenderer.hpp
@@ -1,13 +1,18 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/CVector4f.hpp"
-#include "zeus/CColor.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "hecl/VertexBufferPool.hpp"
-#include "hecl/UniformBufferPool.hpp"
-#include "Graphics/CGraphics.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Graphics/CGraphics.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <hecl/UniformBufferPool.hpp>
+#include <hecl/VertexBufferPool.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CVector2f.hpp>
+#include <zeus/CVector3f.hpp>
+#include <zeus/CVector4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/CMetroidModelInstance.hpp
+++ b/Runtime/Graphics/CMetroidModelInstance.hpp
@@ -1,11 +1,17 @@
 #pragma once
 
+#include <memory>
+#include <unordered_map>
 #include <vector>
-#include "RetroTypes.hpp"
-#include "zeus/CTransform.hpp"
-#include "zeus/CAABox.hpp"
-#include "hecl/HMDLMeta.hpp"
+
+#include "Runtime/RetroTypes.hpp"
+
 #include "Shaders/CModelShaders.hpp"
+
+#include <hecl/HMDLMeta.hpp>
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CTransform.hpp>
 
 namespace urde {
 class CBooModel;

--- a/Runtime/Graphics/CModel.hpp
+++ b/Runtime/Graphics/CModel.hpp
@@ -1,23 +1,29 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CColor.hpp"
-#include "CFactoryMgr.hpp"
-#include "CToken.hpp"
-#include "zeus/CAABox.hpp"
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
 #include "DNACommon/CMDL.hpp"
 #include "DNAMP1/CMDLMaterials.hpp"
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
 #include "Shaders/CModelShaders.hpp"
-#include "hecl/HMDLMeta.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+#include <hecl/HMDLMeta.hpp>
+#include <zeus/CAABox.hpp>
+#include <zeus/CColor.hpp>
 
 namespace urde {
-class IObjectStore;
-class CTexture;
 class CLight;
-class CSkinRules;
-class CPoseAsTransforms;
 class CModel;
+class CPoseAsTransforms;
+class CSkinRules;
+class CTexture;
+class IObjectStore;
 
 struct CModelFlags {
   u8 x0_blendMode = 0; /* 2: add color, >6: additive, >4: blend, else opaque */
@@ -115,10 +121,10 @@ struct SShader {
 };
 
 class CBooModel {
-  friend class CModel;
-  friend class CGameArea;
   friend class CBooRenderer;
+  friend class CGameArea;
   friend class CMetroidModelInstance;
+  friend class CModel;
   friend class CSkinnedModel;
   friend struct GeometryUniformLayout;
 

--- a/Runtime/Graphics/CMoviePlayer.hpp
+++ b/Runtime/Graphics/CMoviePlayer.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CDvdFile.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "specter/View.hpp"
-#include "zeus/CVector3f.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/CDvdFile.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+#include <specter/View.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/CPVSAreaSet.hpp
+++ b/Runtime/Graphics/CPVSAreaSet.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CPVSVisOctree.hpp"
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Graphics/CPVSVisOctree.hpp"
 
 namespace urde {
 

--- a/Runtime/Graphics/CPVSVisOctree.hpp
+++ b/Runtime/Graphics/CPVSVisOctree.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "CPVSVisSet.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Graphics/CPVSVisSet.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/CPVSVisSet.hpp
+++ b/Runtime/Graphics/CPVSVisSet.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CAABox.hpp"
-#include <memory>
+#include "Runtime/RetroTypes.hpp"
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CPVSVisOctree;

--- a/Runtime/Graphics/CRainSplashGenerator.hpp
+++ b/Runtime/Graphics/CRainSplashGenerator.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CRandom16.hpp"
-#include "zeus/CVector3f.hpp"
-#include "Graphics/CLineRenderer.hpp"
+#include <utility>
+#include <vector>
+
+#include "Runtime/CRandom16.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Graphics/CLineRenderer.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CStateManager;

--- a/Runtime/Graphics/CSimpleShadow.hpp
+++ b/Runtime/Graphics/CSimpleShadow.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "zeus/CAABox.hpp"
-#include "Graphics/Shaders/CTexturedQuadFilter.hpp"
+#include <optional>
+
+#include "Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CTransform.hpp>
 
 namespace urde {
 class CTexture;

--- a/Runtime/Graphics/CSkinnedModel.hpp
+++ b/Runtime/Graphics/CSkinnedModel.hpp
@@ -1,14 +1,20 @@
 #pragma once
 
-#include "CToken.hpp"
-#include "CModel.hpp"
+#include <memory>
 #include <optional>
+#include <utility>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/Graphics/CModel.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CModel;
-class CSkinRules;
 class CCharLayoutInfo;
+class CModel;
 class CPoseAsTransforms;
+class CSkinRules;
 class CVertexMorphEffect;
 class IObjectStore;
 

--- a/Runtime/Graphics/CTexture.hpp
+++ b/Runtime/Graphics/CTexture.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
-#include "GCNTypes.hpp"
-#include "CFactoryMgr.hpp"
-#include "IObj.hpp"
-#include "IOStreams.hpp"
-#include "Graphics/CGraphics.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+#include <memory>
+#include <string>
+
+#include "Runtime/CFactoryMgr.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/IObj.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/Graphics/CGraphics.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
 
 namespace urde {
 class CVParamTransfer;

--- a/Runtime/Graphics/CVertexMorphEffect.hpp
+++ b/Runtime/Graphics/CVertexMorphEffect.hpp
@@ -1,11 +1,17 @@
 #pragma once
 
-#include "CToken.hpp"
-#include "Character/CPoseAsTransforms.hpp"
+#include <utility>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/Character/CPoseAsTransforms.hpp"
+
+#include <zeus/CUnitVector.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CSkinRules;
 class CRandom16;
+class CSkinRules;
 
 class CVertexMorphEffect {
   zeus::CUnitVector3f x0_;

--- a/Runtime/Graphics/IRenderer.hpp
+++ b/Runtime/Graphics/IRenderer.hpp
@@ -1,26 +1,29 @@
 #pragma once
 
+#include <functional>
 #include <vector>
-#include "../RetroTypes.hpp"
-#include "../CToken.hpp"
-#include "zeus/CAABox.hpp"
-#include "zeus/CPlane.hpp"
-#include "zeus/CFrustum.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CRectangle.hpp"
-#include "CGraphics.hpp"
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Graphics/CGraphics.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/CFrustum.hpp>
+#include <zeus/CPlane.hpp>
+#include <zeus/CRectangle.hpp>
 
 namespace urde {
-class CMetroidModelInstance;
-class CLight;
 class CAreaOctTree;
-class CParticleGen;
+class CLight;
+class CMetroidModelInstance;
 class CModel;
-struct SShader;
-class CSkinnedModel;
 class CPVSVisSet;
+class CParticleGen;
+class CSkinnedModel;
 struct CAreaRenderOctTree;
 struct CModelFlags;
+struct SShader;
 
 class IRenderer {
 public:

--- a/Runtime/Graphics/Shaders/CAABoxShader.hpp
+++ b/Runtime/Graphics/Shaders/CAABoxShader.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CAABox.hpp"
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CCameraBlurFilter.hpp
+++ b/Runtime/Graphics/Shaders/CCameraBlurFilter.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CVector3f.hpp>
+#include <zeus/CVector4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CColoredQuadFilter.hpp
+++ b/Runtime/Graphics/Shaders/CColoredQuadFilter.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CRectangle.hpp"
-#include "Camera/CCameraFilter.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/Camera/CCameraFilter.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CRectangle.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CColoredStripShader.hpp
+++ b/Runtime/Graphics/Shaders/CColoredStripShader.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
 
 namespace urde
 {

--- a/Runtime/Graphics/Shaders/CDecalShaders.hpp
+++ b/Runtime/Graphics/Shaders/CDecalShaders.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Graphics/CGraphics.hpp"
+#include "Runtime/Graphics/CGraphics.hpp"
 
 namespace urde {
 struct CQuadDecal;

--- a/Runtime/Graphics/Shaders/CElementGenShaders.hpp
+++ b/Runtime/Graphics/Shaders/CElementGenShaders.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "Graphics/CGraphics.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+#include <array>
+
+#include "Runtime/Graphics/CGraphics.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
 
 namespace urde {
 class CElementGen;

--- a/Runtime/Graphics/Shaders/CEnergyBarShader.hpp
+++ b/Runtime/Graphics/Shaders/CEnergyBarShader.hpp
@@ -1,9 +1,14 @@
 #pragma once
 
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CRectangle.hpp"
-#include "Camera/CCameraFilter.hpp"
+#include <vector>
+
+#include "Runtime/Camera/CCameraFilter.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CRectangle.hpp>
+#include <zeus/CVector2f.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CEnvFxShaders.hpp
+++ b/Runtime/Graphics/Shaders/CEnvFxShaders.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "Graphics/CGraphics.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+#include "Runtime/Graphics/CGraphics.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CVector2f.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CEnvFxManager;

--- a/Runtime/Graphics/Shaders/CFluidPlaneShader.hpp
+++ b/Runtime/Graphics/Shaders/CFluidPlaneShader.hpp
@@ -1,13 +1,22 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "CModelShaders.hpp"
-#include "World/CFluidPlaneManager.hpp"
-#include "Graphics/CTexture.hpp"
-#include "CToken.hpp"
-#include "zeus/CAABox.hpp"
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Graphics/CTexture.hpp"
+#include "Runtime/Graphics/Shaders/CModelShaders.hpp"
+#include "Runtime/World/CFluidPlaneManager.hpp"
+
 #include "Shaders/shader_CFluidPlaneShader.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CVector3f.hpp>
+#include <zeus/CVector4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CFogVolumeFilter.hpp
+++ b/Runtime/Graphics/Shaders/CFogVolumeFilter.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CRectangle.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CRectangle.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CFogVolumePlaneShader.hpp
+++ b/Runtime/Graphics/Shaders/CFogVolumePlaneShader.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CRectangle.hpp"
-#include "zeus/CVector4f.hpp"
+#include <cstddef>
+#include <vector>
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CRectangle.hpp>
+#include <zeus/CVector4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CLineRendererShaders.hpp
+++ b/Runtime/Graphics/Shaders/CLineRendererShaders.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "Graphics/CGraphics.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+#include <array>
+
+#include "Runtime/Graphics/CGraphics.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
 
 namespace urde {
 class CLineRenderer;

--- a/Runtime/Graphics/Shaders/CMapSurfaceShader.hpp
+++ b/Runtime/Graphics/Shaders/CMapSurfaceShader.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CModelShaders.hpp
+++ b/Runtime/Graphics/Shaders/CModelShaders.hpp
@@ -1,13 +1,18 @@
 #pragma once
 
-#include "hecl/Runtime.hpp"
-#include "hecl/Backend.hpp"
-#include <optional>
-#include "zeus/CVector3f.hpp"
-#include "zeus/CColor.hpp"
-#include "Graphics/CGraphics.hpp"
-#include "DataSpec/DNAMP1/CMDLMaterials.hpp"
 #include <array>
+#include <optional>
+
+#include "DataSpec/DNAMP1/CMDLMaterials.hpp"
+
+#include "Runtime/Graphics/CGraphics.hpp"
+
+#include <hecl/Backend.hpp>
+#include <hecl/Runtime.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CVector3f.hpp>
+#include <zeus/CVector4f.hpp>
 
 #define URDE_MAX_LIGHTS 8
 

--- a/Runtime/Graphics/Shaders/CParticleSwooshShaders.hpp
+++ b/Runtime/Graphics/Shaders/CParticleSwooshShaders.hpp
@@ -1,7 +1,14 @@
 #pragma once
 
-#include "Graphics/CGraphics.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+#include <array>
+
+#include "Runtime/Graphics/CGraphics.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CVector2f.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CParticleSwoosh;

--- a/Runtime/Graphics/Shaders/CPhazonSuitFilter.hpp
+++ b/Runtime/Graphics/Shaders/CPhazonSuitFilter.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "zeus/CColor.hpp"
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+#include <zeus/CColor.hpp>
 
 namespace urde {
 class CTexture;

--- a/Runtime/Graphics/Shaders/CRadarPaintShader.hpp
+++ b/Runtime/Graphics/Shaders/CRadarPaintShader.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CRectangle.hpp"
-#include "Camera/CCameraFilter.hpp"
+#include <vector>
+
+#include "Runtime/Camera/CCameraFilter.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CRectangle.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CRandomStaticFilter.hpp
+++ b/Runtime/Graphics/Shaders/CRandomStaticFilter.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CRectangle.hpp"
-#include "Camera/CCameraFilter.hpp"
+#include "Runtime/Camera/CCameraFilter.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CRectangle.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CScanLinesFilter.hpp
+++ b/Runtime/Graphics/Shaders/CScanLinesFilter.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CRectangle.hpp"
-#include "Camera/CCameraFilter.hpp"
+#include "Runtime/Camera/CCameraFilter.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CRectangle.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CSpaceWarpFilter.hpp
+++ b/Runtime/Graphics/Shaders/CSpaceWarpFilter.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "RetroTypes.hpp"
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CTextSupportShader.hpp
+++ b/Runtime/Graphics/Shaders/CTextSupportShader.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
-#include "GuiSys/CGuiWidget.hpp"
-#include "hecl/VertexBufferPool.hpp"
-#include "hecl/UniformBufferPool.hpp"
-#include "zeus/CVector2i.hpp"
+#include "Runtime/GuiSys/CGuiWidget.hpp"
+
+#include <hecl/UniformBufferPool.hpp>
+#include <hecl/VertexBufferPool.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CVector2f.hpp>
+#include <zeus/CVector2i.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CGlyph;

--- a/Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp
+++ b/Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "zeus/CRectangle.hpp"
-#include "Camera/CCameraFilter.hpp"
-#include "CToken.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/Camera/CCameraFilter.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CRectangle.hpp>
+#include <zeus/CVector2f.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CThermalColdFilter.hpp
+++ b/Runtime/Graphics/Shaders/CThermalColdFilter.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+#include "Runtime/RetroTypes.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CThermalHotFilter.hpp
+++ b/Runtime/Graphics/Shaders/CThermalHotFilter.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CWorldShadowShader.hpp
+++ b/Runtime/Graphics/Shaders/CWorldShadowShader.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "CColoredQuadFilter.hpp"
-#include "CTexturedQuadFilter.hpp"
+#include <optional>
+
+#include "Runtime/Graphics/Shaders/CColoredQuadFilter.hpp"
+#include "Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
 
 namespace urde {
 

--- a/Runtime/Graphics/Shaders/CXRayBlurFilter.hpp
+++ b/Runtime/Graphics/Shaders/CXRayBlurFilter.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
-#include "boo/graphicsdev/IGraphicsDataFactory.hpp"
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CColor.hpp"
-#include "CToken.hpp"
+#include "Runtime/CToken.hpp"
+
+#include <boo/graphicsdev/IGraphicsDataFactory.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix4f.hpp>
 
 namespace urde {
 class CTexture;

--- a/Runtime/MP1/CArtifactDoll.hpp
+++ b/Runtime/MP1/CArtifactDoll.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "Character/CActorLights.hpp"
-#include "CToken.hpp"
-#include "CPlayerState.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/CPlayerState.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CActorLights.hpp"
 
 namespace urde {
 class CModel;

--- a/Runtime/MP1/CAudioStateWin.hpp
+++ b/Runtime/MP1/CAudioStateWin.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../CIOWin.hpp"
+#include "Runtime/CIOWin.hpp"
 
 namespace urde::MP1 {
 class CAudioStateWin : public CIOWin {

--- a/Runtime/MP1/CCredits.hpp
+++ b/Runtime/MP1/CCredits.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "CIOWin.hpp"
+#include "Runtime/CIOWin.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CFaceplateDecoration.hpp
+++ b/Runtime/MP1/CFaceplateDecoration.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "Graphics/Shaders/CTexturedQuadFilter.hpp"
+#include <optional>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp"
 
 namespace urde {
 class CStateManager;

--- a/Runtime/MP1/CFrontEndUI.hpp
+++ b/Runtime/MP1/CFrontEndUI.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <array>
+#include <memory>
+#include <optional>
 
 #include "Runtime/CGameDebug.hpp"
 #include "Runtime/CGameOptionsTouchBar.hpp"
@@ -19,20 +21,20 @@
 #include <zeus/CVector3f.hpp>
 
 namespace urde {
+class CAudioGroupSet;
+class CDependencyGroup;
+class CGuiFrame;
+class CGuiModel;
 class CGuiSliderGroup;
 class CGuiTableGroup;
-class CMoviePlayer;
-struct SObjectTag;
-class CDependencyGroup;
-class CTexture;
-class CAudioGroupSet;
-class CSaveWorld;
-class CStringTable;
-class CGuiFrame;
+class CGuiTableGroup;
 class CGuiTextPane;
 class CGuiWidget;
-class CGuiTableGroup;
-class CGuiModel;
+class CMoviePlayer;
+class CSaveWorld;
+class CStringTable;
+class CTexture;
+struct SObjectTag;
 
 namespace MP1 {
 class CNESEmulator;

--- a/Runtime/MP1/CGBASupport.hpp
+++ b/Runtime/MP1/CGBASupport.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "CDvdFile.hpp"
+#include <memory>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/CDvdFile.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CGameCubeDoll.hpp
+++ b/Runtime/MP1/CGameCubeDoll.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "Character/CActorLights.hpp"
-#include "CToken.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CActorLights.hpp"
 
 namespace urde {
 class CModel;

--- a/Runtime/MP1/CInGameGuiManager.hpp
+++ b/Runtime/MP1/CInGameGuiManager.hpp
@@ -1,35 +1,45 @@
 #pragma once
 
-#include "CToken.hpp"
-#include "CRandom16.hpp"
-#include "CPlayerVisor.hpp"
-#include "CFaceplateDecoration.hpp"
-#include "CSamusFaceReflection.hpp"
-#include "CMessageScreen.hpp"
-#include "CSaveGameScreen.hpp"
-#include "Camera/CCameraFilter.hpp"
-#include "CStateManager.hpp"
+#include <list>
+#include <memory>
+#include <optional>
+#include <vector>
+
 #include "DataSpec/DNACommon/Tweaks/ITweakGui.hpp"
-#include "CInventoryScreen.hpp"
-#include "CPauseScreen.hpp"
-#include "CPauseScreenBlur.hpp"
-#include "CInGameGuiManagerCommon.hpp"
-#include "Graphics/Shaders/CRandomStaticFilter.hpp"
+
+#include "Runtime/CRandom16.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/CStateManager.hpp"
+#include "Runtime/Camera/CCameraFilter.hpp"
+#include "Runtime/Graphics/Shaders/CRandomStaticFilter.hpp"
+#include "Runtime/MP1/CFaceplateDecoration.hpp"
+#include "Runtime/MP1/CInGameGuiManagerCommon.hpp"
+#include "Runtime/MP1/CInventoryScreen.hpp"
+#include "Runtime/MP1/CMessageScreen.hpp"
+#include "Runtime/MP1/CPauseScreen.hpp"
+#include "Runtime/MP1/CPauseScreenBlur.hpp"
+#include "Runtime/MP1/CPlayerVisor.hpp"
+#include "Runtime/MP1/CSamusFaceReflection.hpp"
+#include "Runtime/MP1/CSaveGameScreen.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CStateManager;
-class CArchitectureQueue;
-class CDependencyGroup;
-class CModelData;
 class CActorLights;
-class CGuiModel;
-class CGuiCamera;
+class CArchitectureQueue;
 class CAutoMapper;
+class CDependencyGroup;
+class CGuiCamera;
+class CGuiModel;
+class CModelData;
+class CStateManager;
 
 namespace MP1 {
+class CPauseScreen;
 class CPauseScreenBlur;
 class CSamusHud;
-class CPauseScreen;
 
 class CInGameGuiManager {
 public:

--- a/Runtime/MP1/CInGameGuiManagerCommon.hpp
+++ b/Runtime/MP1/CInGameGuiManagerCommon.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-
 namespace urde::MP1 {
 
 enum class EInGameGuiState { Zero, InGame, MapScreen, PauseGame, PauseLogBook, PauseSaveGame, PauseHUDMessage };

--- a/Runtime/MP1/CInGameTweakManager.hpp
+++ b/Runtime/MP1/CInGameTweakManager.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "CInGameTweakManagerBase.hpp"
+#include "Runtime/CInGameTweakManagerBase.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CInventoryScreen.hpp
+++ b/Runtime/MP1/CInventoryScreen.hpp
@@ -1,8 +1,12 @@
 #pragma once
 
-#include "CInGameGuiManager.hpp"
-#include "CPauseScreenBase.hpp"
-#include "CSamusDoll.hpp"
+#include <memory>
+
+#include "Runtime/MP1/CInGameGuiManager.hpp"
+#include "Runtime/MP1/CPauseScreenBase.hpp"
+#include "Runtime/MP1/CSamusDoll.hpp"
+
+#include <zeus/CVector2f.hpp>
 
 namespace urde {
 class CDependencyGroup;

--- a/Runtime/MP1/CLogBookScreen.hpp
+++ b/Runtime/MP1/CLogBookScreen.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "CInGameGuiManager.hpp"
-#include "CPauseScreenBase.hpp"
-#include "CArtifactDoll.hpp"
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "Runtime/rstl.hpp"
+#include "Runtime/MP1/CArtifactDoll.hpp"
+#include "Runtime/MP1/CInGameGuiManager.hpp"
+#include "Runtime/MP1/CPauseScreenBase.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CMFGame.hpp
+++ b/Runtime/MP1/CMFGame.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "CMFGameBase.hpp"
-#include "CInGameGuiManager.hpp"
-#include "Graphics/Shaders/CColoredQuadFilter.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/CMFGameBase.hpp"
+#include "Runtime/Graphics/Shaders/CColoredQuadFilter.hpp"
+#include "Runtime/MP1/CInGameGuiManager.hpp"
 
 namespace urde {
 class CStateManager;

--- a/Runtime/MP1/CMainFlow.hpp
+++ b/Runtime/MP1/CMainFlow.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "CMainFlowBase.hpp"
+#include "Runtime/CMainFlowBase.hpp"
 
 namespace urde {
 class CArchitectureMessage;

--- a/Runtime/MP1/CMemoryCardDriver.hpp
+++ b/Runtime/MP1/CMemoryCardDriver.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "CMemoryCardSys.hpp"
-#include "CGameState.hpp"
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "Runtime/CGameState.hpp"
+#include "Runtime/CMemoryCardSys.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CMessageScreen.hpp
+++ b/Runtime/MP1/CMessageScreen.hpp
@@ -1,15 +1,17 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CToken.hpp"
-#include "GuiSys/CStringTable.hpp"
-#include "GuiSys/CGuiFrame.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/GuiSys/CGuiFrame.hpp"
+#include "Runtime/GuiSys/CStringTable.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 struct CFinalInput;
-class CGuiWidget;
-class CGuiTextPane;
 class CGuiModel;
+class CGuiTextPane;
+class CGuiWidget;
 
 namespace MP1 {
 

--- a/Runtime/MP1/COptionsScreen.hpp
+++ b/Runtime/MP1/COptionsScreen.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "CInGameGuiManager.hpp"
-#include "CPauseScreenBase.hpp"
-#include "CGameCubeDoll.hpp"
-#include "CQuitGameScreen.hpp"
+#include <memory>
+
+#include "Runtime/MP1/CGameCubeDoll.hpp"
+#include "Runtime/MP1/CInGameGuiManager.hpp"
+#include "Runtime/MP1/CPauseScreenBase.hpp"
+#include "Runtime/MP1/CQuitGameScreen.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CPauseScreen.hpp
+++ b/Runtime/MP1/CPauseScreen.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "CInGameGuiManager.hpp"
+#include <memory>
+
 #include "Editor/ProjectResourceFactoryBase.hpp"
-#include "CPauseScreenBase.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/MP1/CInGameGuiManager.hpp"
+#include "Runtime/MP1/CPauseScreenBase.hpp"
 
 namespace urde {
 class CDependencyGroup;

--- a/Runtime/MP1/CPauseScreenBase.hpp
+++ b/Runtime/MP1/CPauseScreenBase.hpp
@@ -1,20 +1,24 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "zeus/CVector3f.hpp"
-#include "GuiSys/CGuiFrame.hpp"
+#include <string>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/GuiSys/CGuiFrame.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CStateManager;
-class CGuiWidget;
-class CGuiTableGroup;
-class CGuiModel;
-class CGuiTextPane;
-class CGuiSliderGroup;
-class CAuiImagePane;
-class CStringTable;
-class CRandom16;
 class CArchitectureQueue;
+class CAuiImagePane;
+class CGuiModel;
+class CGuiSliderGroup;
+class CGuiTableGroup;
+class CGuiTextPane;
+class CGuiWidget;
+class CRandom16;
+class CStateManager;
+class CStringTable;
 
 namespace MP1 {
 

--- a/Runtime/MP1/CPauseScreenBlur.hpp
+++ b/Runtime/MP1/CPauseScreenBlur.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include "CInGameGuiManagerCommon.hpp"
-#include "CToken.hpp"
-#include "Camera/CCameraFilter.hpp"
-#include "Graphics/CTexture.hpp"
-#include "Graphics/Shaders/CTexturedQuadFilter.hpp"
-#include "Graphics/Shaders/CScanLinesFilter.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/Camera/CCameraFilter.hpp"
+#include "Runtime/Graphics/CTexture.hpp"
+#include "Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp"
+#include "Runtime/Graphics/Shaders/CScanLinesFilter.hpp"
+#include "Runtime/MP1/CInGameGuiManagerCommon.hpp"
 
 namespace urde {
 class CStateManager;

--- a/Runtime/MP1/CPlayMovie.hpp
+++ b/Runtime/MP1/CPlayMovie.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "CPlayMovieBase.hpp"
-#include "RetroTypes.hpp"
+#include "Runtime/CPlayMovieBase.hpp"
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CPlayerVisor.hpp
+++ b/Runtime/MP1/CPlayerVisor.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "Camera/CCameraFilter.hpp"
-#include "zeus/CVector2f.hpp"
-#include "Audio/CSfxManager.hpp"
-#include "CPlayerState.hpp"
-#include "Graphics/CModel.hpp"
-#include "Graphics/Shaders/CColoredQuadFilter.hpp"
-#include "Graphics/Shaders/CTexturedQuadFilter.hpp"
+#include "Runtime/CPlayerState.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Audio/CSfxManager.hpp"
+#include "Runtime/Camera/CCameraFilter.hpp"
+#include "Runtime/Graphics/CModel.hpp"
+#include "Runtime/Graphics/Shaders/CColoredQuadFilter.hpp"
+#include "Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp"
+
+#include <zeus/CVector2f.hpp>
 
 namespace urde {
 class CStateManager;

--- a/Runtime/MP1/CPreFrontEnd.hpp
+++ b/Runtime/MP1/CPreFrontEnd.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "CIOWin.hpp"
+#include "Runtime/CIOWin.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CQuitGameScreen.hpp
+++ b/Runtime/MP1/CQuitGameScreen.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CToken.hpp"
-#include "Graphics/Shaders/CColoredQuadFilter.hpp"
+#include <optional>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Graphics/Shaders/CColoredQuadFilter.hpp"
 
 namespace urde {
 struct CFinalInput;

--- a/Runtime/MP1/CSamusDoll.hpp
+++ b/Runtime/MP1/CSamusDoll.hpp
@@ -1,12 +1,22 @@
 #pragma once
 
-#include "CPlayerState.hpp"
-#include "CToken.hpp"
-#include "Character/CModelData.hpp"
-#include "Character/CAnimCharacterSet.hpp"
-#include "Particle/CElementGen.hpp"
-#include "Character/CActorLights.hpp"
-#include "Audio/CSfxManager.hpp"
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "Runtime/CPlayerState.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Audio/CSfxManager.hpp"
+#include "Runtime/Character/CActorLights.hpp"
+#include "Runtime/Character/CAnimCharacterSet.hpp"
+#include "Runtime/Character/CModelData.hpp"
+#include "Runtime/Particle/CElementGen.hpp"
+
+#include <zeus/CRelAngle.hpp>
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CDependencyGroup;

--- a/Runtime/MP1/CSamusFaceReflection.hpp
+++ b/Runtime/MP1/CSamusFaceReflection.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "Character/CModelData.hpp"
-#include "Character/CActorLights.hpp"
+#include <memory>
+
+#include "Runtime/Character/CActorLights.hpp"
+#include "Runtime/Character/CModelData.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CSamusHud.hpp
+++ b/Runtime/MP1/CSamusHud.hpp
@@ -1,24 +1,35 @@
 #pragma once
 
-#include "CInGameGuiManager.hpp"
-#include "GuiSys/CTargetingManager.hpp"
-#include "GuiSys/CHudBallInterface.hpp"
-#include "GuiSys/CHudBossEnergyInterface.hpp"
-#include "GuiSys/CHudDecoInterface.hpp"
-#include "GuiSys/CHudEnergyInterface.hpp"
-#include "GuiSys/CHudFreeLookInterface.hpp"
-#include "GuiSys/CHudHelmetInterface.hpp"
-#include "GuiSys/CHudMissileInterface.hpp"
-#include "GuiSys/CHudRadarInterface.hpp"
-#include "GuiSys/CHudThreatInterface.hpp"
-#include "GuiSys/CHudVisorBeamMenu.hpp"
-#include "Graphics/Shaders/CRandomStaticFilter.hpp"
-#include "World/CHUDMemoParms.hpp"
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Graphics/Shaders/CRandomStaticFilter.hpp"
+#include "Runtime/GuiSys/CHudBallInterface.hpp"
+#include "Runtime/GuiSys/CHudBossEnergyInterface.hpp"
+#include "Runtime/GuiSys/CHudDecoInterface.hpp"
+#include "Runtime/GuiSys/CHudEnergyInterface.hpp"
+#include "Runtime/GuiSys/CHudFreeLookInterface.hpp"
+#include "Runtime/GuiSys/CHudHelmetInterface.hpp"
+#include "Runtime/GuiSys/CHudMissileInterface.hpp"
+#include "Runtime/GuiSys/CHudRadarInterface.hpp"
+#include "Runtime/GuiSys/CHudThreatInterface.hpp"
+#include "Runtime/GuiSys/CHudVisorBeamMenu.hpp"
+#include "Runtime/GuiSys/CTargetingManager.hpp"
+#include "Runtime/MP1/CInGameGuiManager.hpp"
+#include "Runtime/World/CHUDMemoParms.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CMatrix3f.hpp>
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CGuiFrame;
-class CStateManager;
 class CGuiLight;
+class CStateManager;
 
 enum class EHudState { Combat, XRay, Thermal, Scan, Ball, None };
 

--- a/Runtime/MP1/CSaveGameScreen.hpp
+++ b/Runtime/MP1/CSaveGameScreen.hpp
@@ -1,19 +1,22 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CToken.hpp"
-#include "CIOWin.hpp"
-#include "CMemoryCardDriver.hpp"
-#include "CSaveGameScreenTouchBar.hpp"
+#include <memory>
+#include <vector>
+
+#include "Runtime/CIOWin.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/MP1/CMemoryCardDriver.hpp"
+#include "Runtime/MP1/CSaveGameScreenTouchBar.hpp"
 
 namespace urde {
-class CTexture;
-class CStringTable;
 class CGuiFrame;
-class CSaveWorld;
-struct CFinalInput;
-class CGuiTextPane;
 class CGuiTableGroup;
+class CGuiTextPane;
+class CSaveWorld;
+class CStringTable;
+class CTexture;
+struct CFinalInput;
 
 namespace MP1 {
 

--- a/Runtime/MP1/CSaveGameScreenTouchBar.hpp
+++ b/Runtime/MP1/CSaveGameScreenTouchBar.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <utility>
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CSlideShow.hpp
+++ b/Runtime/MP1/CSlideShow.hpp
@@ -1,15 +1,22 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "CIOWin.hpp"
-#include "CToken.hpp"
-#include "GuiSys/CGuiTextSupport.hpp"
-#include "Graphics/Shaders/CTexturedQuadFilter.hpp"
-#include "Audio/CSfxManager.hpp"
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Runtime/CIOWin.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Audio/CSfxManager.hpp"
+#include "Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp"
+#include "Runtime/GuiSys/CGuiTextSupport.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CVector2f.hpp>
 
 namespace urde {
-class CTexture;
 class CDependencyGroup;
+class CTexture;
 
 class CSlideShow : public CIOWin {
 public:

--- a/Runtime/MP1/CStateSetterFlow.hpp
+++ b/Runtime/MP1/CStateSetterFlow.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "CIOWin.hpp"
+#include "Runtime/CIOWin.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/CTweaks.hpp
+++ b/Runtime/MP1/CTweaks.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "RetroTypes.hpp"
+#include "Runtime/RetroTypes.hpp"
+
 namespace hecl {
 class CVarManager;
 }

--- a/Runtime/MP1/MP1OriginalIDs.hpp
+++ b/Runtime/MP1/MP1OriginalIDs.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "RetroTypes.hpp"
-#include "IFactory.hpp"
+#include <utility>
+#include <vector>
+
+#include "Runtime/IFactory.hpp"
+#include "Runtime/RetroTypes.hpp"
 
 namespace urde {
 

--- a/Runtime/MP1/World/CActorContraption.hpp
+++ b/Runtime/MP1/World/CActorContraption.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "World/CScriptActor.hpp"
-#include "World/CDamageInfo.hpp"
+#include <string_view>
+#include <vector>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/World/CDamageInfo.hpp"
+#include "Runtime/World/CScriptActor.hpp"
 
 namespace urde {
 class CFlameThrower;

--- a/Runtime/MP1/World/CAtomicAlpha.hpp
+++ b/Runtime/MP1/World/CAtomicAlpha.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CPathFindSearch.hpp"
-#include "Weapon/CProjectileInfo.hpp"
+#include <string>
+
+#include "Runtime/rstl.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
+#include "Runtime/World/CPathFindSearch.hpp"
 
 namespace urde::MP1 {
 class CAtomicAlpha : public CPatterned {

--- a/Runtime/MP1/World/CAtomicBeta.hpp
+++ b/Runtime/MP1/World/CAtomicBeta.hpp
@@ -1,5 +1,11 @@
 #pragma once
-#include "World/CPatterned.hpp"
+
+#include <string_view>
+
+#include "Runtime/rstl.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CWeaponDescription;

--- a/Runtime/MP1/World/CBabygoth.hpp
+++ b/Runtime/MP1/World/CBabygoth.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
-#include <Runtime/Collision/CJointCollisionDescription.hpp>
-#include "World/CPatterned.hpp"
-#include "World/CPathFindSearch.hpp"
-#include "Weapon/CProjectileInfo.hpp"
-#include "Character/CBoneTracking.hpp"
+#include <memory>
+
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CBoneTracking.hpp"
+#include "Runtime/Collision/CJointCollisionDescription.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPathFindSearch.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
 namespace urde {
 class CCollisionActorManager;
 class CWeaponDescription;

--- a/Runtime/MP1/World/CBeetle.hpp
+++ b/Runtime/MP1/World/CBeetle.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CPathFindSearch.hpp"
-#include "World/CDamageInfo.hpp"
+#include <optional>
+
+#include "Runtime/rstl.hpp"
+#include "Runtime/World/CDamageInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
+#include "Runtime/World/CPathFindSearch.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 

--- a/Runtime/MP1/World/CBloodFlower.hpp
+++ b/Runtime/MP1/World/CBloodFlower.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "Weapon/CProjectileInfo.hpp"
-#include "World/CPatterned.hpp"
+#include <memory>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde {
 class CGenDescription;

--- a/Runtime/MP1/World/CBurrower.hpp
+++ b/Runtime/MP1/World/CBurrower.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/World/CChozoGhost.hpp
+++ b/Runtime/MP1/World/CChozoGhost.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "Weapon/CProjectileInfo.hpp"
-#include "Character/CBoneTracking.hpp"
+#include <string_view>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/Character/CBoneTracking.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 class CChozoGhost : public CPatterned {

--- a/Runtime/MP1/World/CElitePirate.hpp
+++ b/Runtime/MP1/World/CElitePirate.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CActorParameters.hpp"
-#include "World/CAnimationParameters.hpp"
+#include <string_view>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/World/CActorParameters.hpp"
+#include "Runtime/World/CAnimationParameters.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde::MP1 {
 class CElitePirateData {

--- a/Runtime/MP1/World/CEnergyBall.hpp
+++ b/Runtime/MP1/World/CEnergyBall.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "Character/CSteeringBehaviors.hpp"
-#include "World/CDamageInfo.hpp"
-#include "World/CPatterned.hpp"
+#include <string_view>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/Character/CSteeringBehaviors.hpp"
+#include "Runtime/World/CDamageInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde::MP1 {
 class CEnergyBall : public CPatterned {

--- a/Runtime/MP1/World/CEyeball.hpp
+++ b/Runtime/MP1/World/CEyeball.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "Character/CBoneTracking.hpp"
-#include "Weapon/CProjectileInfo.hpp"
+#include <string_view>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Character/CBoneTracking.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 class CEyeball : public CPatterned {

--- a/Runtime/MP1/World/CFireFlea.hpp
+++ b/Runtime/MP1/World/CFireFlea.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CPathFindSearch.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/World/CPathFindSearch.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CColor.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 class CFireFlea : public CPatterned {

--- a/Runtime/MP1/World/CFlaahgra.hpp
+++ b/Runtime/MP1/World/CFlaahgra.hpp
@@ -1,16 +1,27 @@
 #pragma once
 
-#include "World/CActorParameters.hpp"
-#include "World/CAnimationParameters.hpp"
-#include "World/CPatterned.hpp"
-#include "Collision/CJointCollisionDescription.hpp"
-#include "Weapon/CProjectileInfo.hpp"
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "Runtime/rstl.hpp"
+#include "Runtime/Collision/CJointCollisionDescription.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CActorParameters.hpp"
+#include "Runtime/World/CAnimationParameters.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CAABox.hpp>
+#include <zeus/CColor.hpp>
+#include <zeus/COBBox.hpp>
+#include <zeus/CVector3f.hpp>
+
 namespace urde {
-class CCollisionActorManager;
-class CGenDescription;
 class CBoneTracking;
+class CCollisionActorManager;
 class CDependencyGroup;
 class CElementGen;
+class CGenDescription;
 }
 
 namespace urde::MP1 {

--- a/Runtime/MP1/World/CFlaahgraProjectile.hpp
+++ b/Runtime/MP1/World/CFlaahgraProjectile.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Weapon/CEnergyProjectile.hpp"
+#include "Runtime/Weapon/CEnergyProjectile.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/World/CFlaahgraTentacle.hpp
+++ b/Runtime/MP1/World/CFlaahgraTentacle.hpp
@@ -1,7 +1,13 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "Collision/CCollisionActorManager.hpp"
+#include <memory>
+#include <string_view>
+
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/Collision/CCollisionActorManager.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 class CFlaahgraTentacle : public CPatterned {

--- a/Runtime/MP1/World/CFlickerBat.hpp
+++ b/Runtime/MP1/World/CFlickerBat.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde::MP1 {
 class CFlickerBat final : public CPatterned {

--- a/Runtime/MP1/World/CFlyingPirate.hpp
+++ b/Runtime/MP1/World/CFlyingPirate.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde::MP1 {
 class CFlyingPirate : public CPatterned {

--- a/Runtime/MP1/World/CJellyZap.hpp
+++ b/Runtime/MP1/World/CJellyZap.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde::MP1 {
 class CJellyZap : public CPatterned {

--- a/Runtime/MP1/World/CMagdolite.hpp
+++ b/Runtime/MP1/World/CMagdolite.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "Character/CBoneTracking.hpp"
+#include "Runtime/Character/CBoneTracking.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde::MP1 {
 class CMagdolite : public CPatterned {

--- a/Runtime/MP1/World/CMetaree.hpp
+++ b/Runtime/MP1/World/CMetaree.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CDamageInfo.hpp"
 #include "DataSpec/DNAMP1/SFX/Metaree.h"
+
+#include "Runtime/World/CDamageInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 class CMetaree : public CPatterned {

--- a/Runtime/MP1/World/CMetroid.hpp
+++ b/Runtime/MP1/World/CMetroid.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CAnimationParameters.hpp"
+#include <optional>
+#include <string_view>
+
+#include "Runtime/World/CAnimationParameters.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/World/CMetroidBeta.hpp
+++ b/Runtime/MP1/World/CMetroidBeta.hpp
@@ -1,14 +1,18 @@
 #pragma once
 
-#include <Collision/CJointCollisionDescription.hpp>
-#include "World/CPathFindSearch.hpp"
-#include "World/CPatterned.hpp"
-#include "CRandom16.hpp"
+#include <memory>
+
+#include "Runtime/CRandom16.hpp"
+#include "Runtime/Collision/CJointCollisionDescription.hpp"
+#include "Runtime/World/CPathFindSearch.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
+class CCollisionActorManager;
 class CElementGen;
 class CParticleSwoosh;
-class CCollisionActorManager;
 }
 
 namespace urde::MP1 {

--- a/Runtime/MP1/World/CMetroidPrimeExo.hpp
+++ b/Runtime/MP1/World/CMetroidPrimeExo.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CPatternedInfo.hpp"
-#include "World/CActorParameters.hpp"
-#include "Camera/CCameraShakeData.hpp"
-#include "Weapon/CBeamInfo.hpp"
-#include "CMetroidPrimeProjectile.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/Camera/CCameraShakeData.hpp"
+#include "Runtime/MP1/World/CMetroidPrimeProjectile.hpp"
+#include "Runtime/Weapon/CBeamInfo.hpp"
+#include "Runtime/World/CActorParameters.hpp"
+#include "Runtime/World/CPatterned.hpp"
+#include "Runtime/World/CPatternedInfo.hpp"
+
+#include <zeus/CColor.hpp>
 
 namespace urde {
 class CCameraShakeData;

--- a/Runtime/MP1/World/CMetroidPrimeProjectile.hpp
+++ b/Runtime/MP1/World/CMetroidPrimeProjectile.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "Weapon/CEnergyProjectile.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/Weapon/CEnergyProjectile.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/World/CMetroidPrimeRelay.hpp
+++ b/Runtime/MP1/World/CMetroidPrimeRelay.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "World/CEntity.hpp"
-#include "CMetroidPrimeExo.hpp"
+#include "Runtime/RetroTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/MP1/World/CMetroidPrimeExo.hpp"
+#include "Runtime/World/CEntity.hpp"
+
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/World/CNewIntroBoss.hpp
+++ b/Runtime/MP1/World/CNewIntroBoss.hpp
@@ -1,12 +1,18 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "Character/CBoneTracking.hpp"
-#include "Weapon/CProjectileInfo.hpp"
+#include <memory>
+#include <string>
+
+#include "Runtime/Character/CBoneTracking.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CDamageInfo;
 class CCollisionActorManager;
+class CDamageInfo;
 
 namespace MP1 {
 class CNewIntroBoss : public CPatterned {

--- a/Runtime/MP1/World/CParasite.hpp
+++ b/Runtime/MP1/World/CParasite.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "World/CWallWalker.hpp"
-#include "Collision/CCollisionActorManager.hpp"
+#include <vector>
+
+#include "Runtime/Collision/CCollisionActorManager.hpp"
+#include "Runtime/World/CWallWalker.hpp"
+
+#include <zeus/CVector3f.hpp>
+
 namespace urde {
 class CModelData;
 }

--- a/Runtime/MP1/World/CPuddleSpore.hpp
+++ b/Runtime/MP1/World/CPuddleSpore.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "Weapon/CProjectileInfo.hpp"
-#include "Particle/CElementGen.hpp"
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "Runtime/CToken.hpp"
+#include "Runtime/Particle/CElementGen.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde::MP1 {
 class CPuddleSpore : public CPatterned {

--- a/Runtime/MP1/World/CPuddleToadGamma.hpp
+++ b/Runtime/MP1/World/CPuddleToadGamma.hpp
@@ -1,7 +1,12 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "Collision/CCollidableOBBTreeGroup.hpp"
+#include <memory>
+#include <string_view>
+
+#include "Runtime/Collision/CCollidableOBBTreeGroup.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/World/CPuffer.hpp
+++ b/Runtime/MP1/World/CPuffer.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
+#include "Runtime/CToken.hpp"
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/rstl.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 class CPuffer : public CPatterned {

--- a/Runtime/MP1/World/CRidley.hpp
+++ b/Runtime/MP1/World/CRidley.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "Camera/CCameraShakeData.hpp"
-#include "Weapon/CBeamInfo.hpp"
-#include "World/CDamageInfo.hpp"
-#include "World/CPatterned.hpp"
+#include <string_view>
+
+#include "Runtime/Camera/CCameraShakeData.hpp"
+#include "Runtime/Weapon/CBeamInfo.hpp"
+#include "Runtime/World/CDamageInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde {
 namespace MP1 {

--- a/Runtime/MP1/World/CRipper.hpp
+++ b/Runtime/MP1/World/CRipper.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CGrappleParameters.hpp"
-#include "World/CScriptPlatform.hpp"
+#include "Runtime/World/CGrappleParameters.hpp"
+#include "Runtime/World/CPatterned.hpp"
+#include "Runtime/World/CScriptPlatform.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/World/CSeedling.hpp
+++ b/Runtime/MP1/World/CSeedling.hpp
@@ -1,8 +1,13 @@
 #pragma once
 
-#include "World/CWallWalker.hpp"
-#include "World/CPathFindSearch.hpp"
-#include "Weapon/CProjectileInfo.hpp"
+#include <memory>
+#include <string>
+
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPathFindSearch.hpp"
+#include "Runtime/World/CWallWalker.hpp"
+
+#include <zeus/CAABox.hpp>
 
 namespace urde::MP1 {
 class CSeedling : public CWallWalker {

--- a/Runtime/MP1/World/CSpacePirate.hpp
+++ b/Runtime/MP1/World/CSpacePirate.hpp
@@ -1,12 +1,18 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "Weapon/CProjectileInfo.hpp"
-#include "Character/CBoneTracking.hpp"
-#include "Character/CIkChain.hpp"
-#include "Character/CRagDoll.hpp"
-#include "World/CPathFindSearch.hpp"
-#include "Weapon/CBurstFire.hpp"
+#include <list>
+#include <memory>
+
+#include "Runtime/rstl.hpp"
+#include "Runtime/Character/CBoneTracking.hpp"
+#include "Runtime/Character/CIkChain.hpp"
+#include "Runtime/Character/CRagDoll.hpp"
+#include "Runtime/Weapon/CBurstFire.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPathFindSearch.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 class CSpacePirate;

--- a/Runtime/MP1/World/CSpankWeed.hpp
+++ b/Runtime/MP1/World/CSpankWeed.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "Collision/CCollisionActorManager.hpp"
+#include <memory>
+
+#include "Runtime/Collision/CCollisionActorManager.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CVector3f.hpp>
 
 namespace urde::MP1 {
 class CSpankWeed : public CPatterned {

--- a/Runtime/MP1/World/CThardusRockProjectile.hpp
+++ b/Runtime/MP1/World/CThardusRockProjectile.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
+#include "Runtime/World/CPatterned.hpp"
 
 namespace urde {
 

--- a/Runtime/MP1/World/CTryclops.hpp
+++ b/Runtime/MP1/World/CTryclops.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CPathFindSearch.hpp"
+#include "Runtime/World/CPathFindSearch.hpp"
+#include "Runtime/World/CPatterned.hpp"
+
+#include <zeus/CTransform.hpp>
 
 namespace urde::MP1 {
 class CTryclops : public CPatterned {

--- a/Runtime/MP1/World/CWarWasp.hpp
+++ b/Runtime/MP1/World/CWarWasp.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
-#include "World/CPatterned.hpp"
-#include "World/CPathFindSearch.hpp"
-#include "Weapon/CProjectileInfo.hpp"
-#include "Collision/CCollidableSphere.hpp"
+#include "Runtime/Collision/CCollidableSphere.hpp"
+#include "Runtime/Weapon/CProjectileInfo.hpp"
+#include "Runtime/World/CPatterned.hpp"
+#include "Runtime/World/CPathFindSearch.hpp"
+
+#include <zeus/CQuaternion.hpp>
+#include <zeus/CVector3f.hpp>
 
 namespace urde {
 class CDamageInfo;

--- a/Runtime/RetroTypes.hpp
+++ b/Runtime/RetroTypes.hpp
@@ -1,18 +1,21 @@
 #pragma once
 
-#include <vector>
-#include <utility>
-#include <string>
 #include <functional>
-#include "GCNTypes.hpp"
-#include "rstl.hpp"
-#include "IOStreams.hpp"
-#include "hecl/hecl.hpp"
-#include "zeus/CVector3f.hpp"
-#include "zeus/CVector2f.hpp"
-#include "zeus/CMatrix3f.hpp"
-#include "zeus/CMatrix4f.hpp"
-#include "zeus/CTransform.hpp"
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "Runtime/GCNTypes.hpp"
+#include "Runtime/IOStreams.hpp"
+#include "Runtime/rstl.hpp"
+
+#include <hecl/hecl.hpp>
+#include <zeus/CMatrix3f.hpp>
+#include <zeus/CMatrix4f.hpp>
+#include <zeus/CTransform.hpp>
+#include <zeus/CVector2f.hpp>
+#include <zeus/CVector3f.hpp>
 
 #undef min
 #undef max


### PR DESCRIPTION
Performs the same normalizing done to the RuntimeCommonB target, now all of the runtime headers have normalized include paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/86)
<!-- Reviewable:end -->
