### PR TITLE
CSeedling: Convert array of std::string to array of std::string_view

### DIFF
--- a/Runtime/MP1/World/CSeedling.cpp
+++ b/Runtime/MP1/World/CSeedling.cpp
@@ -9,6 +9,26 @@
 #include "TCastTo.hpp" // Generated file, do not modify include path
 
 namespace urde::MP1 {
+namespace {
+const std::string skNeedleLocators[2][6] = {
+    {
+        "A_spike1_LCTR_SDK",
+        "A_spike2_LCTR_SDK",
+        "A_spike3_LCTR_SDK",
+        "A_spike4_LCTR_SDK",
+        "A_spike5_LCTR_SDK",
+        "A_spike6_LCTR_SDK",
+    },
+    {
+        "B_spike1_LCTR_SDK",
+        "B_spike2_LCTR_SDK",
+        "B_spike3_LCTR_SDK",
+        "B_spike4_LCTR_SDK",
+        "B_spike5_LCTR_SDK",
+        "B_spike6_LCTR_SDK",
+    },
+};
+} // Anonymous namespace
 
 CSeedling::CSeedling(TUniqueId uid, std::string_view name, const CEntityInfo& info, const zeus::CTransform& xf,
                      CModelData&& mData, const CPatternedInfo& pInfo, const CActorParameters& actParms,
@@ -29,23 +49,6 @@ CSeedling::CSeedling(TUniqueId uid, std::string_view name, const CEntityInfo& in
 }
 
 void CSeedling::Accept(IVisitor& visitor) { visitor.Visit(this); }
-
-const std::string CSeedling::skNeedleLocators[2][6] = {{
-                                                           "A_spike1_LCTR_SDK",
-                                                           "A_spike2_LCTR_SDK",
-                                                           "A_spike3_LCTR_SDK",
-                                                           "A_spike4_LCTR_SDK",
-                                                           "A_spike5_LCTR_SDK",
-                                                           "A_spike6_LCTR_SDK",
-                                                       },
-                                                       {
-                                                           "B_spike1_LCTR_SDK",
-                                                           "B_spike2_LCTR_SDK",
-                                                           "B_spike3_LCTR_SDK",
-                                                           "B_spike4_LCTR_SDK",
-                                                           "B_spike5_LCTR_SDK",
-                                                           "B_spike6_LCTR_SDK",
-                                                       }};
 
 void CSeedling::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) {
   CPatterned::AcceptScriptMsg(msg, uid, mgr);

--- a/Runtime/MP1/World/CSeedling.cpp
+++ b/Runtime/MP1/World/CSeedling.cpp
@@ -1,11 +1,12 @@
-#include "MP1/World/CSeedling.hpp"
-#include "World/CPatternedInfo.hpp"
-#include "World/CWorld.hpp"
-#include "World/CGameArea.hpp"
-#include "World/CPlayer.hpp"
-#include "CStateManager.hpp"
+#include "Runtime/MP1/World/CSeedling.hpp"
+
+#include "Runtime/CStateManager.hpp"
+#include "Runtime/World/CGameArea.hpp"
+#include "Runtime/World/CPatternedInfo.hpp"
+#include "Runtime/World/CPlayer.hpp"
+#include "Runtime/World/CWorld.hpp"
+
 #include "TCastTo.hpp" // Generated file, do not modify include path
-#include "CSeedling.hpp"
 
 namespace urde::MP1 {
 

--- a/Runtime/MP1/World/CSeedling.cpp
+++ b/Runtime/MP1/World/CSeedling.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/MP1/World/CSeedling.hpp"
 
+#include <array>
+
 #include "Runtime/CStateManager.hpp"
 #include "Runtime/World/CGameArea.hpp"
 #include "Runtime/World/CPatternedInfo.hpp"
@@ -10,7 +12,7 @@
 
 namespace urde::MP1 {
 namespace {
-const std::string skNeedleLocators[2][6] = {
+const std::array<std::array<std::string, 6>, 2> skNeedleLocators{{
     {
         "A_spike1_LCTR_SDK",
         "A_spike2_LCTR_SDK",
@@ -27,7 +29,7 @@ const std::string skNeedleLocators[2][6] = {
         "B_spike5_LCTR_SDK",
         "B_spike6_LCTR_SDK",
     },
-};
+}};
 } // Anonymous namespace
 
 CSeedling::CSeedling(TUniqueId uid, std::string_view name, const CEntityInfo& info, const zeus::CTransform& xf,
@@ -107,13 +109,14 @@ void CSeedling::Think(float dt, CStateManager& mgr) {
 
 void CSeedling::Render(const CStateManager& mgr) const {
   if (x400_25_alive && x6bc_spikeData) {
-    u32 index = x722_24_renderOnlyClusterA ? 0 : u32(x722_25_curNeedleCluster);
+    const size_t index = x722_24_renderOnlyClusterA ? 0 : size_t(x722_25_curNeedleCluster);
     CModelFlags flags;
     flags.x2_flags = 3;
     flags.x4_color = zeus::skWhite;
 
-    for (const std::string& sv : skNeedleLocators[index])
+    for (const std::string& sv : skNeedleLocators[index]) {
       x6bc_spikeData->Render(mgr, GetLctrTransform(sv), x90_actorLights.get(), flags);
+    }
   }
 
   CWallWalker::Render(mgr);
@@ -206,9 +209,11 @@ bool CSeedling::ShouldAttack(CStateManager& mgr, float) {
 }
 
 void CSeedling::LaunchNeedles(CStateManager& mgr) {
-  for (const std::string& needle : skNeedleLocators[u32(x722_25_curNeedleCluster)])
-    LaunchProjectile(GetLctrTransform(needle), mgr, 6, EProjectileAttrib::None, true, {}, 0xFFFF, false,
-                     GetModelData()->GetScale());
+  const auto& needleLocators = skNeedleLocators[size_t(x722_25_curNeedleCluster)];
+  for (const std::string& needle : needleLocators) {
+    LaunchProjectile(GetLctrTransform(needle), mgr, int(needleLocators.size()), EProjectileAttrib::None, true, {},
+                     0xFFFF, false, GetModelData()->GetScale());
+  }
 
   x722_25_curNeedleCluster = !x722_25_curNeedleCluster;
   x722_24_renderOnlyClusterA = false;

--- a/Runtime/MP1/World/CSeedling.cpp
+++ b/Runtime/MP1/World/CSeedling.cpp
@@ -12,7 +12,7 @@
 
 namespace urde::MP1 {
 namespace {
-const std::array<std::array<std::string, 6>, 2> skNeedleLocators{{
+constexpr std::array<std::array<std::string_view, 6>, 2> skNeedleLocators{{
     {
         "A_spike1_LCTR_SDK",
         "A_spike2_LCTR_SDK",
@@ -114,7 +114,7 @@ void CSeedling::Render(const CStateManager& mgr) const {
     flags.x2_flags = 3;
     flags.x4_color = zeus::skWhite;
 
-    for (const std::string& sv : skNeedleLocators[index]) {
+    for (const std::string_view sv : skNeedleLocators[index]) {
       x6bc_spikeData->Render(mgr, GetLctrTransform(sv), x90_actorLights.get(), flags);
     }
   }
@@ -210,7 +210,7 @@ bool CSeedling::ShouldAttack(CStateManager& mgr, float) {
 
 void CSeedling::LaunchNeedles(CStateManager& mgr) {
   const auto& needleLocators = skNeedleLocators[size_t(x722_25_curNeedleCluster)];
-  for (const std::string& needle : needleLocators) {
+  for (const std::string_view needle : needleLocators) {
     LaunchProjectile(GetLctrTransform(needle), mgr, int(needleLocators.size()), EProjectileAttrib::None, true, {},
                      0xFFFF, false, GetModelData()->GetScale());
   }

--- a/Runtime/MP1/World/CSeedling.hpp
+++ b/Runtime/MP1/World/CSeedling.hpp
@@ -11,7 +11,6 @@
 
 namespace urde::MP1 {
 class CSeedling : public CWallWalker {
-  static const std::string skNeedleLocators[2][6];
   CPathFindSearch x5d8_searchPath;
   std::unique_ptr<CModelData> x6bc_spikeData;
   CProjectileInfo x6c0_projectileInfo;


### PR DESCRIPTION
Makes the array contain non-allocating data. This also gets rid of 12 runtime static constructors that would have need to run on program start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/87)
<!-- Reviewable:end -->
