### PR TITLE
{CToken, IVParamObj}: Mark a few interface functions as noexcept where applicable

### DIFF
--- a/Runtime/CToken.cpp
+++ b/Runtime/CToken.cpp
@@ -16,7 +16,7 @@ u16 CObjectReference::RemoveReference() {
 
 CObjectReference::CObjectReference(IObjectStore& objStore, std::unique_ptr<IObj>&& obj, const SObjectTag& objTag,
                                    CVParamTransfer buildParams)
-: x4_objTag(objTag), xC_objectStore(&objStore), x10_object(std::move(obj)), x14_params(buildParams) {}
+: x4_objTag(objTag), xC_objectStore(&objStore), x10_object(std::move(obj)), x14_params(std::move(buildParams)) {}
 CObjectReference::CObjectReference(std::unique_ptr<IObj>&& obj) : x10_object(std::move(obj)) {}
 
 void CObjectReference::Unlock() {

--- a/Runtime/CToken.cpp
+++ b/Runtime/CToken.cpp
@@ -128,7 +128,7 @@ CToken::CToken(const CToken& other) : x0_objRef(other.x0_objRef) {
       Lock();
   }
 }
-CToken::CToken(CToken&& other) : x0_objRef(other.x0_objRef), x4_lockHeld(other.x4_lockHeld) {
+CToken::CToken(CToken&& other) noexcept : x0_objRef(other.x0_objRef), x4_lockHeld(other.x4_lockHeld) {
   other.x0_objRef = nullptr;
   other.x4_lockHeld = false;
 }

--- a/Runtime/CToken.hpp
+++ b/Runtime/CToken.hpp
@@ -85,7 +85,7 @@ public:
   CToken& operator=(CToken&& other);
   CToken() = default;
   CToken(const CToken& other);
-  CToken(CToken&& other);
+  CToken(CToken&& other) noexcept;
   CToken(IObj* obj);
   CToken(std::unique_ptr<IObj>&& obj);
   const SObjectTag* GetObjectTag() const;

--- a/Runtime/IVParamObj.hpp
+++ b/Runtime/IVParamObj.hpp
@@ -24,7 +24,7 @@ class CVParamTransfer {
   std::shared_ptr<IVParamObj> m_ref;
 
 public:
-  CVParamTransfer() noexcept = default;
+  constexpr CVParamTransfer() noexcept = default;
   CVParamTransfer(IVParamObj* obj) : m_ref(obj) {}
 
   CVParamTransfer(const CVParamTransfer& other) noexcept = default;

--- a/Runtime/IVParamObj.hpp
+++ b/Runtime/IVParamObj.hpp
@@ -16,8 +16,8 @@ class TObjOwnerParam : public IVParamObj {
 
 public:
   TObjOwnerParam(T&& obj) : m_param(std::move(obj)) {}
-  T& GetParam() { return m_param; }
-  const T& GetParam() const { return m_param; }
+  T& GetParam() noexcept { return m_param; }
+  const T& GetParam() const noexcept { return m_param; }
 };
 
 class CVParamTransfer {
@@ -33,15 +33,15 @@ public:
   CVParamTransfer(CVParamTransfer&&) noexcept = default;
   CVParamTransfer& operator=(CVParamTransfer&&) noexcept = default;
 
-  IVParamObj* GetObj() const { return m_ref.get(); }
-  CVParamTransfer ShareTransferRef() const { return CVParamTransfer(*this); }
+  IVParamObj* GetObj() const noexcept { return m_ref.get(); }
+  CVParamTransfer ShareTransferRef() const noexcept { return CVParamTransfer(*this); }
 
   template <class T>
-  T& GetOwnedObj() const {
+  T& GetOwnedObj() const noexcept {
     return static_cast<TObjOwnerParam<T>*>(GetObj())->GetParam();
   }
 
-  static CVParamTransfer Null() { return CVParamTransfer(); }
+  static CVParamTransfer Null() noexcept { return CVParamTransfer(); }
 };
 
 } // namespace urde

--- a/Runtime/IVParamObj.hpp
+++ b/Runtime/IVParamObj.hpp
@@ -24,9 +24,15 @@ class CVParamTransfer {
   std::shared_ptr<IVParamObj> m_ref;
 
 public:
-  CVParamTransfer() = default;
+  CVParamTransfer() noexcept = default;
   CVParamTransfer(IVParamObj* obj) : m_ref(obj) {}
-  CVParamTransfer(const CVParamTransfer& other) : m_ref(other.m_ref) {}
+
+  CVParamTransfer(const CVParamTransfer& other) noexcept = default;
+  CVParamTransfer& operator=(const CVParamTransfer&) noexcept = default;
+
+  CVParamTransfer(CVParamTransfer&&) noexcept = default;
+  CVParamTransfer& operator=(CVParamTransfer&&) noexcept = default;
+
   IVParamObj* GetObj() const { return m_ref.get(); }
   CVParamTransfer ShareTransferRef() const { return CVParamTransfer(*this); }
 


### PR DESCRIPTION
Allows code gen to be slightly better with CToken (in terms of constructors, the rest of the member functions being noexcept is for consistency).

The move constructor doesn't perform any behavior that would result in an exception being thrown. Marking it as noexcept allows the type to play nicely with facilities that make use of `std::is_move_constructible` to determine whether copies can be avoided or not in certain circumstances during reallocations (e.g. the standard library; notably, std::vector).

We can't mark the move assignment operator as noexcept currently, however, as it calls into interfaces outside of CToken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/89)
<!-- Reviewable:end -->
