### PR TITLE
RetroTypes: Make functions noexcept where applicable

### DIFF
--- a/Runtime/RetroTypes.hpp
+++ b/Runtime/RetroTypes.hpp
@@ -49,7 +49,7 @@ struct SObjectTag {
   FourCC type;
   CAssetId id;
 
-  constexpr operator bool() const noexcept { return id.IsValid(); }
+  constexpr explicit operator bool() const noexcept { return id.IsValid(); }
   constexpr bool operator==(const SObjectTag& other) const noexcept { return id == other.id; }
   constexpr bool operator!=(const SObjectTag& other) const noexcept { return !operator==(other); }
   constexpr bool operator<(const SObjectTag& other) const noexcept { return id < other.id; }

--- a/Runtime/RetroTypes.hpp
+++ b/Runtime/RetroTypes.hpp
@@ -30,17 +30,17 @@ class CAssetId {
   u64 id = UINT64_MAX;
 
 public:
-  constexpr CAssetId() = default;
-  constexpr CAssetId(u64 v) { Assign(v); }
+  constexpr CAssetId() noexcept = default;
+  constexpr CAssetId(u64 v) noexcept { Assign(v); }
   explicit CAssetId(CInputStream& in);
-  constexpr bool IsValid() const { return id != UINT64_MAX; }
-  constexpr u64 Value() const { return id; }
-  constexpr void Assign(u64 v) { id = (v == UINT32_MAX ? UINT64_MAX : (v == 0 ? UINT64_MAX : v)); }
-  constexpr void Reset() { id = UINT64_MAX; }
+  constexpr bool IsValid() const noexcept { return id != UINT64_MAX; }
+  constexpr u64 Value() const noexcept { return id; }
+  constexpr void Assign(u64 v) noexcept { id = (v == UINT32_MAX ? UINT64_MAX : (v == 0 ? UINT64_MAX : v)); }
+  constexpr void Reset() noexcept { id = UINT64_MAX; }
   void PutTo(COutputStream& out);
-  constexpr bool operator==(const CAssetId& other) const { return id == other.id; }
-  constexpr bool operator!=(const CAssetId& other) const { return !operator==(other); }
-  constexpr bool operator<(const CAssetId& other) const { return id < other.id; }
+  constexpr bool operator==(const CAssetId& other) const noexcept { return id == other.id; }
+  constexpr bool operator!=(const CAssetId& other) const noexcept { return !operator==(other); }
+  constexpr bool operator<(const CAssetId& other) const noexcept { return id < other.id; }
 };
 
 //#define kInvalidAssetId CAssetId()
@@ -49,12 +49,12 @@ struct SObjectTag {
   FourCC type;
   CAssetId id;
 
-  constexpr operator bool() const { return id.IsValid(); }
-  constexpr bool operator==(const SObjectTag& other) const { return id == other.id; }
-  constexpr bool operator!=(const SObjectTag& other) const { return !operator==(other); }
-  constexpr bool operator<(const SObjectTag& other) const { return id < other.id; }
-  constexpr SObjectTag() = default;
-  constexpr SObjectTag(FourCC tp, CAssetId rid) : type(tp), id(rid) {}
+  constexpr operator bool() const noexcept { return id.IsValid(); }
+  constexpr bool operator==(const SObjectTag& other) const noexcept { return id == other.id; }
+  constexpr bool operator!=(const SObjectTag& other) const noexcept { return !operator==(other); }
+  constexpr bool operator<(const SObjectTag& other) const noexcept { return id < other.id; }
+  constexpr SObjectTag() noexcept = default;
+  constexpr SObjectTag(FourCC tp, CAssetId rid) noexcept : type(tp), id(rid) {}
   SObjectTag(CInputStream& in) {
     in.readBytesToBuf(&type, 4);
     id = CAssetId(in);
@@ -68,14 +68,16 @@ struct SObjectTag {
 struct TEditorId {
   u32 id = u32(-1);
 
-  constexpr TEditorId() = default;
-  constexpr TEditorId(u32 idin) : id(idin) {}
-  constexpr u8 LayerNum() const { return u8((id >> 26) & 0x3f); }
-  constexpr u16 AreaNum() const { return u16((id >> 16) & 0x3ff); }
-  constexpr u16 Id() const { return u16(id & 0xffff); }
-  constexpr bool operator<(const TEditorId& other) const { return (id & 0x3ffffff) < (other.id & 0x3ffffff); }
-  constexpr bool operator==(const TEditorId& other) const { return (id & 0x3ffffff) == (other.id & 0x3ffffff); }
-  constexpr bool operator!=(const TEditorId& other) const { return !operator==(other); }
+  constexpr TEditorId() noexcept = default;
+  constexpr TEditorId(u32 idin) noexcept : id(idin) {}
+  constexpr u8 LayerNum() const noexcept { return u8((id >> 26) & 0x3f); }
+  constexpr u16 AreaNum() const noexcept { return u16((id >> 16) & 0x3ff); }
+  constexpr u16 Id() const noexcept { return u16(id & 0xffff); }
+  constexpr bool operator<(const TEditorId& other) const noexcept { return (id & 0x3ffffff) < (other.id & 0x3ffffff); }
+  constexpr bool operator==(const TEditorId& other) const noexcept {
+    return (id & 0x3ffffff) == (other.id & 0x3ffffff);
+  }
+  constexpr bool operator!=(const TEditorId& other) const noexcept { return !operator==(other); }
 };
 
 #define kInvalidEditorId TEditorId()
@@ -83,13 +85,13 @@ struct TEditorId {
 struct TUniqueId {
   u16 id = u16(-1);
 
-  constexpr TUniqueId() = default;
-  constexpr TUniqueId(u16 value, u16 version) : id(value | (version << 10)) {}
-  constexpr u16 Version() const { return u16((id >> 10) & 0x3f); }
-  constexpr u16 Value() const { return u16(id & 0x3ff); }
-  constexpr bool operator<(const TUniqueId& other) const { return id < other.id; }
-  constexpr bool operator==(const TUniqueId& other) const { return id == other.id; }
-  constexpr bool operator!=(const TUniqueId& other) const { return !operator==(other); }
+  constexpr TUniqueId() noexcept = default;
+  constexpr TUniqueId(u16 value, u16 version) noexcept : id(value | (version << 10)) {}
+  constexpr u16 Version() const noexcept { return u16((id >> 10) & 0x3f); }
+  constexpr u16 Value() const noexcept { return u16(id & 0x3ff); }
+  constexpr bool operator<(const TUniqueId& other) const noexcept { return id < other.id; }
+  constexpr bool operator==(const TUniqueId& other) const noexcept { return id == other.id; }
+  constexpr bool operator!=(const TUniqueId& other) const noexcept { return !operator==(other); }
 };
 
 #define kInvalidUniqueId TUniqueId()
@@ -120,7 +122,7 @@ public:
 #endif
 
 template <class T>
-T GetAverage(const T* v, s32 count) {
+T GetAverage(const T* v, s32 count) noexcept {
   T r = v[0];
   for (s32 i = 1; i < count; ++i)
     r += v[i];


### PR DESCRIPTION
These functions/types are quite common throughout the codebase, so making these noexcept allows them to be used within noexcept contexts (or allow contexts to become noexcept).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/90)
<!-- Reviewable:end -->
