### PR TITLE
ICollisionFilter: Use forward declarations where applicable

### DIFF
--- a/Runtime/Collision/CAABoxFilter.cpp
+++ b/Runtime/Collision/CAABoxFilter.cpp
@@ -1,5 +1,7 @@
-#include "CAABoxFilter.hpp"
-#include "CollisionUtil.hpp"
+#include "Runtime/Collision/CAABoxFilter.hpp"
+
+#include "Runtime/Collision/CCollisionInfoList.hpp"
+#include "Runtime/Collision/CollisionUtil.hpp"
 
 namespace urde {
 

--- a/Runtime/Collision/CAABoxFilter.hpp
+++ b/Runtime/Collision/CAABoxFilter.hpp
@@ -3,6 +3,7 @@
 #include "Runtime/Collision/ICollisionFilter.hpp"
 
 namespace urde {
+class CCollisionInfoList;
 
 class CAABoxFilter : public ICollisionFilter {
 public:

--- a/Runtime/Collision/CBallFilter.cpp
+++ b/Runtime/Collision/CBallFilter.cpp
@@ -1,5 +1,6 @@
-#include "CBallFilter.hpp"
-#include "CollisionUtil.hpp"
+#include "Runtime/Collision/CBallFilter.hpp"
+#include "Runtime/Collision/CollisionUtil.hpp"
+
 namespace urde {
 
 void CBallFilter::Filter(const CCollisionInfoList& in, CCollisionInfoList& out) const {

--- a/Runtime/Collision/CBallFilter.hpp
+++ b/Runtime/Collision/CBallFilter.hpp
@@ -3,6 +3,7 @@
 #include "Runtime/Collision/ICollisionFilter.hpp"
 
 namespace urde {
+class CCollisionInfoList;
 class CPhysicsActor;
 
 class CBallFilter : public ICollisionFilter {

--- a/Runtime/Collision/CGameCollision.cpp
+++ b/Runtime/Collision/CGameCollision.cpp
@@ -1,18 +1,21 @@
-#include "CGameCollision.hpp"
-#include "CCollidableOBBTreeGroup.hpp"
-#include "CMaterialFilter.hpp"
-#include "CMaterialList.hpp"
-#include "World/CActor.hpp"
-#include "CStateManager.hpp"
+#include "Runtime/Collision/CGameCollision.hpp"
+
+#include "Runtime/CStateManager.hpp"
+#include "Runtime/Character/CGroundMovement.hpp"
+#include "Runtime/Collision/CAABoxFilter.hpp"
+#include "Runtime/Collision/CBallFilter.hpp"
+#include "Runtime/Collision/CCollidableOBBTreeGroup.hpp"
+#include "Runtime/Collision/CCollidableSphere.hpp"
+#include "Runtime/Collision/CCollisionInfoList.hpp"
+#include "Runtime/Collision/CMaterialFilter.hpp"
+#include "Runtime/Collision/CMaterialList.hpp"
+#include "Runtime/Collision/CMetroidAreaCollider.hpp"
+#include "Runtime/Collision/CollisionUtil.hpp"
+#include "Runtime/World/CActor.hpp"
+#include "Runtime/World/CScriptPlatform.hpp"
+#include "Runtime/World/CWorld.hpp"
+
 #include "TCastTo.hpp" // Generated file, do not modify include path
-#include "World/CWorld.hpp"
-#include "CAABoxFilter.hpp"
-#include "CBallFilter.hpp"
-#include "CMetroidAreaCollider.hpp"
-#include "CollisionUtil.hpp"
-#include "World/CScriptPlatform.hpp"
-#include "CCollidableSphere.hpp"
-#include "Character/CGroundMovement.hpp"
 
 namespace urde {
 

--- a/Runtime/Collision/CGameCollision.hpp
+++ b/Runtime/Collision/CGameCollision.hpp
@@ -16,11 +16,11 @@ namespace urde {
 class CActor;
 class CCollisionInfo;
 class CCollisionInfoList;
-class CMaterialList;
-class CStateManager;
-class CPhysicsActor;
-class CMaterialFilter;
 class CGameArea;
+class CMaterialFilter;
+class CMaterialList;
+class CPhysicsActor;
+class CStateManager;
 class ICollisionFilter;
 
 class CGameCollision {

--- a/Runtime/Collision/ICollisionFilter.hpp
+++ b/Runtime/Collision/ICollisionFilter.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include "Runtime/Collision/CCollisionInfoList.hpp"
-
 namespace urde {
 class CActor;
+class CCollisionInfoList;
 
 class ICollisionFilter {
   CActor& x4_actor;


### PR DESCRIPTION
With the headers all normalized, we can safely convert the only ICollisionFilter include into a forward declaration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/92)
<!-- Reviewable:end -->
