### PR TITLE
MkCastTo: Use '_v' variants of type traits where applicable

### DIFF
--- a/Runtime/MkCastTo.py
+++ b/Runtime/MkCastTo.py
@@ -184,7 +184,7 @@ for tp in CENTITY_TYPES:
         sourcef.write('''template <class T>
 void TCastToPtr<T>::Visit(%s* p) {
   static_assert(sizeof(T) > 0 && !std::is_void_v<T>, "TCastToPtr can not cast to incomplete type");
-  ptr = reinterpret_cast<T*>(std::is_convertible_v<%s*, T*> ? p : nullptr);
+  ptr = static_cast<T*>(std::is_convertible_v<%s*, T*> ? p : nullptr);
 }
 
 ''' % (qual, qual))

--- a/Runtime/MkCastTo.py
+++ b/Runtime/MkCastTo.py
@@ -183,8 +183,8 @@ for tp in CENTITY_TYPES:
         qual = getqualified(tp)
         sourcef.write('''template <class T>
 void TCastToPtr<T>::Visit(%s* p) {
-  static_assert(sizeof(T) > 0 && !std::is_void<T>::value, "TCastToPtr can not cast to incomplete type");
-  ptr = reinterpret_cast<T*>(std::is_convertible<%s*, T*>::value ? p : nullptr);
+  static_assert(sizeof(T) > 0 && !std::is_void_v<T>, "TCastToPtr can not cast to incomplete type");
+  ptr = reinterpret_cast<T*>(std::is_convertible_v<%s*, T*> ? p : nullptr);
 }
 
 ''' % (qual, qual))


### PR DESCRIPTION
Same thing, but less typing, slightly shrinking the file size.

We can also make use of `static_cast` instead of `reinterpret_cast` here, given we check if conversions can be performed with `std::is_convertible` beforehand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/95)
<!-- Reviewable:end -->
