### PR TITLE
CElementGen: Correct FourCC in SetTranslation()

### DIFF
--- a/Runtime/Particle/CElementGen.cpp
+++ b/Runtime/Particle/CElementGen.cpp
@@ -1753,7 +1753,7 @@ void CElementGen::SetTranslation(const zeus::CVector3f& translation) {
 
   for (const std::unique_ptr<CParticleGen>& ch : x290_activePartChildren) {
     switch (ch->Get4CharId().toUint32()) {
-    case SBIG('SELC'):
+    case SBIG('ELSC'):
       ch->SetTranslation(translation + x2c0_SEPO);
       break;
     case SBIG('SWHC'):


### PR DESCRIPTION
The game executable checks for a FourCC of ELSC within this function, not SELC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/99)
<!-- Reviewable:end -->
