### PR TITLE
rstl: Make constructors/assignment operators of reserved_vector conditionally noexcept

### DIFF
--- a/Runtime/rstl.hpp
+++ b/Runtime/rstl.hpp
@@ -271,10 +271,10 @@ private:
   }
 
 public:
-  reserved_vector() : x0_size(0) {}
+  reserved_vector() noexcept(std::is_nothrow_constructible_v<T>) : x0_size(0) {}
 
   template <size_t LN>
-  reserved_vector(const T(&l)[LN])
+  reserved_vector(const T (&l)[LN]) noexcept(std::is_nothrow_copy_constructible_v<T>)
   : x0_size(LN) {
     static_assert(LN <= N, "initializer array too large for reserved_vector");
     for (size_t i = 0; i < LN; ++i) {
@@ -282,13 +282,14 @@ public:
     }
   }
 
-  reserved_vector(const reserved_vector& other) : x0_size(other.x0_size) {
+  reserved_vector(const reserved_vector& other) noexcept(std::is_nothrow_copy_constructible_v<T>)
+  : x0_size(other.x0_size) {
     for (size_t i = 0; i < x0_size; ++i) {
       ::new (static_cast<void*>(std::addressof(_value(i)))) T(other._value(i));
     }
   }
 
-  reserved_vector& operator=(const reserved_vector& other) {
+  reserved_vector& operator=(const reserved_vector& other) noexcept(std::is_nothrow_copy_assignable_v<T>) {
     size_t i = 0;
     if (other.x0_size > x0_size) {
       for (; i < x0_size; ++i) {
@@ -317,13 +318,14 @@ public:
     return *this;
   }
 
-  reserved_vector(reserved_vector&& other) : x0_size(other.x0_size) {
+  reserved_vector(reserved_vector&& other) noexcept(std::is_nothrow_move_constructible_v<T>) : x0_size(other.x0_size) {
     for (size_t i = 0; i < x0_size; ++i) {
       ::new (static_cast<void*>(std::addressof(_value(i)))) T(std::forward<T>(other._value(i)));
     }
   }
 
-  reserved_vector& operator=(reserved_vector&& other) {
+  reserved_vector& operator=(reserved_vector&& other) noexcept(
+      std::is_nothrow_move_assignable_v<T>&& std::is_nothrow_move_constructible_v<T>) {
     size_t i = 0;
     if (other.x0_size > x0_size) {
       for (; i < x0_size; ++i) {

--- a/Runtime/rstl.hpp
+++ b/Runtime/rstl.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#include <vector>
 #include <algorithm>
-#include <type_traits>
 #include <cstdlib>
 #include <optional>
-#include "logvisor/logvisor.hpp"
+#include <type_traits>
+#include <vector>
+
+#ifndef NDEBUG
+#include <logvisor/logvisor.hpp>
+#endif
 
 namespace rstl {
 

--- a/Runtime/rstl.hpp
+++ b/Runtime/rstl.hpp
@@ -229,6 +229,26 @@ protected:
  */
 template <class T, size_t N>
 class reserved_vector : public _reserved_vector_base<T> {
+  using base = _reserved_vector_base<T>;
+
+public:
+  using value_type = T;
+
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+
+  using reference = value_type&;
+  using const_reference = const value_type&;
+
+  using difference_type = std::ptrdiff_t;
+  using size_type = std::size_t;
+
+  using iterator = typename base::iterator;
+  using const_iterator = typename base::const_iterator;
+  using reverse_iterator = typename base::reverse_iterator;
+  using const_reverse_iterator = typename base::const_reverse_iterator;
+
+private:
   union alignas(T) storage_t {
     struct {
     } _dummy;
@@ -251,11 +271,6 @@ class reserved_vector : public _reserved_vector_base<T> {
   }
 
 public:
-  using base = _reserved_vector_base<T>;
-  using iterator = typename base::iterator;
-  using const_iterator = typename base::const_iterator;
-  using reverse_iterator = typename base::reverse_iterator;
-  using const_reverse_iterator = typename base::const_reverse_iterator;
   reserved_vector() : x0_size(0) {}
 
   template <size_t LN>


### PR DESCRIPTION
Makes the constructors and assignment operators for reserved_vector conditionally noexcept, allowing them to play nicely with standard facilities and avoid needing to copy construct where avoidable if said types don't have throwing constructors/assignment operators. While we're in the same area, we can make minor adjustments to the interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/100)
<!-- Reviewable:end -->
