### PR TITLE
CIntElement: Add class to handle RTOI int elements

### DIFF
--- a/Runtime/Particle/CIntElement.cpp
+++ b/Runtime/Particle/CIntElement.cpp
@@ -284,4 +284,20 @@ int CIESubtract::GetMaxValue() const {
   return a - b;
 }
 
+bool CIERealToInt::GetValue(int frame, int& valOut) const {
+  float a = 0.0f;
+  float b = 1.0f;
+
+  x8_b->GetValue(frame, b);
+  x4_a->GetValue(frame, a);
+
+  valOut = static_cast<int>(a * b);
+  return false;
+}
+
+int CIERealToInt::GetMaxValue() const {
+  // TODO: Implement
+  return 1;
+}
+
 } // namespace urde

--- a/Runtime/Particle/CIntElement.hpp
+++ b/Runtime/Particle/CIntElement.hpp
@@ -206,4 +206,16 @@ public:
   int GetMaxValue() const override;
 };
 
+class CIERealToInt final : public CIntElement {
+  std::unique_ptr<CRealElement> x4_a;
+  std::unique_ptr<CRealElement> x8_b;
+
+public:
+  explicit CIERealToInt(std::unique_ptr<CRealElement>&& a, std::unique_ptr<CRealElement>&& b)
+  : x4_a{std::move(a)}, x8_b{std::move(b)} {}
+
+  bool GetValue(int frame, int& valOut) const override;
+  int GetMaxValue() const override;
+};
+
 } // namespace urde

--- a/Runtime/Particle/CParticleDataFactory.cpp
+++ b/Runtime/Particle/CParticleDataFactory.cpp
@@ -666,6 +666,11 @@ std::unique_ptr<CIntElement> CParticleDataFactory::GetIntElement(CInputStream& i
     auto b = GetIntElement(in);
     return std::make_unique<CIERandom>(std::move(a), std::move(b));
   }
+  case SBIG('RTOI'): {
+    auto a = GetRealElement(in);
+    auto b = GetRealElement(in);
+    return std::make_unique<CIERealToInt>(std::move(a), std::move(b));
+  }
   case SBIG('TSCL'): {
     auto a = GetRealElement(in);
     return std::make_unique<CIETimeScale>(std::move(a));


### PR DESCRIPTION
Within the int element handling code, there seems to be a missing implementation (with the FourCC 'RTOI'), which seems to take two 32-bit floating point values, multiplies them, then converts the result to a 32-bit integer.

I've implemented the behavior that the executable performs, though I'm not sure how I'd derive the value to return within `GetMaxValue()`, since this seems to be an urde-specific addition to the vtables (as far as I can tell), and there's no documentation on what it's supposed to do in particular. I don't even think Metroid Prime makes use of the RTOI element (unless I missed it somewhere in a particle script file). Nevertheless, the handling *is* in the executable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/102)
<!-- Reviewable:end -->
