### PR TITLE
CUVElement: Provide initial value for cv in GetValueUV()

### DIFF
--- a/Runtime/Particle/CUVElement.cpp
+++ b/Runtime/Particle/CUVElement.cpp
@@ -42,7 +42,7 @@ CUVEAnimTexture::CUVEAnimTexture(TToken<CTexture>&& tex, std::unique_ptr<CIntEle
 }
 
 void CUVEAnimTexture::GetValueUV(int frame, SUVElementSet& valOut) const {
-  int cv;
+  int cv = 1;
   x28_cycleFrames->GetValue(frame, cv);
   float cvf = float(cv) / float(x20_tiles);
   cvf = float(frame) / cvf;

--- a/Runtime/Particle/CUVElement.cpp
+++ b/Runtime/Particle/CUVElement.cpp
@@ -14,21 +14,29 @@ CUVEAnimTexture::CUVEAnimTexture(TToken<CTexture>&& tex, std::unique_ptr<CIntEle
   strideW->GetValue(0, x18_strideW);
   strideH->GetValue(0, x1c_strideH);
 
-  int width = x4_tex.GetObj()->GetWidth();
-  int height = x4_tex.GetObj()->GetHeight();
-  float widthF = width;
-  float heightF = height;
-  int xTiles = std::max(1, width / x18_strideW);
-  int yTiles = std::max(1, height / x1c_strideH);
+  const int width = int(x4_tex.GetObj()->GetWidth());
+  const int height = int(x4_tex.GetObj()->GetHeight());
+  const float widthF = float(width);
+  const float heightF = float(height);
+  const int xTiles = std::max(1, width / x18_strideW);
+  const int yTiles = std::max(1, height / x1c_strideH);
+
   x20_tiles = xTiles * yTiles;
   x2c_uvElems.reserve(x20_tiles);
+
   for (int y = yTiles - 1; y >= 0; --y) {
     for (int x = 0; x < xTiles; ++x) {
-      int px = x18_strideW * x;
-      int px2 = px + x10_tileW;
-      int py = x1c_strideH * y;
-      int py2 = py + x14_tileH;
-      x2c_uvElems.push_back({px / widthF, py / heightF, px2 / widthF, py2 / heightF});
+      const int px = x18_strideW * x;
+      const int px2 = px + x10_tileW;
+      const int py = x1c_strideH * y;
+      const int py2 = py + x14_tileH;
+
+      x2c_uvElems.push_back({
+          float(px) / widthF,
+          float(py) / heightF,
+          float(px2) / widthF,
+          float(py2) / heightF,
+      });
     }
   }
 }
@@ -36,16 +44,18 @@ CUVEAnimTexture::CUVEAnimTexture(TToken<CTexture>&& tex, std::unique_ptr<CIntEle
 void CUVEAnimTexture::GetValueUV(int frame, SUVElementSet& valOut) const {
   int cv;
   x28_cycleFrames->GetValue(frame, cv);
-  float cvf = cv / float(x20_tiles);
-  cvf = frame / cvf;
+  float cvf = float(cv) / float(x20_tiles);
+  cvf = float(frame) / cvf;
 
-  int tile = cvf;
+  int tile = int(cvf);
   if (x24_loop) {
-    if (cvf >= x20_tiles)
+    if (cvf >= float(x20_tiles)) {
       tile = int(cvf) % x20_tiles;
+    }
   } else {
-    if (cvf >= x20_tiles)
+    if (cvf >= float(x20_tiles)) {
       tile = x20_tiles - 1;
+    }
   }
 
   valOut = x2c_uvElems[tile];


### PR DESCRIPTION
The game executable initializes the variable being passed into `GetValue()` to `1` before the call. This is likely to ensure that the value is always sane in the event the CIntElement instance doesn't assign anything to the out reference. We can do the same here as well to maintain that guarantee.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/104)
<!-- Reviewable:end -->
