### PR TITLE
CCollisionPrimitive: Minor cleanup

### DIFF
--- a/Runtime/Collision/CCollidableAABox.cpp
+++ b/Runtime/Collision/CCollidableAABox.cpp
@@ -8,7 +8,7 @@ namespace urde {
 const CCollisionPrimitive::Type CCollidableAABox::sType(CCollidableAABox::SetStaticTableIndex, "CCollidableAABox");
 u32 CCollidableAABox::sTableIndex = -1;
 
-CCollidableAABox::CCollidableAABox() {}
+CCollidableAABox::CCollidableAABox() = default;
 
 CCollidableAABox::CCollidableAABox(const zeus::CAABox& aabox, const CMaterialList& list)
 : CCollisionPrimitive(list), x10_aabox(aabox) {}

--- a/Runtime/Collision/CCollisionPrimitive.hpp
+++ b/Runtime/Collision/CCollisionPrimitive.hpp
@@ -137,7 +137,7 @@ public:
   virtual zeus::CAABox CalculateAABox(const zeus::CTransform&) const = 0;
   virtual zeus::CAABox CalculateLocalAABox() const = 0;
   virtual FourCC GetPrimType() const = 0;
-  virtual ~CCollisionPrimitive() {}
+  virtual ~CCollisionPrimitive() = default;
   virtual CRayCastResult CastRayInternal(const CInternalRayCastStructure&) const = 0;
   CRayCastResult CastRay(const zeus::CVector3f& start, const zeus::CVector3f& dir, float length,
                          const CMaterialFilter& filter, const zeus::CTransform& xf) const;

--- a/Runtime/Collision/CCollisionPrimitive.hpp
+++ b/Runtime/Collision/CCollisionPrimitive.hpp
@@ -44,11 +44,12 @@ class COBBTree;
 class CCollisionInfo;
 class CCollisionInfoList;
 class CInternalRayCastStructure;
-typedef bool (*ComparisonFunc)(const CInternalCollisionStructure&, CCollisionInfoList&);
-typedef bool (*MovingComparisonFunc)(const CInternalCollisionStructure&, const zeus::CVector3f&, double&,
-                                     CCollisionInfo&);
-typedef bool (*BooleanComparisonFunc)(const CInternalCollisionStructure&);
-typedef void (*PrimitiveSetter)(u32);
+
+using BooleanComparisonFunc = bool (*)(const CInternalCollisionStructure&);
+using ComparisonFunc = bool (*)(const CInternalCollisionStructure&, CCollisionInfoList&);
+using MovingComparisonFunc = bool (*)(const CInternalCollisionStructure&, const zeus::CVector3f&, double&,
+                                      CCollisionInfo&);
+using PrimitiveSetter = void (*)(u32);
 
 class CCollisionPrimitive {
 public:


### PR DESCRIPTION
No behavioral changes. Just converts four typedefs into using aliases and defaults the virtual destructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/105)
<!-- Reviewable:end -->
