### PR TITLE
CCollisionPrimitive: Simplify the InitAdd* member functions

### DIFF
--- a/Runtime/Collision/CCollisionPrimitive.hpp
+++ b/Runtime/Collision/CCollisionPrimitive.hpp
@@ -122,6 +122,10 @@ private:
   static BooleanComparisonFunc sNullBooleanCollider;
   static MovingComparisonFunc sNullMovingCollider;
 
+  // Attempts to locate an entry within the collision type list that matches the supplied name.
+  // Returns the end iterator in the event of no matches.
+  static std::vector<Type>::const_iterator FindCollisionType(const char* name);
+
   static bool InternalCollide(const CInternalCollisionStructure& collision, CCollisionInfoList& list);
   static bool InternalCollideBoolean(const CInternalCollisionStructure& collision);
   static bool InternalCollideMoving(const CInternalCollisionStructure& collision, const zeus::CVector3f& dir,


### PR DESCRIPTION
We can extract the duplicated behavior out into its own member function and then reuse it in order to deduplicate repeated behavior, making for nicer reading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/106)
<!-- Reviewable:end -->
