### PR TITLE
CBallCamera: Use bool instead of float for holding boolean value

### DIFF
--- a/Runtime/Camera/CBallCamera.cpp
+++ b/Runtime/Camera/CBallCamera.cpp
@@ -1750,7 +1750,8 @@ bool CBallCamera::DetectCollision(const zeus::CVector3f& from, const zeus::CVect
   zeus::CVector3f delta = to - from;
   float deltaMag = delta.magnitude();
   zeus::CVector3f deltaNorm = delta * (1.f / deltaMag);
-  float clear = true;
+  bool clear = true;
+
   if (deltaMag > 0.000001f) {
     float margin = 2.f * radius;
     zeus::CAABox aabb;


### PR DESCRIPTION
Using a float is very suspect and also more expensive in terms of code-gen to access and modify the variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/107)
<!-- Reviewable:end -->
