### PR TITLE
CAutoMapper: Collapse case statements in ProcessMapZoomInput()

### DIFF
--- a/Runtime/AutoMapper/CAutoMapper.cpp
+++ b/Runtime/AutoMapper/CAutoMapper.cpp
@@ -615,31 +615,25 @@ void CAutoMapper::ProcessMapZoomInput(const CFinalInput& input, const CStateMana
     }
   }
 
-  EZoomState nextZoomState = EZoomState::None;
-  switch (x324_zoomState) {
-  case EZoomState::None:
-    if (in)
-      nextZoomState = EZoomState::In;
-    else if (out)
-      nextZoomState = EZoomState::Out;
-    break;
-  case EZoomState::In:
-    if (in)
-      nextZoomState = EZoomState::In;
-    else if (out)
-      nextZoomState = EZoomState::Out;
-    break;
-  case EZoomState::Out:
-    if (in)
-      nextZoomState = EZoomState::In;
-    else if (out)
-      nextZoomState = EZoomState::Out;
-    break;
-  default:
-    break;
-  }
+  const EZoomState nextZoomState = [this, in, out] {
+        switch (x324_zoomState) {
+        case EZoomState::None:
+        case EZoomState::In:
+        case EZoomState::Out:
+          if (in) {
+            return EZoomState::In;
+          }
+          if (out) {
+            return EZoomState::Out;
+          }
+          return EZoomState::None;
 
+        default:
+          return EZoomState::None;
+        }
+  }();
   x324_zoomState = nextZoomState;
+
   float delta = input.DeltaTime() * 60.f * (x1bc_state == EAutoMapperState::MapScreen ? 1.f : 4.f) *
                 g_tweakAutoMapper->GetCamZoomUnitsPerFrame() * zoomSpeed;
   float oldDist = xa8_renderStates[0].x18_camDist;


### PR DESCRIPTION
Same behavior as the game executable, but without the code duplication per case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/108)
<!-- Reviewable:end -->
