### PR TITLE
CGunWeapon: Minor changes

### DIFF
--- a/Runtime/Weapon/CGunWeapon.cpp
+++ b/Runtime/Weapon/CGunWeapon.cpp
@@ -1,12 +1,13 @@
-#include "CGunWeapon.hpp"
-#include "GameGlobalObjects.hpp"
-#include "CSimplePool.hpp"
-#include "CDependencyGroup.hpp"
-#include "CGameState.hpp"
-#include "CWeapon.hpp"
-#include "CEnergyProjectile.hpp"
-#include "Graphics/CSkinnedModel.hpp"
-#include "Graphics/CVertexMorphEffect.hpp"
+#include "Runtime/Weapon/CGunWeapon.hpp"
+
+#include "Runtime/CDependencyGroup.hpp"
+#include "Runtime/CGameState.hpp"
+#include "Runtime/CSimplePool.hpp"
+#include "Runtime/GameGlobalObjects.hpp"
+#include "Runtime/Graphics/CSkinnedModel.hpp"
+#include "Runtime/Graphics/CVertexMorphEffect.hpp"
+#include "Runtime/Weapon/CEnergyProjectile.hpp"
+#include "Runtime/Weapon/CWeapon.hpp"
 
 namespace urde {
 static const char* skBeamXferNames[] = {"PowerXfer", "IceXfer", "WaveXfer", "PlasmaXfer", "PhazonXfer"};

--- a/Runtime/Weapon/CGunWeapon.cpp
+++ b/Runtime/Weapon/CGunWeapon.cpp
@@ -298,14 +298,14 @@ void CGunWeapon::Draw(bool drawSuitArm, const CStateManager& mgr, const zeus::CT
 }
 
 void CGunWeapon::DrawMuzzleFx(const CStateManager& mgr) const {
-  if (const CElementGen* effect = x1a4_muzzleGenerators[x208_muzzleEffectIdx].get()) {
+  if (CElementGen* const effect = x1a4_muzzleGenerators[x208_muzzleEffectIdx].get()) {
     if (x200_beamId != CPlayerState::EBeamId::Ice &&
         mgr.GetPlayerState()->GetActiveVisor(mgr) == CPlayerState::EPlayerVisor::XRay) {
       CElementGen::SetSubtractBlend(true);
-      const_cast<CElementGen*>(effect)->Render();
+      effect->Render();
       CElementGen::SetSubtractBlend(false);
     } else {
-      const_cast<CElementGen*>(effect)->Render();
+      effect->Render();
     }
   }
 }

--- a/Runtime/Weapon/CGunWeapon.hpp
+++ b/Runtime/Weapon/CGunWeapon.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <memory>
 #include <vector>
 
@@ -54,7 +55,7 @@ public:
   enum class EFrozenFxType { None, Frozen, Thawed };
 
 protected:
-  static const s32 skShootAnim[2];
+  static const std::array<s32, 2> skShootAnim;
   zeus::CVector3f x4_scale;
   std::optional<CModelData> x10_solidModelData;
   std::optional<CModelData> x60_holoModelData;

--- a/Runtime/Weapon/CWaveBeam.cpp
+++ b/Runtime/Weapon/CWaveBeam.cpp
@@ -1,9 +1,20 @@
-#include "CWaveBeam.hpp"
-#include "GameGlobalObjects.hpp"
-#include "CSimplePool.hpp"
-#include "CEnergyProjectile.hpp"
+#include "Runtime/Weapon/CWaveBeam.hpp"
+
+#include <array>
+
+#include "Runtime/CSimplePool.hpp"
+#include "Runtime/GameGlobalObjects.hpp"
+#include "Runtime/Weapon/CEnergyProjectile.hpp"
 
 namespace urde {
+namespace {
+constexpr float skShotAnglePitch = 120.f;
+
+constexpr std::array<u16, 2> kSoundId{
+    SFXwpn_fire_wave_normal,
+    SFXwpn_fire_wave_charged,
+};
+} // Anonymous namespace
 
 CWaveBeam::CWaveBeam(CAssetId characterId, EWeaponType type, TUniqueId playerId, EMaterialTypes playerMaterial,
                      const zeus::CVector3f& scale)
@@ -50,9 +61,6 @@ void CWaveBeam::UpdateGunFx(bool shotSmoke, float dt, const CStateManager& mgr, 
   CGunWeapon::UpdateGunFx(shotSmoke, dt, mgr, xf);
 }
 
-static const float skShotAnglePitch = 120.f;
-static const u16 kSoundId[] = {SFXwpn_fire_wave_normal, SFXwpn_fire_wave_charged};
-
 void CWaveBeam::Fire(bool underwater, float dt, EChargeState chargeState, const zeus::CTransform& xf,
                      CStateManager& mgr, TUniqueId homingTarget, float chargeFactor1, float chargeFactor2) {
   if (chargeState == EChargeState::Charged) {
@@ -74,8 +82,8 @@ void CWaveBeam::Fire(bool underwater, float dt, EChargeState chargeState, const 
   if (chargeState == EChargeState::Charged)
     x218_25_enableCharge = true;
 
-  NWeaponTypes::play_sfx(kSoundId[int(chargeState)], underwater, false, 0.165f);
-  CAnimPlaybackParms parms(skShootAnim[int(chargeState)], -1, 1.f, true);
+  NWeaponTypes::play_sfx(kSoundId[size_t(chargeState)], underwater, false, 0.165f);
+  const CAnimPlaybackParms parms(skShootAnim[size_t(chargeState)], -1, 1.f, true);
   x10_solidModelData->GetAnimationData()->EnableLooping(false);
   x10_solidModelData->GetAnimationData()->SetAnimation(parms, false);
 }


### PR DESCRIPTION
Makes use of std::array where applicable, making the types impervious to implicit pointer decay and also making it trivial to eliminate hardcoded loop constants, instead querying the container sizes. This also ensures that the string arrays always end up in read-only memory (given they were still technically mutable).

We can also make a few minor other changes while we're in the same area.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/111)
<!-- Reviewable:end -->
