### PR TITLE
CAnimData: Remove usage of const_cast within Touch()

### DIFF
--- a/Runtime/Character/CAnimData.cpp
+++ b/Runtime/Character/CAnimData.cpp
@@ -250,7 +250,7 @@ std::shared_ptr<CAnimationManager> CAnimData::GetAnimationManager() { return x10
 void CAnimData::SetPhase(float ph) { x1f8_animRoot->VSetPhase(ph); }
 
 void CAnimData::Touch(const CSkinnedModel& model, int shadIdx) const {
-  const_cast<CBooModel&>(*model.GetModelInst()).Touch(shadIdx);
+  model.GetModelInst()->Touch(shadIdx);
 }
 
 SAdvancementDeltas CAnimData::GetAdvancementDeltas(const CCharAnimTime& a, const CCharAnimTime& b) const {


### PR DESCRIPTION
We can just call the function normally without the need for a const_cast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/115)
<!-- Reviewable:end -->
