### PR TITLE
CParticleGenInfo: Use slightly more full names for parameters where applicable

### DIFF
--- a/Runtime/Character/CParticleGenInfo.cpp
+++ b/Runtime/Character/CParticleGenInfo.cpp
@@ -102,13 +102,14 @@ void CParticleGenInfoGeneric::SetGlobalTranslation(const zeus::CVector3f& trans,
 
 void CParticleGenInfoGeneric::SetGlobalScale(const zeus::CVector3f& scale) { x84_system->SetGlobalScale(scale); }
 
-void CParticleGenInfoGeneric::SetParticleEmission(bool emission, CStateManager& stateMgr) {
-  x84_system->SetParticleEmission(emission);
+void CParticleGenInfoGeneric::SetParticleEmission(bool isActive, CStateManager& stateMgr) {
+  x84_system->SetParticleEmission(isActive);
 
   TCastToPtr<CGameLight> gl(stateMgr.ObjectById(x88_lightId));
 
-  if (gl)
-    gl->SetActive(emission);
+  if (gl) {
+    gl->SetActive(isActive);
+  }
 }
 
 bool CParticleGenInfoGeneric::IsSystemDeletable() const { return x84_system->IsSystemDeletable(); }

--- a/Runtime/Character/CParticleGenInfo.hpp
+++ b/Runtime/Character/CParticleGenInfo.hpp
@@ -54,12 +54,12 @@ public:
   virtual void DeleteLight(CStateManager& stateMgr) = 0;
   virtual void SetModulationColor(const zeus::CColor& color) = 0;
 
-  void SetFlags(s32 f) { x2c_flags = f; }
+  void SetFlags(s32 flags) { x2c_flags = flags; }
   s32 GetFlags() const { return x2c_flags; }
-  void SetIsGrabInitialData(bool g) { x40_grabInitialData = g; }
+  void SetIsGrabInitialData(bool grabInitialData) { x40_grabInitialData = grabInitialData; }
   bool GetIsGrabInitialData() const { return x40_grabInitialData; }
   bool GetIsActive() const { return x24_active; }
-  void SetIsActive(bool a) { x24_active = a; }
+  void SetIsActive(bool isActive) { x24_active = isActive; }
   void OffsetTime(float dt) { x20_curTime += dt; }
   const zeus::CVector3f& GetCurOffset() const { return x74_offset; }
   void SetCurOffset(const zeus::CVector3f& offset) { x74_offset = offset; }
@@ -67,12 +67,12 @@ public:
   void SetCurTransform(const zeus::CTransform& xf) { x44_transform = xf; }
   const zeus::CVector3f& GetCurScale() const { return x30_particleScale; }
   void SetCurScale(const zeus::CVector3f& scale) { x30_particleScale = scale; }
-  void SetInactiveStartTime(float s) { xc_seconds = s; }
+  void SetInactiveStartTime(float seconds) { xc_seconds = seconds; }
   float GetInactiveStartTime() const { return xc_seconds; }
   void MarkFinishTime() { x3c_finishTime = x20_curTime; }
   float GetFinishTime() const { return x3c_finishTime; }
   float GetCurrentTime() const { return x20_curTime; }
-  void SetCurrentTime(float t) { x20_curTime = t; }
+  void SetCurrentTime(float time) { x20_curTime = time; }
   EParticleGenType GetType() const { return x80_type; }
 
   CParticleData::EParentedMode GetParentedMode() const { return x28_parentMode; }
@@ -86,7 +86,7 @@ class CParticleGenInfoGeneric : public CParticleGenInfo {
 public:
   CParticleGenInfoGeneric(const SObjectTag& part, const std::weak_ptr<CParticleGen>& system, int frames,
                           std::string_view boneName, const zeus::CVector3f& scale,
-                          CParticleData::EParentedMode parentMode, int flags, CStateManager& stateMgr, TAreaId,
+                          CParticleData::EParentedMode parentMode, int flags, CStateManager& stateMgr, TAreaId areaId,
                           int lightId, EParticleGenType state);
 
   void AddToRenderer() override;

--- a/Runtime/Character/CParticleGenInfo.hpp
+++ b/Runtime/Character/CParticleGenInfo.hpp
@@ -44,7 +44,7 @@ public:
   virtual void SetGlobalOrientation(const zeus::CTransform& xf, CStateManager& stateMgr) = 0;
   virtual void SetGlobalTranslation(const zeus::CVector3f& trans, CStateManager& stateMgr) = 0;
   virtual void SetGlobalScale(const zeus::CVector3f& scale) = 0;
-  virtual void SetParticleEmission(bool, CStateManager& stateMgr) = 0;
+  virtual void SetParticleEmission(bool isActive, CStateManager& stateMgr) = 0;
   virtual bool IsSystemDeletable() const = 0;
   virtual std::optional<zeus::CAABox> GetBounds() const = 0;
   virtual bool HasActiveParticles() const = 0;
@@ -97,7 +97,7 @@ public:
   void SetGlobalOrientation(const zeus::CTransform& xf, CStateManager& stateMgr) override;
   void SetGlobalTranslation(const zeus::CVector3f& trans, CStateManager& stateMgr) override;
   void SetGlobalScale(const zeus::CVector3f& scale) override;
-  void SetParticleEmission(bool, CStateManager& stateMgr) override;
+  void SetParticleEmission(bool isActive, CStateManager& stateMgr) override;
   bool IsSystemDeletable() const override;
   std::optional<zeus::CAABox> GetBounds() const override;
   bool HasActiveParticles() const override;


### PR DESCRIPTION
Allows Intellisense and any other function prototype highlighting features of IDEs to be a little more informative.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/116)
<!-- Reviewable:end -->
