### PR TITLE
CollisionPrimitive: Make collision primitive types constexpr capable

### DIFF
--- a/Runtime/Collision/CCollidableAABox.cpp
+++ b/Runtime/Collision/CCollidableAABox.cpp
@@ -5,7 +5,7 @@
 #include "CInternalRayCastStructure.hpp"
 
 namespace urde {
-const CCollisionPrimitive::Type CCollidableAABox::sType(CCollidableAABox::SetStaticTableIndex, "CCollidableAABox");
+constexpr CCollisionPrimitive::Type sType(CCollidableAABox::SetStaticTableIndex, "CCollidableAABox");
 u32 CCollidableAABox::sTableIndex = -1;
 
 CCollidableAABox::CCollidableAABox() = default;

--- a/Runtime/Collision/CCollidableAABox.hpp
+++ b/Runtime/Collision/CCollidableAABox.hpp
@@ -12,7 +12,6 @@ bool AABox_AABox_Bool(const CInternalCollisionStructure&);
 } // namespace Collide
 
 class CCollidableAABox : public CCollisionPrimitive {
-  static const Type sType;
   static u32 sTableIndex;
 
   zeus::CAABox x10_aabox;

--- a/Runtime/Collision/CCollidableCollisionSurface.cpp
+++ b/Runtime/Collision/CCollidableCollisionSurface.cpp
@@ -1,8 +1,8 @@
 #include "CCollidableCollisionSurface.hpp"
 
 namespace urde {
-const CCollisionPrimitive::Type CCollidableCollisionSurface::sType(CCollidableCollisionSurface::SetStaticTableIndex,
-                                                                   "CCollidableCollisionSurface");
+constexpr CCollisionPrimitive::Type sType(CCollidableCollisionSurface::SetStaticTableIndex,
+                                          "CCollidableCollisionSurface");
 u32 CCollidableCollisionSurface::sTableIndex = -1;
 
 const CCollisionPrimitive::Type& CCollidableCollisionSurface::GetType() { return sType; }

--- a/Runtime/Collision/CCollidableCollisionSurface.hpp
+++ b/Runtime/Collision/CCollidableCollisionSurface.hpp
@@ -5,7 +5,6 @@
 
 namespace urde {
 class CCollidableCollisionSurface {
-  static const CCollisionPrimitive::Type sType;
   static u32 sTableIndex;
 
 public:

--- a/Runtime/Collision/CCollidableOBBTreeGroup.cpp
+++ b/Runtime/Collision/CCollidableOBBTreeGroup.cpp
@@ -7,8 +7,7 @@
 #include "CToken.hpp"
 
 namespace urde {
-const CCollisionPrimitive::Type CCollidableOBBTreeGroup::sType(CCollidableOBBTreeGroup::SetStaticTableIndex,
-                                                               "CCollidableOBBTreeGroup");
+constexpr CCollisionPrimitive::Type sType(CCollidableOBBTreeGroup::SetStaticTableIndex, "CCollidableOBBTreeGroup");
 u32 CCollidableOBBTreeGroup::sTableIndex = -1;
 
 CCollidableOBBTreeGroupContainer::CCollidableOBBTreeGroupContainer(CInputStream& in) {

--- a/Runtime/Collision/CCollidableOBBTreeGroup.hpp
+++ b/Runtime/Collision/CCollidableOBBTreeGroup.hpp
@@ -24,7 +24,6 @@ public:
 };
 
 class CCollidableOBBTreeGroup : public CCollisionPrimitive {
-  static const Type sType;
   static u32 sTableIndex;
   const CCollidableOBBTreeGroupContainer* x10_container;
 

--- a/Runtime/Collision/CCollidableSphere.cpp
+++ b/Runtime/Collision/CCollidableSphere.cpp
@@ -5,7 +5,7 @@
 #include "CInternalRayCastStructure.hpp"
 
 namespace urde {
-const CCollisionPrimitive::Type CCollidableSphere::sType(CCollidableSphere::SetStaticTableIndex, "CCollidableSphere");
+constexpr CCollisionPrimitive::Type sType(CCollidableSphere::SetStaticTableIndex, "CCollidableSphere");
 u32 CCollidableSphere::sTableIndex = -1;
 
 namespace Collide {
@@ -223,6 +223,8 @@ CRayCastResult CCollidableSphere::CastRayInternal(const CInternalRayCastStructur
 
   return {};
 }
+
+const CCollisionPrimitive::Type& CCollidableSphere::GetType() { return sType; }
 
 bool CCollidableSphere::CollideMovingAABox(const CInternalCollisionStructure& collision, const zeus::CVector3f& dir,
                                            double& dOut, CCollisionInfo& infoOut) {

--- a/Runtime/Collision/CCollidableSphere.hpp
+++ b/Runtime/Collision/CCollidableSphere.hpp
@@ -12,8 +12,8 @@ bool Sphere_AABox_Bool(const CInternalCollisionStructure&);
 bool Sphere_Sphere(const CInternalCollisionStructure&, CCollisionInfoList&);
 bool Sphere_Sphere_Bool(const CInternalCollisionStructure&);
 } // namespace Collide
+
 class CCollidableSphere : public CCollisionPrimitive {
-  static const Type sType;
   static u32 sTableIndex;
 
   zeus::CSphere x10_sphere;
@@ -31,7 +31,7 @@ public:
   FourCC GetPrimType() const override;
   CRayCastResult CastRayInternal(const CInternalRayCastStructure&) const override;
 
-  static const Type& GetType() { return sType; }
+  static const Type& GetType();
   static void SetStaticTableIndex(u32 index) { sTableIndex = index; }
   static bool CollideMovingAABox(const CInternalCollisionStructure&, const zeus::CVector3f&, double&, CCollisionInfo&);
   static bool CollideMovingSphere(const CInternalCollisionStructure&, const zeus::CVector3f&, double&, CCollisionInfo&);

--- a/Runtime/Collision/CCollisionPrimitive.hpp
+++ b/Runtime/Collision/CCollisionPrimitive.hpp
@@ -54,15 +54,15 @@ using PrimitiveSetter = void (*)(u32);
 class CCollisionPrimitive {
 public:
   class Type {
-    PrimitiveSetter x0_setter;
-    const char* x4_info;
+    PrimitiveSetter x0_setter = nullptr;
+    const char* x4_info = nullptr;
 
   public:
-    Type() = default;
-    Type(PrimitiveSetter setter, const char* info) : x0_setter(setter), x4_info(info) {}
+    constexpr Type() noexcept = default;
+    constexpr Type(PrimitiveSetter setter, const char* info) noexcept : x0_setter(setter), x4_info(info) {}
 
-    const char* GetInfo() const { return x4_info; }
-    PrimitiveSetter GetSetter() const { return x0_setter; }
+    constexpr const char* GetInfo() const noexcept { return x4_info; }
+    constexpr PrimitiveSetter GetSetter() const noexcept { return x0_setter; }
   };
 
   class Comparison {
@@ -71,12 +71,12 @@ public:
     const char* x8_type2;
 
   public:
-    Comparison(ComparisonFunc collider, const char* type1, const char* type2)
+    constexpr Comparison(ComparisonFunc collider, const char* type1, const char* type2) noexcept
     : x0_collider(collider), x4_type1(type1), x8_type2(type2) {}
 
-    ComparisonFunc GetCollider() const { return x0_collider; }
-    const char* GetType1() const { return x4_type1; }
-    const char* GetType2() const { return x8_type2; }
+    constexpr ComparisonFunc GetCollider() const noexcept { return x0_collider; }
+    constexpr const char* GetType1() const noexcept { return x4_type1; }
+    constexpr const char* GetType2() const noexcept { return x8_type2; }
   };
 
   class MovingComparison {
@@ -85,12 +85,12 @@ public:
     const char* x8_type2;
 
   public:
-    MovingComparison(MovingComparisonFunc collider, const char* type1, const char* type2)
+    constexpr MovingComparison(MovingComparisonFunc collider, const char* type1, const char* type2) noexcept
     : x0_collider(collider), x4_type1(type1), x8_type2(type2) {}
 
-    MovingComparisonFunc GetCollider() const { return x0_collider; }
-    const char* GetType1() const { return x4_type1; }
-    const char* GetType2() const { return x8_type2; }
+    constexpr MovingComparisonFunc GetCollider() const noexcept { return x0_collider; }
+    constexpr const char* GetType1() const noexcept { return x4_type1; }
+    constexpr const char* GetType2() const noexcept { return x8_type2; }
   };
 
   class BooleanComparison {
@@ -99,12 +99,12 @@ public:
     const char* x8_type2;
 
   public:
-    BooleanComparison(BooleanComparisonFunc collider, const char* type1, const char* type2)
+    constexpr BooleanComparison(BooleanComparisonFunc collider, const char* type1, const char* type2) noexcept
     : x0_collider(collider), x4_type1(type1), x8_type2(type2) {}
 
-    BooleanComparisonFunc GetCollider() const { return x0_collider; }
-    const char* GetType1() const { return x4_type1; }
-    const char* GetType2() const { return x8_type2; }
+    constexpr BooleanComparisonFunc GetCollider() const noexcept { return x0_collider; }
+    constexpr const char* GetType1() const noexcept { return x4_type1; }
+    constexpr const char* GetType2() const noexcept { return x8_type2; }
   };
 
 private:


### PR DESCRIPTION
We can make these constexpr capable, given they only store primitives and a pointer to a function. This eliminates some static constructors, since the constructors can be elided at compile-time now.

This also completely hides the Type instances from other code, fully making them implementation details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/119)
<!-- Reviewable:end -->
