### PR TITLE
CPatterned: Mark CMaterialList instance in CollidedWith as constexpr

### DIFF
--- a/Runtime/World/CPatterned.cpp
+++ b/Runtime/World/CPatterned.cpp
@@ -357,8 +357,8 @@ void CPatterned::CollidedWith(TUniqueId other, const CCollisionInfoList& list, C
       }
     }
   }
-  static CMaterialList testList(EMaterialTypes::Solid, EMaterialTypes::Ceiling, EMaterialTypes::Wall,
-                                EMaterialTypes::Floor, EMaterialTypes::Character);
+  static constexpr CMaterialList testList(EMaterialTypes::Solid, EMaterialTypes::Ceiling, EMaterialTypes::Wall,
+                                          EMaterialTypes::Floor, EMaterialTypes::Character);
   for (const CCollisionInfo& info : list) {
     if (info.GetMaterialLeft().Intersection(testList)) {
       if (!info.GetMaterialLeft().HasMaterial(EMaterialTypes::Floor)) {


### PR DESCRIPTION
This isn't ever modified, so we can mark it constexpr to eliminate potential runtime initializers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/125)
<!-- Reviewable:end -->
