### PR TITLE
CCameraManager:: Resolve signed/unsigned mismatch within RemoveCameraShaker()

### DIFF
--- a/Runtime/Camera/CCameraManager.cpp
+++ b/Runtime/Camera/CCameraManager.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/Camera/CCameraManager.hpp"
 
+#include <algorithm>
+
 #include "Runtime/CStateManager.hpp"
 #include "Runtime/GameGlobalObjects.hpp"
 #include "Runtime/Camera/CBallCamera.hpp"
@@ -38,11 +40,12 @@ zeus::CTransform CCameraManager::GetCurrentCameraTransform(const CStateManager& 
 }
 
 void CCameraManager::RemoveCameraShaker(u32 id) {
-  for (auto it = x14_shakers.begin(); it != x14_shakers.end(); ++it)
-    if (it->xbc_shakerId == id) {
-      x14_shakers.erase(it);
-      break;
-    }
+  const auto iter = std::find_if(x14_shakers.cbegin(), x14_shakers.cend(),
+                                 [id](const auto& shaker) { return shaker.xbc_shakerId == id; });
+  if (iter == x14_shakers.cend()) {
+    return;
+  }
+  x14_shakers.erase(iter);
 }
 
 int CCameraManager::AddCameraShaker(const CCameraShakeData& data, bool sfx) {

--- a/Runtime/Camera/CCameraManager.cpp
+++ b/Runtime/Camera/CCameraManager.cpp
@@ -37,7 +37,7 @@ zeus::CTransform CCameraManager::GetCurrentCameraTransform(const CStateManager& 
   return camera->GetTransform() * zeus::CTransform::Translate(x30_shakeOffset);
 }
 
-void CCameraManager::RemoveCameraShaker(int id) {
+void CCameraManager::RemoveCameraShaker(u32 id) {
   for (auto it = x14_shakers.begin(); it != x14_shakers.end(); ++it)
     if (it->xbc_shakerId == id) {
       x14_shakers.erase(it);

--- a/Runtime/Camera/CCameraManager.hpp
+++ b/Runtime/Camera/CCameraManager.hpp
@@ -94,7 +94,7 @@ public:
   bool IsInFirstPersonCamera() const;
   zeus::CVector3f GetGlobalCameraTranslation(const CStateManager& stateMgr) const;
   zeus::CTransform GetCurrentCameraTransform(const CStateManager& stateMgr) const;
-  void RemoveCameraShaker(int id);
+  void RemoveCameraShaker(u32 id);
   int AddCameraShaker(const CCameraShakeData& data, bool sfx);
   void AddCinemaCamera(TUniqueId, CStateManager& stateMgr);
   void RemoveCinemaCamera(TUniqueId, CStateManager&);


### PR DESCRIPTION
An unsigned value is passed into RemoveCameraShaker at its only usage spot. This also resolves unsigned/signed comparisons within the function itself. While we're in the same area, we can also collapse the manual lookup into std::find_if.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/127)
<!-- Reviewable:end -->
