### PR TITLE
CWeaponMode: Make constexpr capable

### DIFF
--- a/Runtime/Weapon/CWeaponMode.hpp
+++ b/Runtime/Weapon/CWeaponMode.hpp
@@ -10,27 +10,23 @@ class CWeaponMode {
   bool x4_26_instantKill : 1;
 
 public:
-  CWeaponMode() {
-    x4_24_charged = false;
-    x4_25_comboed = false;
-    x4_26_instantKill = false;
-  }
-  CWeaponMode(EWeaponType type, bool charged = false, bool comboed = false, bool instaKill = false)
+  constexpr CWeaponMode() : x4_24_charged{false}, x4_25_comboed{false}, x4_26_instantKill{false} {}
+  constexpr explicit CWeaponMode(EWeaponType type, bool charged = false, bool comboed = false, bool instaKill = false)
   : x0_weaponType(type), x4_24_charged(charged), x4_25_comboed(comboed), x4_26_instantKill(instaKill) {}
-  EWeaponType GetType() const { return x0_weaponType; }
+  constexpr EWeaponType GetType() const { return x0_weaponType; }
 
-  bool IsCharged() const { return x4_24_charged; }
-  bool IsComboed() const { return x4_25_comboed; }
-  bool IsInstantKill() const { return x4_26_instantKill; }
+  constexpr bool IsCharged() const { return x4_24_charged; }
+  constexpr bool IsComboed() const { return x4_25_comboed; }
+  constexpr bool IsInstantKill() const { return x4_26_instantKill; }
 
-  static CWeaponMode Invalid() { return CWeaponMode(EWeaponType::None); }
-  static CWeaponMode Phazon() { return CWeaponMode(EWeaponType::Phazon); }
-  static CWeaponMode Plasma() { return CWeaponMode(EWeaponType::Plasma); }
-  static CWeaponMode Wave() { return CWeaponMode(EWeaponType::Wave); }
-  static CWeaponMode BoostBall() { return CWeaponMode(EWeaponType::BoostBall); }
-  static CWeaponMode Ice() { return CWeaponMode(EWeaponType::Ice); }
-  static CWeaponMode Power() { return CWeaponMode(EWeaponType::Power); }
-  static CWeaponMode Bomb() { return CWeaponMode(EWeaponType::Bomb); }
-  static CWeaponMode PowerBomb() { return CWeaponMode(EWeaponType::PowerBomb); }
+  static constexpr CWeaponMode Invalid() { return CWeaponMode(EWeaponType::None); }
+  static constexpr CWeaponMode Phazon() { return CWeaponMode(EWeaponType::Phazon); }
+  static constexpr CWeaponMode Plasma() { return CWeaponMode(EWeaponType::Plasma); }
+  static constexpr CWeaponMode Wave() { return CWeaponMode(EWeaponType::Wave); }
+  static constexpr CWeaponMode BoostBall() { return CWeaponMode(EWeaponType::BoostBall); }
+  static constexpr CWeaponMode Ice() { return CWeaponMode(EWeaponType::Ice); }
+  static constexpr CWeaponMode Power() { return CWeaponMode(EWeaponType::Power); }
+  static constexpr CWeaponMode Bomb() { return CWeaponMode(EWeaponType::Bomb); }
+  static constexpr CWeaponMode PowerBomb() { return CWeaponMode(EWeaponType::PowerBomb); }
 };
 } // namespace urde

--- a/Runtime/World/CScriptTrigger.cpp
+++ b/Runtime/World/CScriptTrigger.cpp
@@ -207,7 +207,7 @@ std::optional<zeus::CAABox> CScriptTrigger::GetTouchBounds() const {
     return {GetTriggerBoundsWR()};
   return {};
 }
-static const CWeaponMode sktonOHurtWeaponMode = CWeaponMode(EWeaponType::Power, false, false, true);
+constexpr auto sktonOHurtWeaponMode = CWeaponMode(EWeaponType::Power, false, false, true);
 
 void CScriptTrigger::Touch(CActor& act, CStateManager& mgr) {
   if (!act.GetActive() || act.GetMaterialList().HasMaterial(EMaterialTypes::Trigger))


### PR DESCRIPTION
Given this is such a simple type, this can be made usable with constexpr. This allows the type to be usable at file-scope without potentially incurring a runtime constructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/128)
<!-- Reviewable:end -->
