### PR TITLE
CActor: Remove top-level const from GetScaledLocatorTransform() and GetLocatorTransform()

### DIFF
--- a/Runtime/World/CActor.cpp
+++ b/Runtime/World/CActor.cpp
@@ -343,11 +343,11 @@ void CActor::SetVolume(float vol) {
   xd4_maxVol = vol;
 }
 
-const zeus::CTransform CActor::GetScaledLocatorTransform(std::string_view segName) const {
+zeus::CTransform CActor::GetScaledLocatorTransform(std::string_view segName) const {
   return x64_modelData->GetScaledLocatorTransform(segName);
 }
 
-const zeus::CTransform CActor::GetLocatorTransform(std::string_view segName) const {
+zeus::CTransform CActor::GetLocatorTransform(std::string_view segName) const {
   return x64_modelData->GetLocatorTransform(segName);
 }
 

--- a/Runtime/World/CActor.hpp
+++ b/Runtime/World/CActor.hpp
@@ -134,8 +134,8 @@ public:
   void SetMuted(bool);
   const zeus::CTransform& GetTransform() const { return x34_transform; }
   const zeus::CVector3f& GetTranslation() const { return x34_transform.origin; }
-  const zeus::CTransform GetScaledLocatorTransform(std::string_view segName) const;
-  const zeus::CTransform GetLocatorTransform(std::string_view segName) const;
+  zeus::CTransform GetScaledLocatorTransform(std::string_view segName) const;
+  zeus::CTransform GetLocatorTransform(std::string_view segName) const;
   void RemoveMaterial(EMaterialTypes, EMaterialTypes, EMaterialTypes, EMaterialTypes, CStateManager&);
   void RemoveMaterial(EMaterialTypes, EMaterialTypes, EMaterialTypes, CStateManager&);
   void RemoveMaterial(EMaterialTypes, EMaterialTypes, CStateManager&);


### PR DESCRIPTION
Same behavior, less code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/131)
<!-- Reviewable:end -->
