### PR TITLE
CRealElement: Remove redundant instance() call in CRELifetimeTween::GetValue()

### DIFF
--- a/Runtime/Particle/CRealElement.cpp
+++ b/Runtime/Particle/CRealElement.cpp
@@ -55,7 +55,7 @@ bool CREKeyframeEmitter::GetValue(int frame, float& valOut) const {
 }
 
 bool CRELifetimeTween::GetValue(int frame, float& valOut) const {
-  float ltFac = frame / CParticleGlobals::instance()->instance()->m_ParticleLifetimeReal;
+  float ltFac = frame / CParticleGlobals::instance()->m_ParticleLifetimeReal;
   float a, b;
   x4_a->GetValue(frame, a);
   x8_b->GetValue(frame, b);


### PR DESCRIPTION
This only needs to be called once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/132)
<!-- Reviewable:end -->
