### PR TITLE
CTextParser: Resolve double->float truncation within ParseTag()

### DIFF
--- a/Runtime/GuiSys/CTextParser.cpp
+++ b/Runtime/GuiSys/CTextParser.cpp
@@ -114,7 +114,7 @@ void CTextParser::ParseTag(CTextExecuteBuffer& out, const char16_t* str, int len
       out.AddColorOverride(val, color);
     }
   } else if (BeginsWith(str, len, u"line-spacing=")) {
-    out.AddLineSpacing(ParseInt(str + 13, len - 13, true) / 100.0);
+    out.AddLineSpacing(ParseInt(str + 13, len - 13, true) / 100.0f);
   } else if (BeginsWith(str, len, u"line-extra-space=")) {
     out.AddLineExtraSpace(ParseInt(str + 17, len - 17, true));
   } else if (BeginsWith(str, len, u"just=")) {


### PR DESCRIPTION
This should be prepended with the f suffix to prevent double to float implicit truncation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/133)
<!-- Reviewable:end -->
