### PR TITLE
CPlayer: Add missing element to skDashStrafeDistances

### DIFF
--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -57,7 +57,7 @@ constexpr std::array<float, 8> skStrafeDistances{
 };
 
 constexpr std::array<float, 8> skDashStrafeDistances{
-    30.0f, 22.6f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f,
+    11.8f, 30.0f, 22.6f, 10.0f, 10.0f, 10.0f, 10.0f, 10.0f,
 };
 
 constexpr std::array<float, 8> skOrbitForwardDistances{


### PR DESCRIPTION
`skDashStrafeDistances` was previously missing the initial element within the array, causing all the elements in the table to be shifted to the over by one. This corrects that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/135)
<!-- Reviewable:end -->
