### PR TITLE
CDamageInfo: Make certain constructors constexpr

### DIFF
--- a/Runtime/World/CDamageInfo.hpp
+++ b/Runtime/World/CDamageInfo.hpp
@@ -19,7 +19,7 @@ class CDamageInfo {
   bool x18_noImmunity = false;
 
 public:
-  CDamageInfo() = default;
+  constexpr CDamageInfo() = default;
   CDamageInfo(CInputStream& in) {
     in.readUint32Big();
     x0_weaponMode = CWeaponMode(EWeaponType(in.readUint32Big()));
@@ -28,10 +28,15 @@ public:
     x10_radius = in.readFloatBig();
     x14_knockback = in.readFloatBig();
   }
-  CDamageInfo(const CWeaponMode& mode, float damage, float radius, float knockback)
+  constexpr CDamageInfo(const CWeaponMode& mode, float damage, float radius, float knockback)
   : x0_weaponMode(mode), x8_damage(damage), xc_radiusDamage(damage), x10_radius(radius), x14_knockback(knockback) {}
 
-  CDamageInfo(const CDamageInfo& other) = default;
+  constexpr CDamageInfo(const CDamageInfo&) = default;
+  constexpr CDamageInfo& operator=(const CDamageInfo&) = default;
+
+  constexpr CDamageInfo(CDamageInfo&&) = default;
+  constexpr CDamageInfo& operator=(CDamageInfo&&) = default;
+
   CDamageInfo(const CDamageInfo&, float);
   CDamageInfo(const DataSpec::SShotParam& other);
   CDamageInfo& operator=(const DataSpec::SShotParam& other);

--- a/Runtime/World/CKnockBackController.cpp
+++ b/Runtime/World/CKnockBackController.cpp
@@ -534,7 +534,7 @@ void CKnockBackController::DoDeferredKnockBack(CStateManager& mgr, CPatterned& p
       DoKnockBackAnimation(backVec, mgr, parent, 10.f);
       ResetKnockBackImpulse(parent, backVec, 2.f);
       x82_25_inDeferredKnockBack = true;
-      parent.KnockBack(backVec, mgr, CDamageInfo({x14_deferWeaponType, false, true, false}, 0.f, 0.f, 10.f),
+      parent.KnockBack(backVec, mgr, CDamageInfo(CWeaponMode{x14_deferWeaponType, false, true, false}, 0.f, 0.f, 10.f),
                        EKnockBackType::Radius, x82_25_inDeferredKnockBack, 10.f);
       x82_25_inDeferredKnockBack = false;
     }

--- a/Runtime/World/CMorphBall.cpp
+++ b/Runtime/World/CMorphBall.cpp
@@ -2045,7 +2045,7 @@ float CMorphBall::ComputeMaxSpeed() const {
     return g_tweakBall->GetBallTranslationMaxSpeed(int(x0_player.GetSurfaceRestraint()));
 }
 
-static const CDamageInfo kBallDamage = {CWeaponMode(EWeaponType::BoostBall), 50000.f, 0.f, 0.f};
+constexpr CDamageInfo kBallDamage = {CWeaponMode(EWeaponType::BoostBall), 50000.f, 0.f, 0.f};
 
 void CMorphBall::Touch(CActor& actor, CStateManager& mgr) {
   if (TCastToPtr<CPhysicsActor> act = actor) {

--- a/Runtime/World/CPatterned.cpp
+++ b/Runtime/World/CPatterned.cpp
@@ -258,7 +258,7 @@ void CPatterned::Think(float dt, CStateManager& mgr) {
     if (x450_bodyController->IsElectrocuting()) {
       mgr.GetActorModelParticles()->StartElectric(*this);
       if (x3f0_pendingShockDamage > 0.f && x400_25_alive) {
-        CDamageInfo dInfo({{EWeaponType::Wave}, x3f0_pendingShockDamage, 0.f, 0.f}, dt);
+        const CDamageInfo dInfo(CDamageInfo{CWeaponMode{EWeaponType::Wave}, x3f0_pendingShockDamage, 0.f, 0.f}, dt);
         mgr.ApplyDamage(kInvalidUniqueId, GetUniqueId(), kInvalidUniqueId, dInfo,
                         CMaterialFilter::MakeIncludeExclude({EMaterialTypes::Solid}, {}), {});
       }
@@ -273,7 +273,7 @@ void CPatterned::Think(float dt, CStateManager& mgr) {
   if (x450_bodyController->IsOnFire()) {
     if (x400_25_alive) {
       mgr.GetActorModelParticles()->LightDudeOnFire(*this);
-      CDamageInfo dInfo({{EWeaponType::Plasma}, x3ec_pendingFireDamage, 0.f, 0.f}, dt);
+      const CDamageInfo dInfo(CDamageInfo{CWeaponMode{EWeaponType::Plasma}, x3ec_pendingFireDamage, 0.f, 0.f}, dt);
       mgr.ApplyDamage(kInvalidUniqueId, GetUniqueId(), kInvalidUniqueId, dInfo,
                       CMaterialFilter::MakeIncludeExclude({EMaterialTypes::Solid}, {}), {});
     }

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -867,7 +867,7 @@ const CDamageVulnerability* CPlayer::GetDamageVulnerability(const zeus::CVector3
 }
 
 const CDamageVulnerability* CPlayer::GetDamageVulnerability() const {
-  CDamageInfo info(CWeaponMode(EWeaponType::Power, false, false, false), 0.f, 0.f, 0.f);
+  constexpr CDamageInfo info(CWeaponMode(EWeaponType::Power, false, false, false), 0.f, 0.f, 0.f);
   return GetDamageVulnerability(zeus::skZero3f, zeus::skUp, info);
 }
 

--- a/Runtime/World/CWallCrawlerSwarm.cpp
+++ b/Runtime/World/CWallCrawlerSwarm.cpp
@@ -1100,7 +1100,7 @@ void CWallCrawlerSwarm::Touch(CActor& other, CStateManager& mgr) {
           zeus::CAABox aabb(b.GetTranslation() - radius, b.GetTranslation() + radius);
           if (playerTb->intersects(aabb)) {
             if (b.GetActive() && x558_flavor == EFlavor::Parasite) {
-              CDamageInfo dInfo(CWeaponMode(EWeaponType::AI), 2.0e-05f, 0.f, 0.f);
+              constexpr CDamageInfo dInfo(CWeaponMode(EWeaponType::AI), 2.0e-05f, 0.f, 0.f);
               mgr.ApplyDamage(GetUniqueId(), player->GetUniqueId(), GetUniqueId(), dInfo,
                  CMaterialFilter::MakeIncludeExclude({EMaterialTypes::Solid}, {}), zeus::skZero3f);
               KillBoid(b, mgr, 0.f, 1.f);


### PR DESCRIPTION
Allows eliminating potential runtime static constructors by allowing file-scope instances to be declared constexpr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/137)
<!-- Reviewable:end -->
