### PR TITLE
CScriptSound: Remove active check within AcceptScriptMsg() deactivate path

### DIFF
--- a/Runtime/World/CScriptSound.cpp
+++ b/Runtime/World/CScriptSound.cpp
@@ -158,8 +158,7 @@ void CScriptSound::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CSta
       StopSound(mgr);
   } break;
   case EScriptObjectMessage::Deactivate: {
-    if (GetActive())
-      StopSound(mgr);
+    StopSound(mgr);
   } break;
   case EScriptObjectMessage::Activate: {
     if (GetActive())


### PR DESCRIPTION
Game code doesn't check for active status within this branch, and there's no comment indicating whether or not this difference was intentional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/138)
<!-- Reviewable:end -->
