### PR TITLE
CScriptDock: Make EDockState an enum class

### DIFF
--- a/Runtime/World/CScriptDock.hpp
+++ b/Runtime/World/CScriptDock.hpp
@@ -8,7 +8,7 @@
 namespace urde {
 
 class CScriptDock : public CPhysicsActor {
-  enum EDockState { Idle, PlayerTouched, EnterNextArea, Three };
+  enum class EDockState { Idle, PlayerTouched, EnterNextArea, Three };
 
   friend class CScriptDoor;
   s32 x258_dockReferenceCount;


### PR DESCRIPTION
Makes the enum type strongly typed. All usages currently allow for this anyways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/140)
<!-- Reviewable:end -->
