### PR TITLE
CScript*: Return std::nullopt in GetTouchBounds()

### DIFF
--- a/Runtime/World/CScriptActor.cpp
+++ b/Runtime/World/CScriptActor.cpp
@@ -185,9 +185,10 @@ EWeaponCollisionResponseTypes CScriptActor::GetCollisionResponseType(const zeus:
 }
 
 std::optional<zeus::CAABox> CScriptActor::GetTouchBounds() const {
-  if (GetActive() && x68_material.HasMaterial(EMaterialTypes::Solid))
+  if (GetActive() && x68_material.HasMaterial(EMaterialTypes::Solid)) {
     return {CPhysicsActor::GetBoundingBox()};
-  return {};
+  }
+  return std::nullopt;
 }
 
 void CScriptActor::Touch(CActor&, CStateManager&) {

--- a/Runtime/World/CScriptCoverPoint.cpp
+++ b/Runtime/World/CScriptCoverPoint.cpp
@@ -28,10 +28,11 @@ void CScriptCoverPoint::Think(float delta, CStateManager&) {
 }
 
 std::optional<zeus::CAABox> CScriptCoverPoint::GetTouchBounds() const {
-  if (x100_touchBounds)
+  if (x100_touchBounds) {
     return x100_touchBounds;
+  }
 
-  return {};
+  return std::nullopt;
 }
 
 void CScriptCoverPoint::SetInUse(bool inUse) {

--- a/Runtime/World/CScriptDamageableTrigger.cpp
+++ b/Runtime/World/CScriptDamageableTrigger.cpp
@@ -193,9 +193,10 @@ void CScriptDamageableTrigger::Think(float dt, CStateManager& mgr) {
 }
 
 std::optional<zeus::CAABox> CScriptDamageableTrigger::GetTouchBounds() const {
-  if (x30_24_active && x300_24_notOccluded)
-    return {zeus::CAABox(x14c_bounds.min + GetTranslation(), x14c_bounds.max + GetTranslation())};
-  return {};
+  if (x30_24_active && x300_24_notOccluded) {
+    return zeus::CAABox(x14c_bounds.min + GetTranslation(), x14c_bounds.max + GetTranslation());
+  }
+  return std::nullopt;
 }
 
 } // namespace urde

--- a/Runtime/World/CScriptDebris.cpp
+++ b/Runtime/World/CScriptDebris.cpp
@@ -352,9 +352,10 @@ void CScriptDebris::Touch(CActor& other, CStateManager& mgr) {
 }
 
 std::optional<zeus::CAABox> CScriptDebris::GetTouchBounds() const {
-  if (x281_31_dieOnProjectile)
-    return {GetBoundingBox()};
-  return {};
+  if (x281_31_dieOnProjectile) {
+    return GetBoundingBox();
+  }
+  return std::nullopt;
 }
 
 void CScriptDebris::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {

--- a/Runtime/World/CScriptDock.cpp
+++ b/Runtime/World/CScriptDock.cpp
@@ -150,8 +150,9 @@ void CScriptDock::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStat
 }
 
 std::optional<zeus::CAABox> CScriptDock::GetTouchBounds() const {
-  if (x264_dockState == EDockState::Three)
-    return {};
+  if (x264_dockState == EDockState::Three) {
+    return std::nullopt;
+  }
 
   return GetBoundingBox();
 }

--- a/Runtime/World/CScriptDoor.cpp
+++ b/Runtime/World/CScriptDoor.cpp
@@ -365,15 +365,17 @@ void CScriptDoor::SetDoorAnimation(CScriptDoor::EDoorAnimType type) {
 }
 
 std::optional<zeus::CAABox> CScriptDoor::GetTouchBounds() const {
-  if (GetActive() && GetMaterialList().HasMaterial(EMaterialTypes::Solid))
-    return {CPhysicsActor::GetBoundingBox()};
-  return {};
+  if (GetActive() && GetMaterialList().HasMaterial(EMaterialTypes::Solid)) {
+    return CPhysicsActor::GetBoundingBox();
+  }
+  return std::nullopt;
 }
 
 std::optional<zeus::CAABox> CScriptDoor::GetProjectileBounds() const {
-  if (x2a8_28_projectilesCollide)
-    return {{x284_modelBounds.min + GetTranslation(), x284_modelBounds.max + GetTranslation()}};
-  return {};
+  if (x2a8_28_projectilesCollide) {
+    return zeus::CAABox{x284_modelBounds.min + GetTranslation(), x284_modelBounds.max + GetTranslation()};
+  }
+  return std::nullopt;
 }
 
 } // namespace urde

--- a/Runtime/World/CScriptGunTurret.cpp
+++ b/Runtime/World/CScriptGunTurret.cpp
@@ -311,9 +311,10 @@ void CScriptGunTurret::Touch(CActor& act, CStateManager& mgr) {
 }
 
 std::optional<zeus::CAABox> CScriptGunTurret::GetTouchBounds() const {
-  if (GetActive() && GetMaterialList().HasMaterial(EMaterialTypes::Solid))
-    return {GetBoundingBox()};
-  return {};
+  if (GetActive() && GetMaterialList().HasMaterial(EMaterialTypes::Solid)) {
+    return GetBoundingBox();
+  }
+  return std::nullopt;
 }
 
 zeus::CVector3f CScriptGunTurret::GetOrbitPosition(const CStateManager& mgr) const { return GetAimPosition(mgr, 0.f); }

--- a/Runtime/World/CScriptSpiderBallAttractionSurface.cpp
+++ b/Runtime/World/CScriptSpiderBallAttractionSurface.cpp
@@ -27,9 +27,10 @@ void CScriptSpiderBallAttractionSurface::AcceptScriptMsg(EScriptObjectMessage ms
 }
 
 std::optional<zeus::CAABox> CScriptSpiderBallAttractionSurface::GetTouchBounds() const {
-  if (GetActive())
-    return {zeus::CAABox(xf4_aabb.min + GetTranslation(), xf4_aabb.max + GetTranslation())};
-  return {};
+  if (GetActive()) {
+    return zeus::CAABox(xf4_aabb.min + GetTranslation(), xf4_aabb.max + GetTranslation());
+  }
+  return std::nullopt;
 }
 
 void CScriptSpiderBallAttractionSurface::Touch(CActor& actor, CStateManager& mgr) {

--- a/Runtime/World/CScriptTrigger.cpp
+++ b/Runtime/World/CScriptTrigger.cpp
@@ -203,9 +203,10 @@ void CScriptTrigger::UpdateInhabitants(float dt, CStateManager& mgr) {
 std::list<CScriptTrigger::CObjectTracker>& CScriptTrigger::GetInhabitants() { return xe8_inhabitants; }
 
 std::optional<zeus::CAABox> CScriptTrigger::GetTouchBounds() const {
-  if (x30_24_active)
-    return {GetTriggerBoundsWR()};
-  return {};
+  if (x30_24_active) {
+    return GetTriggerBoundsWR();
+  }
+  return std::nullopt;
 }
 constexpr auto sktonOHurtWeaponMode = CWeaponMode(EWeaponType::Power, false, false, true);
 

--- a/Runtime/World/CScriptVisorGoo.cpp
+++ b/Runtime/World/CScriptVisorGoo.cpp
@@ -111,7 +111,7 @@ void CScriptVisorGoo::Render(const CStateManager& mgr) const {
   // Empty
 }
 
-std::optional<zeus::CAABox> CScriptVisorGoo::GetTouchBounds() const { return {}; }
+std::optional<zeus::CAABox> CScriptVisorGoo::GetTouchBounds() const { return std::nullopt; }
 
 void CScriptVisorGoo::Touch(CActor& other, CStateManager& mgr) {
   // Empty


### PR DESCRIPTION
In some implementations, returning via default construction for std::optional can cause the entire inner buffer to be zeroed out. Returning with std::nullopt causes only the internal validity flag to be set and nothing more.

Given it's such a small change, there's no harm in doing this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/141)
<!-- Reviewable:end -->
