### PR TITLE
CScriptPlatform: Amend delta time value in AcceptScriptMsg for deletion

### DIFF
--- a/Runtime/World/CScriptPlatform.cpp
+++ b/Runtime/World/CScriptPlatform.cpp
@@ -144,7 +144,7 @@ void CScriptPlatform::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, C
     CScriptColorModulate::FadeOutHelper(mgr, GetUniqueId(), x26c_fadeOutTime);
     break;
   case EScriptObjectMessage::Deleted:
-    DecayRiders(x318_riders, 0.f, mgr);
+    DecayRiders(x318_riders, 1.66666675f, mgr);
     break;
   default:
     break;


### PR DESCRIPTION
Game code makes use of 1.66666675f here, not 0.0f.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/142)
<!-- Reviewable:end -->
