### PR TITLE
CWarWasp: Amend damping radius value within ApplyNormalSteering()

### DIFF
--- a/Runtime/MP1/World/CWarWasp.cpp
+++ b/Runtime/MP1/World/CWarWasp.cpp
@@ -310,7 +310,7 @@ void CWarWasp::ApplyNormalSteering(CStateManager& mgr) {
           CBCLocomotionCmd(x45c_steeringBehaviors.Arrival(*this, teamPos, 3.f), zeus::skZero3f, 1.f));
       zeus::CVector3f target = GetTranslation();
       target.z() = float(teamPos.z());
-      zeus::CVector3f moveVec = x45c_steeringBehaviors.Arrival(*this, target, 3.f);
+      zeus::CVector3f moveVec = x45c_steeringBehaviors.Arrival(*this, target, 2.5f);
       if (moveVec.magSquared() > 0.01f) {
         x450_bodyController->GetCommandMgr().DeliverCmd(CBCLocomotionCmd(moveVec, zeus::skZero3f, 3.f));
       }


### PR DESCRIPTION
GM8E v0-00 uses `2.5` for the second Arrival() damping radius value, not `3.0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/143)
<!-- Reviewable:end -->
