### PR TITLE
CBloodFlower: Mark sFireEffects as constexpr

### DIFF
--- a/Runtime/MP1/World/CBloodFlower.cpp
+++ b/Runtime/MP1/World/CBloodFlower.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/MP1/World/CBloodFlower.hpp"
 
+#include <array>
+
 #include "Runtime/CSimplePool.hpp"
 #include "Runtime/CStateManager.hpp"
 #include "Runtime/GameGlobalObjects.hpp"
@@ -73,7 +75,7 @@ void CBloodFlower::UpdateFire(CStateManager& mgr) {
   ++x5d8_effectState;
 }
 
-static std::string_view sFireEffects[3] = {
+constexpr std::array sFireEffects{
     "Fire1"sv,
     "Fire2"sv,
     "Fire3"sv,


### PR DESCRIPTION
Allows the strings to be put into the read-only section of the binary (and makes it explicit that the strings aren't modified). While we're at it we can make use of std::array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/144)
<!-- Reviewable:end -->
