### PR TITLE
CBloodFlower: Implement GetCollisionResponseType

### DIFF
--- a/Runtime/MP1/World/CBloodFlower.cpp
+++ b/Runtime/MP1/World/CBloodFlower.cpp
@@ -146,6 +146,17 @@ void CBloodFlower::Render(const CStateManager& mgr) const {
   x574_podEffect->Render(GetActorLights());
 }
 
+EWeaponCollisionResponseTypes CBloodFlower::GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
+                                                                     const CWeaponMode& weaponMode, EProjectileAttrib) const {
+  const auto* const damageVulnerability = GetDamageVulnerability();
+
+  if (damageVulnerability->WeaponHurts(weaponMode, false)) {
+    return EWeaponCollisionResponseTypes::Unknown28;
+  }
+
+  return EWeaponCollisionResponseTypes::Unknown78;
+}
+
 bool CBloodFlower::ShouldAttack(CStateManager& mgr, float arg) {
   if (TooClose(mgr, 0.f))
     return false;

--- a/Runtime/MP1/World/CBloodFlower.hpp
+++ b/Runtime/MP1/World/CBloodFlower.hpp
@@ -56,6 +56,9 @@ public:
   void DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node, EUserEventType type, float dt) override;
   void Render(const CStateManager& mgr) const override;
   void Touch(CActor&, CStateManager&) override {}
+  EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f& v1, const zeus::CVector3f& v2,
+                                                         const CWeaponMode& weaponMode,
+                                                         EProjectileAttrib attribute) const override;
   CProjectileInfo* GetProjectileInfo() override { return &x590_projectileInfo; }
 
   bool ShouldAttack(CStateManager&, float) override;


### PR DESCRIPTION
CBloodFlower seems to be missing the implementation of `GetCollisionResponseType()` from v0-00. This change adds in its equivalent behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/145)
<!-- Reviewable:end -->
