### PR TITLE
CFlickerBat: Add missing SetMuted() call within Death()

### DIFF
--- a/Runtime/MP1/World/CFlickerBat.cpp
+++ b/Runtime/MP1/World/CFlickerBat.cpp
@@ -137,6 +137,7 @@ void CFlickerBat::DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node,
 
 void CFlickerBat::Death(CStateManager& mgr, const zeus::CVector3f& direction, EScriptObjectState state) {
   SetFlickerBatState(EFlickerBatState::Visible, mgr);
+  SetMuted(false);
   CPatterned::Death(mgr, direction, state);
 }
 


### PR DESCRIPTION
v0-00 contains a call to `SetMuted(false)` in game code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/146)
<!-- Reviewable:end -->
