### PR TITLE
CFireFlea: Set CPathFindSearch's padding to 50.0f within AcceptScriptMsg()

### DIFF
--- a/Runtime/MP1/World/CFireFlea.cpp
+++ b/Runtime/MP1/World/CFireFlea.cpp
@@ -85,7 +85,7 @@ void CFireFlea::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateM
     x450_bodyController->Activate(mgr);
   } else if (msg == EScriptObjectMessage::InitializedInArea) {
     xd8c_pathFind.SetArea(mgr.GetWorld()->GetAreaAlways(GetAreaIdAlways())->GetPostConstructed()->x10bc_pathArea);
-    xe64_ = 50.f;
+    xd8c_pathFind.SetPadding(50.0f);
   }
 }
 

--- a/Runtime/MP1/World/CFireFlea.hpp
+++ b/Runtime/MP1/World/CFireFlea.hpp
@@ -30,7 +30,6 @@ class CFireFlea : public CPatterned {
   float x568_ = 1.f;
   float x56c_;
   rstl::reserved_vector<TUniqueId, 1024> x570_nearList;
-  float xe64_;
   zeus::CVector3f xd74_;
   zeus::CVector3f xd80_targetPos;
   CPathFindSearch xd8c_pathFind;

--- a/Runtime/World/CPathFindSearch.hpp
+++ b/Runtime/World/CPathFindSearch.hpp
@@ -56,6 +56,7 @@ public:
   void SetArea(CPFArea* area) { x0_area = area; }
   float GetCharacterHeight() const { return xd0_chHeight; }
   void SetCharacterHeight(float h) { xd0_chHeight = h; }
+  void SetPadding(float padding) { xd8_padding = padding; }
   float RemainingPathDistance(const zeus::CVector3f& pos) const;
   void DebugDraw() const;
 };


### PR DESCRIPTION
v0-00 sets the padding member of CPathFindSearch here to `50.0`, not a member variable that's part of the CFireFlea class. With this, we can also remove the now-unused `xe64_` member within CFireFlea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/148)
<!-- Reviewable:end -->
