### PR TITLE
CMetaree: Set locomotion type to crouched if deactivated in InActive()

### DIFF
--- a/Runtime/MP1/World/CMetaree.cpp
+++ b/Runtime/MP1/World/CMetaree.cpp
@@ -153,8 +153,9 @@ void CMetaree::Active(CStateManager& mgr, EStateMsg msg, float) {
 
 void CMetaree::InActive(CStateManager&, EStateMsg msg, float) {
   if (msg == EStateMsg::Activate) {
-    if (!x5ca_26_deactivated)
-      x450_bodyController->SetLocomotionType(pas::ELocomotionType::Relaxed);
+    const auto locomotionType = x5ca_26_deactivated ? pas::ELocomotionType::Crouch
+                                                    : pas::ELocomotionType::Relaxed;
+    x450_bodyController->SetLocomotionType(locomotionType);
   } else if (msg == EStateMsg::Deactivate) {
     x5ca_26_deactivated = true;
   }


### PR DESCRIPTION
v0-00 sets this locomotion type when the deactivation flag is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/149)
<!-- Reviewable:end -->
