### PR TITLE
CPlayer: Add missing return within UpdateOrbitModeTimer()

### DIFF
--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -4230,8 +4230,10 @@ void CPlayer::UpdateOrbitPreventionTimer(float dt) {
 }
 
 void CPlayer::UpdateOrbitModeTimer(float dt) {
-  if (x304_orbitState == EPlayerOrbitState::NoOrbit && x32c_orbitModeTimer > 0.f)
+  if (x304_orbitState == EPlayerOrbitState::NoOrbit && x32c_orbitModeTimer > 0.f) {
     x32c_orbitModeTimer -= dt;
+    return;
+  }
   x32c_orbitModeTimer = 0.f;
 }
 


### PR DESCRIPTION
Previously, any call to this function would always reset the timer to 0.0, rather than potentially decrement it.

GM8E v0 always returns within the conditional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/161)
<!-- Reviewable:end -->
