### PR TITLE
ITweakGunRes: Minor cleanup

### DIFF
--- a/DataSpec/DNACommon/Tweaks/ITweakGunRes.hpp
+++ b/DataSpec/DNACommon/Tweaks/ITweakGunRes.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "ITweak.hpp"
 #include "Runtime/IFactory.hpp"
 #include "Runtime/CPlayerState.hpp"
@@ -27,10 +29,11 @@ struct ITweakGunRes : ITweak {
   ResId x30_powerBombExplode;
 
   /* Power, Ice, Wave, Plasma, Phazon / Beam, Ball */
-  ResId x34_weapons[5][2];
-  ResId x84_muzzle[5];
-  ResId x94_charge[5];
-  ResId xa4_auxMuzzle[5];
+  using WeaponPair = std::array<ResId, 2>;
+  std::array<WeaponPair, 5> x34_weapons;
+  std::array<ResId, 5> x84_muzzle;
+  std::array<ResId, 5> x94_charge;
+  std::array<ResId, 5> xa4_auxMuzzle;
 
   ResId xb4_grappleSegment;
   ResId xb8_grappleClaw;
@@ -57,10 +60,11 @@ struct ITweakGunRes : ITweak {
     }
   }
 
-  const ResId* GetWeaponPair(EBeamId beam) const {
-    auto b = int(beam);
-    if (b < 0 || b > 4)
+  const WeaponPair& GetWeaponPair(EBeamId beam) const {
+    const auto b = int(beam);
+    if (b < 0 || b > 4) {
       return x34_weapons[0];
+    }
     return x34_weapons[b];
   }
 
@@ -81,18 +85,23 @@ struct ITweakGunRes : ITweak {
     x2c_bombExplode = factory.GetResourceIdByName(GetBombExplode())->id;
     x30_powerBombExplode = factory.GetResourceIdByName(GetPowerBombExplode())->id;
 
-    for (int i = 0; i < 5; ++i)
-      for (int j = 0; j < 2; ++j)
-        x34_weapons[i][j] = factory.GetResourceIdByName(GetWeapon(i, j))->id;
+    for (size_t i = 0; i < x34_weapons.size(); ++i) {
+      for (size_t j = 0; j < x34_weapons[i].size(); ++j) {
+        x34_weapons[i][j] = factory.GetResourceIdByName(GetWeapon(i, j != 0))->id;
+      }
+    }
 
-    for (int i = 0; i < 5; ++i)
+    for (size_t i = 0; i < x84_muzzle.size(); ++i) {
       x84_muzzle[i] = factory.GetResourceIdByName(GetMuzzleParticle(i))->id;
+    }
 
-    for (int i = 0; i < 5; ++i)
+    for (size_t i = 0; i < x94_charge.size(); ++i) {
       x94_charge[i] = factory.GetResourceIdByName(GetChargeParticle(i))->id;
+    }
 
-    for (int i = 0; i < 5; ++i)
+    for (size_t i = 0; i < xa4_auxMuzzle.size(); ++i) {
       xa4_auxMuzzle[i] = factory.GetResourceIdByName(GetAuxMuzzleParticle(i))->id;
+    }
 
     xb4_grappleSegment = factory.GetResourceIdByName(GetGrappleSegmentParticle())->id;
     xb8_grappleClaw = factory.GetResourceIdByName(GetGrappleClawParticle())->id;

--- a/DataSpec/DNACommon/Tweaks/ITweakGunRes.hpp
+++ b/DataSpec/DNACommon/Tweaks/ITweakGunRes.hpp
@@ -65,40 +65,40 @@ struct ITweakGunRes : ITweak {
   }
 
   void ResolveResources(const urde::IFactory& factory) {
-    x4_gunMotion = factory.GetResourceIdByName(GetGunMotion().c_str())->id;
-    x8_grappleArm = factory.GetResourceIdByName(GetGrappleArm().c_str())->id;
-    xc_rightHand = factory.GetResourceIdByName(GetRightHand().c_str())->id;
+    x4_gunMotion = factory.GetResourceIdByName(GetGunMotion())->id;
+    x8_grappleArm = factory.GetResourceIdByName(GetGrappleArm())->id;
+    xc_rightHand = factory.GetResourceIdByName(GetRightHand())->id;
 
-    x10_powerBeam = factory.GetResourceIdByName(GetPowerBeam().c_str())->id;
-    x14_iceBeam = factory.GetResourceIdByName(GetIceBeam().c_str())->id;
-    x18_waveBeam = factory.GetResourceIdByName(GetWaveBeam().c_str())->id;
-    x1c_plasmaBeam = factory.GetResourceIdByName(GetPlasmaBeam().c_str())->id;
-    x20_phazonBeam = factory.GetResourceIdByName(GetPhazonBeam().c_str())->id;
+    x10_powerBeam = factory.GetResourceIdByName(GetPowerBeam())->id;
+    x14_iceBeam = factory.GetResourceIdByName(GetIceBeam())->id;
+    x18_waveBeam = factory.GetResourceIdByName(GetWaveBeam())->id;
+    x1c_plasmaBeam = factory.GetResourceIdByName(GetPlasmaBeam())->id;
+    x20_phazonBeam = factory.GetResourceIdByName(GetPhazonBeam())->id;
 
-    x24_holoTransition = factory.GetResourceIdByName(GetHoloTransition().c_str())->id;
+    x24_holoTransition = factory.GetResourceIdByName(GetHoloTransition())->id;
 
-    x28_bombSet = factory.GetResourceIdByName(GetBombSet().c_str())->id;
-    x2c_bombExplode = factory.GetResourceIdByName(GetBombExplode().c_str())->id;
-    x30_powerBombExplode = factory.GetResourceIdByName(GetPowerBombExplode().c_str())->id;
+    x28_bombSet = factory.GetResourceIdByName(GetBombSet())->id;
+    x2c_bombExplode = factory.GetResourceIdByName(GetBombExplode())->id;
+    x30_powerBombExplode = factory.GetResourceIdByName(GetPowerBombExplode())->id;
 
     for (int i = 0; i < 5; ++i)
       for (int j = 0; j < 2; ++j)
-        x34_weapons[i][j] = factory.GetResourceIdByName(GetWeapon(i, j).c_str())->id;
+        x34_weapons[i][j] = factory.GetResourceIdByName(GetWeapon(i, j))->id;
 
     for (int i = 0; i < 5; ++i)
-      x84_muzzle[i] = factory.GetResourceIdByName(GetMuzzleParticle(i).c_str())->id;
+      x84_muzzle[i] = factory.GetResourceIdByName(GetMuzzleParticle(i))->id;
 
     for (int i = 0; i < 5; ++i)
-      x94_charge[i] = factory.GetResourceIdByName(GetChargeParticle(i).c_str())->id;
+      x94_charge[i] = factory.GetResourceIdByName(GetChargeParticle(i))->id;
 
     for (int i = 0; i < 5; ++i)
-      xa4_auxMuzzle[i] = factory.GetResourceIdByName(GetAuxMuzzleParticle(i).c_str())->id;
+      xa4_auxMuzzle[i] = factory.GetResourceIdByName(GetAuxMuzzleParticle(i))->id;
 
-    xb4_grappleSegment = factory.GetResourceIdByName(GetGrappleSegmentParticle().c_str())->id;
-    xb8_grappleClaw = factory.GetResourceIdByName(GetGrappleClawParticle().c_str())->id;
-    xbc_grappleHit = factory.GetResourceIdByName(GetGrappleHitParticle().c_str())->id;
-    xc0_grappleMuzzle = factory.GetResourceIdByName(GetGrappleMuzzleParticle().c_str())->id;
-    xc4_grappleSwoosh = factory.GetResourceIdByName(GetGrappleSwooshParticle().c_str())->id;
+    xb4_grappleSegment = factory.GetResourceIdByName(GetGrappleSegmentParticle())->id;
+    xb8_grappleClaw = factory.GetResourceIdByName(GetGrappleClawParticle())->id;
+    xbc_grappleHit = factory.GetResourceIdByName(GetGrappleHitParticle())->id;
+    xc0_grappleMuzzle = factory.GetResourceIdByName(GetGrappleMuzzleParticle())->id;
+    xc4_grappleSwoosh = factory.GetResourceIdByName(GetGrappleSwooshParticle())->id;
   }
 
 protected:

--- a/Runtime/Weapon/CGunWeapon.cpp
+++ b/Runtime/Weapon/CGunWeapon.cpp
@@ -76,7 +76,7 @@ CGunWeapon::CGunWeapon(CAssetId ancsId, EWeaponType type, TUniqueId playerId, EM
 }
 
 void CGunWeapon::AllocResPools(CPlayerState::EBeamId beam) {
-  const CAssetId* const wPair = g_tweakGunRes->GetWeaponPair(beam);
+  const auto& wPair = g_tweakGunRes->GetWeaponPair(beam);
   const char* const* muzzleNames = &skMuzzleNames[size_t(beam) * 2];
   const char* const* frozenNames = &skFrozenNames[size_t(beam) * 2];
 

--- a/Runtime/Weapon/CPlayerGun.cpp
+++ b/Runtime/Weapon/CPlayerGun.cpp
@@ -107,8 +107,8 @@ void CPlayerGun::InitBombData() {
 }
 
 void CPlayerGun::InitMuzzleData() {
-  for (int i = 0; i < 5; ++i) {
-    x7c0_auxMuzzleEffects.push_back(g_SimplePool->GetObj(SObjectTag{FOURCC('PART'), g_tweakGunRes->xa4_auxMuzzle[i]}));
+  for (const auto muzzleID : g_tweakGunRes->xa4_auxMuzzle) {
+    x7c0_auxMuzzleEffects.push_back(g_SimplePool->GetObj(SObjectTag{FOURCC('PART'), muzzleID}));
     x800_auxMuzzleGenerators.emplace_back(std::make_unique<CElementGen>(x7c0_auxMuzzleEffects.back()));
     x800_auxMuzzleGenerators.back()->SetParticleEmission(false);
   }


### PR DESCRIPTION
Makes use of std::array to deduplicate hardcoded array sizes and removes some unnecessary `c_str()` calls, which also eliminates unnecessary strlen calls, since string_view instances aren't being constructed around a regular C string anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/163)
<!-- Reviewable:end -->
