### PR TITLE
CMidiManager: std::move sequencer within SetAudioSysHandle()

### DIFF
--- a/Runtime/Audio/CMidiManager.hpp
+++ b/Runtime/Audio/CMidiManager.hpp
@@ -30,7 +30,7 @@ public:
 
   public:
     amuse::ObjToken<amuse::Sequencer> GetAudioSysHandle() const { return x0_sequencer; }
-    void SetAudioSysHandle(amuse::ObjToken<amuse::Sequencer> sequencer) { x0_sequencer = sequencer; }
+    void SetAudioSysHandle(amuse::ObjToken<amuse::Sequencer> sequencer) { x0_sequencer = std::move(sequencer); }
     // const CSfxHandle& GetManagerHandle() const { return x4_handle; }
     // void SetMidiHandle(const CSfxHandle& handle) { x4_handle = handle; }
     bool IsAvailable() const { return xa_available; }


### PR DESCRIPTION
Provides the same behavior but without a redundant reference count increment and then decrement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/164)
<!-- Reviewable:end -->
