### PR TITLE
CGroundMovement: Collapse 'dampUnderwater ? 0.2f : 0.2f' conditional

### DIFF
--- a/Runtime/Character/CGroundMovement.cpp
+++ b/Runtime/Character/CGroundMovement.cpp
@@ -485,7 +485,7 @@ void CGroundMovement::MoveGroundCollider_New(CStateManager& mgr, CPhysicsActor& 
     opts.x24_dampedNormalCoefficient = 0.f;
     opts.x28_dampedDeltaCoefficient = 1.f;
     opts.x2c_floorElasticForce = 0.1f;
-    opts.x30_wallElasticConstant = dampUnderwater ? 0.2f : 0.2f;
+    opts.x30_wallElasticConstant = 0.2f;
     opts.x3c_floorPlaneNormal = player.GetLastFloorPlaneNormal();
     opts.x38_maxPositiveVerticalVelocity = player.GetMaximumPlayerPositiveVerticalVelocity(mgr);
 


### PR DESCRIPTION
The conditional itself aside, in GM8E v0, this is always assigned as `0.2f`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/166)
<!-- Reviewable:end -->
