### PR TITLE
SpecBase: Flatten loop within flattenDependenciesBlend()

### DIFF
--- a/DataSpec/SpecBase.cpp
+++ b/DataSpec/SpecBase.cpp
@@ -283,11 +283,11 @@ void SpecBase::flattenDependenciesBlend(const hecl::ProjectPath& in, std::vector
   if (!conn.openBlend(in))
     return;
   switch (conn.getBlendType()) {
-  case hecl::blender::BlendType::Mesh: {
+  case hecl::blender::BlendType::Mesh:
+  case hecl::blender::BlendType::Area: {
     hecl::blender::DataStream ds = conn.beginData();
     std::vector<hecl::ProjectPath> texs = ds.getTextures();
-    for (const hecl::ProjectPath& tex : texs)
-      pathsOut.push_back(tex);
+    pathsOut.insert(pathsOut.end(), std::make_move_iterator(texs.begin()), std::make_move_iterator(texs.end()));
     break;
   }
   case hecl::blender::BlendType::Actor: {
@@ -378,13 +378,6 @@ void SpecBase::flattenDependenciesBlend(const hecl::ProjectPath& in, std::vector
 
     pathsOut.push_back(asGlob);
     return;
-  }
-  case hecl::blender::BlendType::Area: {
-    hecl::blender::DataStream ds = conn.beginData();
-    std::vector<hecl::ProjectPath> texs = ds.getTextures();
-    for (const hecl::ProjectPath& tex : texs)
-      pathsOut.push_back(tex);
-    break;
   }
   default:
     break;


### PR DESCRIPTION
We can use `insert()` with `std::make_move_iterator()` to perform the same behavior, minus unnecessary copies.

While we're at it, we can collapse the code within the Area case, since it's the exact same as the Mesh code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/167)
<!-- Reviewable:end -->
