### PR TITLE
SpecBase: Remove redundant std::bind

### DIFF
--- a/DataSpec/SpecBase.cpp
+++ b/DataSpec/SpecBase.cpp
@@ -1201,7 +1201,7 @@ void SpecBase::beginBackgroundIndex() {
   cancelBackgroundIndex();
   clearTagCache();
   m_backgroundRunning = true;
-  m_backgroundIndexTh = std::thread(std::bind(&SpecBase::backgroundIndexProc, this));
+  m_backgroundIndexTh = std::thread(&SpecBase::backgroundIndexProc, this);
 }
 
 void SpecBase::waitForIndexComplete() const {


### PR DESCRIPTION
std::thread can already execute the supplied function as is without the assistance of std::bind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/168)
<!-- Reviewable:end -->
