### PR TITLE
CPAS*: Minor cleanup

### DIFF
--- a/Runtime/Character/CPASAnimState.cpp
+++ b/Runtime/Character/CPASAnimState.cpp
@@ -87,7 +87,7 @@ s32 CPASAnimState::PickRandomAnimation(CRandom16& rand) const {
 
 std::pair<float, s32> CPASAnimState::FindBestAnimation(const rstl::reserved_vector<CPASAnimParm, 8>& parms,
                                                        CRandom16& rand, s32 ignoreAnim) const {
-  const_cast<std::vector<s32>*>(&x24_selectionCache)->clear();
+  x24_selectionCache.clear();
   float weight = -1.f;
 
   for (const CPASAnimInfo& info : x14_anims) {
@@ -130,11 +130,11 @@ std::pair<float, s32> CPASAnimState::FindBestAnimation(const rstl::reserved_vect
       calcWeight = 1.0f;
 
     if (calcWeight > weight) {
-      const_cast<std::vector<s32>*>(&x24_selectionCache)->clear();
-      const_cast<std::vector<s32>*>(&x24_selectionCache)->push_back(info.GetAnimId());
+      x24_selectionCache.clear();
+      x24_selectionCache.push_back(info.GetAnimId());
       weight = calcWeight;
     } else if (weight == calcWeight) {
-      const_cast<std::vector<s32>*>(&x24_selectionCache)->push_back(info.GetAnimId());
+      x24_selectionCache.push_back(info.GetAnimId());
       weight = calcWeight;
     }
   }

--- a/Runtime/Character/CPASAnimState.hpp
+++ b/Runtime/Character/CPASAnimState.hpp
@@ -14,7 +14,7 @@ class CPASAnimState {
   s32 x0_id;
   std::vector<CPASParmInfo> x4_parms;
   std::vector<CPASAnimInfo> x14_anims;
-  std::vector<s32> x24_selectionCache;
+  mutable std::vector<s32> x24_selectionCache;
 
 public:
   CPASAnimState(CInputStream& in);

--- a/Runtime/Character/CPASAnimState.hpp
+++ b/Runtime/Character/CPASAnimState.hpp
@@ -17,8 +17,8 @@ class CPASAnimState {
   mutable std::vector<s32> x24_selectionCache;
 
 public:
-  CPASAnimState(CInputStream& in);
-  CPASAnimState(int stateId);
+  explicit CPASAnimState(CInputStream& in);
+  explicit CPASAnimState(int stateId);
   s32 GetStateId() const { return x0_id; }
   s32 GetNumAnims() const { return x14_anims.size(); }
   CPASAnimParm GetAnimParmData(s32, u32) const;

--- a/Runtime/Character/CPASDatabase.hpp
+++ b/Runtime/Character/CPASDatabase.hpp
@@ -18,7 +18,7 @@ class CPASDatabase {
   void SetDefaultState(s32 state) { x10_defaultState = state; }
 
 public:
-  CPASDatabase(CInputStream& in);
+  explicit CPASDatabase(CInputStream& in);
 
   std::pair<float, s32> FindBestAnimation(const CPASAnimParmData&, s32) const;
   std::pair<float, s32> FindBestAnimation(const CPASAnimParmData&, CRandom16&, s32) const;

--- a/Runtime/Character/CPASParmInfo.hpp
+++ b/Runtime/Character/CPASParmInfo.hpp
@@ -9,6 +9,7 @@ class CPASParmInfo {
 public:
   enum class EWeightFunction { ExactMatch, PercentError, AngularPercent, NoWeight };
 
+private:
   CPASAnimParm::EParmType x0_type;
   EWeightFunction x4_weightFunction;
   float x8_weight;

--- a/Runtime/Character/CPASParmInfo.hpp
+++ b/Runtime/Character/CPASParmInfo.hpp
@@ -16,7 +16,7 @@ public:
   CPASAnimParm::UParmValue x10_max;
 
 public:
-  CPASParmInfo(CInputStream& in);
+  explicit CPASParmInfo(CInputStream& in);
   CPASAnimParm::EParmType GetParameterType() const { return x0_type; }
   EWeightFunction GetWeightFunction() const { return x4_weightFunction; }
   float GetParameterWeight() const { return x8_weight; }


### PR DESCRIPTION
Tidies up some `const_cast` usage, makes constructors explicit and makes some data members private that don't need to be public.

Each change should be fairly self contained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/171)
<!-- Reviewable:end -->
