### PR TITLE
Runtime: Remove unnecessary c_str() calls

### DIFF
--- a/Runtime/Audio/CStreamAudioManager.cpp
+++ b/Runtime/Audio/CStreamAudioManager.cpp
@@ -654,7 +654,7 @@ public:
     if (stream.x70_26_headerReadState != 0 || stream.x70_24_unclaimed)
       return false;
 
-    CDvdFile file(stream.x60_fileName.c_str());
+    CDvdFile file(stream.x60_fileName);
     if (!file)
       return false;
 
@@ -668,11 +668,11 @@ public:
         rstream.x70_24_unclaimed)
       return false;
 
-    CDvdFile lfile(lstream.x60_fileName.c_str());
+    CDvdFile lfile(lstream.x60_fileName);
     if (!lfile)
       return false;
 
-    CDvdFile rfile(rstream.x60_fileName.c_str());
+    CDvdFile rfile(rstream.x60_fileName);
     if (!rfile)
       return false;
 

--- a/Runtime/GuiSys/CHudBallInterface.cpp
+++ b/Runtime/GuiSys/CHudBallInterface.cpp
@@ -18,7 +18,7 @@ CHudBallInterface::CHudBallInterface(CGuiFrame& selHud, int pbAmount, int pbCapa
   xc_model_bombicon = static_cast<CGuiModel*>(selHud.FindWidget("model_bombicon"));
   x10_textpane_bombdigits = static_cast<CGuiTextPane*>(selHud.FindWidget("textpane_bombdigits"));
   for (int i = 0; i < 3; ++i) {
-    CGuiGroup* grp = static_cast<CGuiGroup*>(selHud.FindWidget(fmt::format(fmt("group_bombcount{}"), i).c_str()));
+    CGuiGroup* grp = static_cast<CGuiGroup*>(selHud.FindWidget(fmt::format(fmt("group_bombcount{}"), i)));
     CGuiWidget* filled = grp->GetWorkerWidget(1);
     CGuiWidget* empty = grp->GetWorkerWidget(0);
     x14_group_bombfilled.push_back(filled);

--- a/Runtime/MP1/CFrontEndUI.cpp
+++ b/Runtime/MP1/CFrontEndUI.cpp
@@ -647,11 +647,11 @@ void CFrontEndUI::SNewFileSelectFrame::DoFileMenuAdvance(CGuiTableGroup* caller)
 
 CFrontEndUI::SFileMenuOption CFrontEndUI::SNewFileSelectFrame::FindFileSelectOption(CGuiFrame* frame, int idx) {
   SFileMenuOption ret;
-  ret.x0_base = frame->FindWidget(fmt::format(fmt("basewidget_file{}"), idx).c_str());
-  ret.x4_textpanes[0] = FindTextPanePair(frame, fmt::format(fmt("textpane_filename{}"), idx).c_str());
-  ret.x4_textpanes[1] = FindTextPanePair(frame, fmt::format(fmt("textpane_world{}"), idx).c_str());
-  ret.x4_textpanes[2] = FindTextPanePair(frame, fmt::format(fmt("textpane_playtime{}"), idx).c_str());
-  ret.x4_textpanes[3] = FindTextPanePair(frame, fmt::format(fmt("textpane_date{}"), idx).c_str());
+  ret.x0_base = frame->FindWidget(fmt::format(fmt("basewidget_file{}"), idx));
+  ret.x4_textpanes[0] = FindTextPanePair(frame, fmt::format(fmt("textpane_filename{}"), idx));
+  ret.x4_textpanes[1] = FindTextPanePair(frame, fmt::format(fmt("textpane_world{}"), idx));
+  ret.x4_textpanes[2] = FindTextPanePair(frame, fmt::format(fmt("textpane_playtime{}"), idx));
+  ret.x4_textpanes[3] = FindTextPanePair(frame, fmt::format(fmt("textpane_date{}"), idx));
   return ret;
 }
 
@@ -1108,17 +1108,17 @@ void CFrontEndUI::SGuiTextPair::SetPairText(std::u16string_view str) {
   x0_panes[1]->TextSupport().SetText(str);
 }
 
-CFrontEndUI::SGuiTextPair CFrontEndUI::FindTextPanePair(CGuiFrame* frame, const char* name) {
+CFrontEndUI::SGuiTextPair CFrontEndUI::FindTextPanePair(CGuiFrame* frame, std::string_view name) {
   SGuiTextPair ret;
   ret.x0_panes[0] = static_cast<CGuiTextPane*>(frame->FindWidget(name));
-  ret.x0_panes[1] = static_cast<CGuiTextPane*>(frame->FindWidget(fmt::format(fmt("{}b"), name).c_str()));
+  ret.x0_panes[1] = static_cast<CGuiTextPane*>(frame->FindWidget(fmt::format(fmt("{}b"), name)));
   return ret;
 }
 
-void CFrontEndUI::FindAndSetPairText(CGuiFrame* frame, const char* name, std::u16string_view str) {
+void CFrontEndUI::FindAndSetPairText(CGuiFrame* frame, std::string_view name, std::u16string_view str) {
   CGuiTextPane* w1 = static_cast<CGuiTextPane*>(frame->FindWidget(name));
   w1->TextSupport().SetText(str);
-  CGuiTextPane* w2 = static_cast<CGuiTextPane*>(frame->FindWidget(fmt::format(fmt("{}b"), name).c_str()));
+  CGuiTextPane* w2 = static_cast<CGuiTextPane*>(frame->FindWidget(fmt::format(fmt("{}b"), name)));
   w2->TextSupport().SetText(str);
 }
 
@@ -1535,11 +1535,10 @@ void CFrontEndUI::SOptionsFrontEndFrame::SetRightUIText() {
   for (int i = 0; i < 5; ++i) {
     std::string name = fmt::format(fmt("textpane_right{}"), i);
     if (i < static_cast<int>(options.first)) {
-      FindTextPanePair(x1c_loadedFrame, name.c_str()).SetPairText(
-        x20_loadedPauseStrg->GetString(options.second[i].stringId));
+      FindTextPanePair(x1c_loadedFrame, name).SetPairText(x20_loadedPauseStrg->GetString(options.second[i].stringId));
       x28_tablegroup_rightmenu->GetWorkerWidget(i)->SetIsSelectable(true);
     } else {
-      FindTextPanePair(x1c_loadedFrame, name.c_str()).SetPairText(u"");
+      FindTextPanePair(x1c_loadedFrame, name).SetPairText(u"");
       x28_tablegroup_rightmenu->GetWorkerWidget(i)->SetIsSelectable(false);
     }
   }
@@ -1596,8 +1595,8 @@ void CFrontEndUI::SOptionsFrontEndFrame::FinishedLoading() {
 
   // Visor, Display, Sound, Controller
   for (int i = 0; i < 4; ++i) {
-    std::string name = fmt::format(fmt("textpane_filename{}"), i);
-    FindTextPanePair(x1c_loadedFrame, name.c_str()).SetPairText(x20_loadedPauseStrg->GetString(16 + i));
+    const std::string name = fmt::format(fmt("textpane_filename{}"), i);
+    FindTextPanePair(x1c_loadedFrame, name).SetPairText(x20_loadedPauseStrg->GetString(16 + i));
   }
 
   x2c_tablegroup_double->SetVertical(false);
@@ -1756,7 +1755,7 @@ CFrontEndUI::CFrontEndUI() : CIOWin("FrontEndUI") {
   g_GameState->GameOptions().ResetToDefaults();
   g_GameState->WriteBackupBuf();
 
-  for (int i = 0; CDvdFile::FileExists(GetAttractMovieFileName(i).c_str()); ++i)
+  for (int i = 0; CDvdFile::FileExists(GetAttractMovieFileName(i)); ++i)
     ++xc0_attractCount;
 
   m_touchBar = NewFrontEndUITouchBar();

--- a/Runtime/MP1/CFrontEndUI.hpp
+++ b/Runtime/MP1/CFrontEndUI.hpp
@@ -65,8 +65,8 @@ public:
     std::array<CGuiTextPane*, 2> x0_panes{};
     void SetPairText(std::u16string_view str);
   };
-  static SGuiTextPair FindTextPanePair(CGuiFrame* frame, const char* name);
-  static void FindAndSetPairText(CGuiFrame* frame, const char* name, std::u16string_view str);
+  static SGuiTextPair FindTextPanePair(CGuiFrame* frame, std::string_view name);
+  static void FindAndSetPairText(CGuiFrame* frame, std::string_view name, std::u16string_view str);
 
   struct SFileMenuOption {
     CGuiWidget* x0_base;

--- a/Runtime/MP1/MP1.cpp
+++ b/Runtime/MP1/MP1.cpp
@@ -337,8 +337,9 @@ void CMain::AddWorldPaks() {
     if (i != 0)
       path += '0' + i;
 
-    if (CDvdFile::FileExists((path + ".upak").c_str()))
+    if (CDvdFile::FileExists(path + ".upak")) {
       loader->AddPakFileAsync(path, false, true);
+    }
   }
   loader->WaitForPakFileLoadingComplete();
 }
@@ -352,9 +353,10 @@ void CMain::AddOverridePaks() {
    * the higher the number the higer the priority, e.g: Override0 has less priority than Override1 etc.
    */
   for (size_t i = 999; i > 0; --i) {
-    std::string path = fmt::format(fmt("Override{}"), i);
-    if (CDvdFile::FileExists((path + ".upak").c_str()))
+    const std::string path = fmt::format(fmt("Override{}"), i);
+    if (CDvdFile::FileExists(path + ".upak")) {
       loader->AddPakFileAsync(path, false, false, true);
+    }
   }
   /* Make sure all Override paks are ready before attempting to load URDE.upak */
   loader->WaitForPakFileLoadingComplete();

--- a/Runtime/World/CMorphBall.cpp
+++ b/Runtime/World/CMorphBall.cpp
@@ -291,7 +291,7 @@ CMorphBall::CMorphBall(CPlayer& player, float radius)
 }
 
 void CMorphBall::LoadAnimationTokens(std::string_view ancsName) {
-  TToken<CDependencyGroup> dgrp = g_SimplePool->GetObj((std::string(ancsName) + "_DGRP").c_str());
+  TToken<CDependencyGroup> dgrp = g_SimplePool->GetObj(std::string(ancsName).append("_DGRP"));
   x1958_animationTokens.clear();
   x1958_animationTokens.reserve(dgrp->GetObjectTagVector().size());
   for (const SObjectTag& tag : dgrp->GetObjectTagVector()) {


### PR DESCRIPTION
Makes for less noisy code and also gets rid of unnecessary `std::strlen` calls in the case the resulting pointer is passed to a `std::string_view` parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/173)
<!-- Reviewable:end -->
