### PR TITLE
CScriptGunTurret: Remove unnecessary data() call in AcceptScriptMsg()

### DIFF
--- a/Runtime/World/CScriptGunTurret.cpp
+++ b/Runtime/World/CScriptGunTurret.cpp
@@ -174,7 +174,7 @@ void CScriptGunTurret::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, 
       if (x478_targettingLight->SystemHasLight()) {
         x498_lightId = mgr.AllocateUniqueId();
         mgr.AddObject(new CGameLight(x498_lightId, GetAreaIdAlways(), GetActive(),
-                                     std::string("ParticleLight_") + GetName().data(), GetTransform(), GetUniqueId(),
+                                     std::string("ParticleLight_").append(GetName()), GetTransform(), GetUniqueId(),
                                      x478_targettingLight->GetLight(), 0, 1, 0.f));
       }
       SetupCollisionManager(mgr);


### PR DESCRIPTION
We can use `append()` instead of `data()`. This allows the size of the string view instance to be used directly instead of redundantly doing a string size lookup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/178)
<!-- Reviewable:end -->
