### PR TITLE
CFlameThrower: Amend virtual interface discrepancies

### DIFF
--- a/Runtime/Weapon/CFlameThrower.cpp
+++ b/Runtime/Weapon/CFlameThrower.cpp
@@ -95,6 +95,12 @@ void CFlameThrower::AddToRenderer(const zeus::CFrustum&, const CStateManager& mg
   EnsureRendered(mgr, x2e8_flameXf.origin, GetRenderBounds());
 }
 
+void CFlameThrower::Render(const CStateManager&) const {}
+
+std::optional<zeus::CAABox> CFlameThrower::GetTouchBounds() const { return std::nullopt; }
+
+void CFlameThrower::Touch(CActor&, CStateManager&) {}
+
 void CFlameThrower::SetFlameLightActive(CStateManager& mgr, bool active) {
   if (x2c8_projectileLight == kInvalidUniqueId)
     return;

--- a/Runtime/Weapon/CFlameThrower.hpp
+++ b/Runtime/Weapon/CFlameThrower.hpp
@@ -57,6 +57,9 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void Render(const CStateManager& mgr) const override;
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
+  void Touch(CActor& actor, CStateManager& mgr) override;
   void SetTransform(const zeus::CTransform& xf, float);
   void Reset(CStateManager&, bool);
   void Fire(const zeus::CTransform&, CStateManager&, bool);


### PR DESCRIPTION
GM8E v0 overrides `Render()`, `GetTouchBounds()` and `Touch()` and does nothing within them. This updates the interface to match it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/180)
<!-- Reviewable:end -->
