### PR TITLE
CInGameGuiManager: Take std::shared_ptr by const reference in DoStateTransition()

### DIFF
--- a/Runtime/MP1/CInGameGuiManager.cpp
+++ b/Runtime/MP1/CInGameGuiManager.cpp
@@ -103,8 +103,8 @@ void CInGameGuiManager::DoStateTransition(CStateManager& stateMgr) {
   case EInGameGuiState::PauseGame:
   case EInGameGuiState::PauseLogBook:
     if (!x48_pauseScreen) {
-      auto pState = stateMgr.GetPlayerState();
-      CPlayerState::EPlayerSuit suit = pState->GetCurrentSuitRaw();
+      const auto& pState = stateMgr.GetPlayerState();
+      const CPlayerState::EPlayerSuit suit = pState->GetCurrentSuitRaw();
       int suitResIdx;
       if (pState->IsFusionEnabled()) {
         switch (suit) {


### PR DESCRIPTION
Trivially avoids an atomic reference count increment and decrement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/181)
<!-- Reviewable:end -->
