### PR TITLE
CThardus: std::move vector instances in constructor

### DIFF
--- a/Runtime/MP1/World/CThardus.cpp
+++ b/Runtime/MP1/World/CThardus.cpp
@@ -59,7 +59,7 @@ constexpr std::array<std::string_view, 7> skRockJoints = {
 } // namespace
 CThardus::CThardus(TUniqueId uid, std::string_view name, const CEntityInfo& info, const zeus::CTransform& xf,
                    CModelData&& mData, const CActorParameters& actParms, const CPatternedInfo& pInfo,
-                   const std::vector<CStaticRes>& mData1, const std::vector<CStaticRes>& mData2, CAssetId particle1,
+                   std::vector<CStaticRes> mData1, std::vector<CStaticRes> mData2, CAssetId particle1,
                    CAssetId particle2, CAssetId particle3, float f1, float f2, float f3, float f4, float f5, float f6,
                    CAssetId stateMachine, CAssetId particle4, CAssetId particle5, CAssetId particle6,
                    CAssetId particle7, CAssetId particle8, CAssetId particle9, CAssetId texture, u32 sfxId1,

--- a/Runtime/MP1/World/CThardus.hpp
+++ b/Runtime/MP1/World/CThardus.hpp
@@ -169,11 +169,10 @@ public:
   DEFINE_PATTERNED(Thardus)
   CThardus(TUniqueId uid, std::string_view name, const CEntityInfo& info, const zeus::CTransform& xf,
            CModelData&& mData, const CActorParameters& actParms, const CPatternedInfo& pInfo,
-           const std::vector<CStaticRes>& mData1, const std::vector<CStaticRes>& mData2, CAssetId particle1,
-           CAssetId particle2, CAssetId particle3, float f1, float f2, float f3, float f4, float f5, float f6,
-           CAssetId stateMachine, CAssetId particle4, CAssetId particle5, CAssetId particle6, CAssetId particle7,
-           CAssetId particle8, CAssetId particle9, CAssetId texture, u32 sfxId1, CAssetId particle10, u32 sfxId2,
-           u32 sfxId3, u32 sfxId4);
+           std::vector<CStaticRes> mData1, std::vector<CStaticRes> mData2, CAssetId particle1, CAssetId particle2,
+           CAssetId particle3, float f1, float f2, float f3, float f4, float f5, float f6, CAssetId stateMachine,
+           CAssetId particle4, CAssetId particle5, CAssetId particle6, CAssetId particle7, CAssetId particle8,
+           CAssetId particle9, CAssetId texture, u32 sfxId1, CAssetId particle10, u32 sfxId2, u32 sfxId3, u32 sfxId4);
 
   void Think(float dt, CStateManager& mgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;

--- a/Runtime/World/ScriptLoader.cpp
+++ b/Runtime/World/ScriptLoader.cpp
@@ -2574,16 +2574,14 @@ CEntity* ScriptLoader::LoadThardus(CStateManager& mgr, CInputStream& in, int pro
   int sfxID2 = in.readUint32Big();
   int sfxID3 = in.readUint32Big();
   int sfxID4 = in.readUint32Big();
-  std::vector<CStaticRes> mData1(7);
-  std::vector<CStaticRes> mData2(7);
-  mData1.assign(std::rbegin(staticRes[0]), std::rend(staticRes[0]));
-  mData2.assign(std::rbegin(staticRes[1]), std::rend(staticRes[1]));
+  std::vector<CStaticRes> mData1(std::rbegin(staticRes[0]), std::rend(staticRes[0]));
+  std::vector<CStaticRes> mData2(std::rbegin(staticRes[1]), std::rend(staticRes[1]));
 
   CModelData mData(CAnimRes(animParms.GetACSFile(), 0, actHead.x40_scale, animParms.GetInitialAnimation(), true));
   return new MP1::CThardus(mgr.AllocateUniqueId(), actHead.x0_name, info, actHead.x10_transform, std::move(mData),
-                           actParms, pInfo, mData1, mData2, particle1, particle2, particle3, f1, f2, f3, f4, f5, f6,
-                           stateMachine, particle4, particle5, particle6, particle7, particle8, particle9, texture,
-                           sfxID1, particle10, sfxID2, sfxID3, sfxID4);
+                           actParms, pInfo, std::move(mData1), std::move(mData2), particle1, particle2, particle3, f1,
+                           f2, f3, f4, f5, f6, stateMachine, particle4, particle5, particle6, particle7, particle8,
+                           particle9, texture, sfxID1, particle10, sfxID2, sfxID3, sfxID4);
 }
 
 CEntity* ScriptLoader::LoadWallCrawlerSwarm(CStateManager& mgr, CInputStream& in, int propCount,


### PR DESCRIPTION
Previously the std::move calls wouldn't do anything, as the parameters were constant references, so we can take them by value and move into the constructor and then move the parameters into the member variables.

While we're at it, we can initialize the vectors in place instead of constructing and then assigning to them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/183)
<!-- Reviewable:end -->
