### PR TITLE
CParticleGenInfo: Fix missing ampersand in GetParticleSystem() member function

### DIFF
--- a/Runtime/Character/CParticleDatabase.cpp
+++ b/Runtime/Character/CParticleDatabase.cpp
@@ -306,7 +306,7 @@ void CParticleDatabase::SetParticleEffectState(std::string_view name, bool activ
 
 void CParticleDatabase::SetCEXTValue(std::string_view name, int idx, float value) {
   if (CParticleGenInfo* info = GetParticleEffect(name)) {
-    static_cast<CElementGen*>(static_cast<CParticleGenInfoGeneric*>(info)->GetParticleSystem().get())
+    std::static_pointer_cast<CElementGen>(static_cast<CParticleGenInfoGeneric*>(info)->GetParticleSystem())
         ->SetExternalVar(idx, value);
   }
 }

--- a/Runtime/Character/CParticleGenInfo.hpp
+++ b/Runtime/Character/CParticleGenInfo.hpp
@@ -106,6 +106,6 @@ public:
   TUniqueId GetLightId() const override;
   void DeleteLight(CStateManager& mgr) override;
   void SetModulationColor(const zeus::CColor& color) override;
-  const std::shared_ptr<CParticleGen> GetParticleSystem() const { return x84_system; }
+  const std::shared_ptr<CParticleGen>& GetParticleSystem() const { return x84_system; }
 };
 } // namespace urde


### PR DESCRIPTION
Previously the particle system shared pointer would always be returned by value, rather than by reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/185)
<!-- Reviewable:end -->
