### PR TITLE
CModelShaders: Make EExtendedShader an enum class

### DIFF
--- a/Runtime/Graphics/CModelBoo.cpp
+++ b/Runtime/Graphics/CModelBoo.cpp
@@ -359,7 +359,7 @@ CBooModel::ModelInstance* CBooModel::PushNewModelInstance(int sharedLayoutBuf) {
       std::vector<boo::ObjToken<boo::IShaderDataBinding>>& extendeds = newInst.m_shaderDataBindings.back();
       extendeds.reserve(pipelines->size());
 
-      int idx = 0;
+      EExtendedShader idx{};
       for (const auto& pipeline : *pipelines) {
         if (idx == EExtendedShader::Thermal) {
           texs[8] = g_Renderer->x220_sphereRamp.get();
@@ -387,7 +387,7 @@ CBooModel::ModelInstance* CBooModel::PushNewModelInstance(int sharedLayoutBuf) {
         extendeds.push_back(ctx.newShaderDataBinding(pipeline, newInst.GetBooVBO(*this, ctx), nullptr,
                                                      m_staticIbo.get(), 4, bufs, stages, thisOffs, thisSizes, 12, texs,
                                                      nullptr, nullptr));
-        ++idx;
+        idx = EExtendedShader(size_t(idx) + 1);
       }
     }
     return true;

--- a/Runtime/Graphics/Shaders/CModelShaders.hpp
+++ b/Runtime/Graphics/Shaders/CModelShaders.hpp
@@ -21,7 +21,7 @@ class ShaderTag;
 namespace urde {
 class CLight;
 
-enum EExtendedShader : uint8_t {
+enum class EExtendedShader : uint8_t {
   Flat,
   Lighting,
   Thermal,
@@ -96,7 +96,7 @@ public:
   static void Initialize();
   static void Shutdown();
 
-  using ShaderPipelinesData = std::array<boo::ObjToken<boo::IShaderPipeline>, EExtendedShader::MAX>;
+  using ShaderPipelinesData = std::array<boo::ObjToken<boo::IShaderPipeline>, size_t(EExtendedShader::MAX)>;
   using ShaderPipelines = std::shared_ptr<ShaderPipelinesData>;
 
   using Material = DataSpec::DNAMP1::HMDLMaterialSet::Material;


### PR DESCRIPTION
Prevents pollution of the urde namespace with general names like `Flat`, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/188)
<!-- Reviewable:end -->
