### PR TITLE
CEyeball: Eliminate unnecessary runtime initializer in Think() 

### DIFF
--- a/Runtime/MP1/World/CEyeball.cpp
+++ b/Runtime/MP1/World/CEyeball.cpp
@@ -83,17 +83,22 @@ void CEyeball::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateMa
   CPatterned::AcceptScriptMsg(msg, uid, mgr);
 }
 
-static float kMinAngle = std::cos(zeus::degToRad(45.f));
 void CEyeball::Think(float dt, CStateManager& mgr) {
   CPatterned::Think(dt, mgr);
-  if (!GetActive())
-    return;
 
-  CPlayer& player = mgr.GetPlayer();
-  zeus::CVector3f direction = (player.GetTranslation() - GetTranslation()).normalized();
+  if (!GetActive()) {
+    return;
+  }
+
+  const CPlayer& player = mgr.GetPlayer();
+  const zeus::CVector3f direction = (player.GetTranslation() - GetTranslation()).normalized();
+
+  // Used to be directly calculated as std::cos(zeus::degToRad(45.f));
+  // but was converted into the exact constant to avoid unnecessary runtime initialization.
+  constexpr float minAngle = 0.707106769f;
 
   x60c_25_playerInRange = (player.GetMorphballTransitionState() == CPlayer::EPlayerMorphBallState::Morphed &&
-                           direction.dot(GetTransform().frontVector()) > kMinAngle);
+                           direction.dot(GetTransform().frontVector()) > minAngle);
 
   if (x60c_25_playerInRange) {
     x570_boneTracking.SetActive(true);

--- a/Runtime/MP1/World/CEyeball.cpp
+++ b/Runtime/MP1/World/CEyeball.cpp
@@ -107,9 +107,10 @@ void CEyeball::Think(float dt, CStateManager& mgr) {
     x570_boneTracking.Update(dt);
     GetModelData()->GetAnimationData()->PreRender();
     x570_boneTracking.PreRender(mgr, *GetModelData()->GetAnimationData(), GetTransform(), GetModelData()->GetScale(),
-                                *x450_bodyController.get());
-  } else
+                                *x450_bodyController);
+  } else {
     x570_boneTracking.SetActive(false);
+  }
 
   if (GetActive()) {
     CPlasmaProjectile* projectile = static_cast<CPlasmaProjectile*>(mgr.ObjectById(x5ec_projectileId));


### PR DESCRIPTION
We can just fold the result into the constant directly, which allows us to avoid the need for a static runtime initializer. This is bit-exact with what the result would be, so this is fine.

While we're in the same area, we can also eliminate an unnecessary `.get()` call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/192)
<!-- Reviewable:end -->
