### PR TITLE
CSaveableState: Initialize vectors in the constructor initializer list

### DIFF
--- a/Runtime/GuiSys/CSaveableState.hpp
+++ b/Runtime/GuiSys/CSaveableState.hpp
@@ -35,10 +35,7 @@ protected:
   EVerticalJustification x84_vjust = EVerticalJustification::Top;
 
 public:
-  CSaveableState() {
-    x54_colors.resize(3, zeus::skBlack);
-    x64_colorOverrides.resize(16);
-  }
+  CSaveableState() : x54_colors(3, zeus::skBlack), x64_colorOverrides(16) {}
 
   bool IsFinishedLoading() const;
 };


### PR DESCRIPTION
Initializes the vectors in place, rather than constructing them and then resizing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/196)
<!-- Reviewable:end -->
