### PR TITLE
CFontRenderState: Collapse common switch cases in RefreshColor()

### DIFF
--- a/Runtime/GuiSys/CFontRenderState.cpp
+++ b/Runtime/GuiSys/CFontRenderState.cpp
@@ -50,12 +50,10 @@ void CFontRenderState::RefreshColor(EColorType tp) {
       return;
     switch (x48_font->GetMode()) {
     case EColorType::Main:
-      if (!x64_colorOverrides[0])
-        x0_drawStrOpts.x4_colors[0] = ConvertToTextureSpace(x54_colors[0]);
-      break;
     case EColorType::Outline:
-      if (!x64_colorOverrides[0])
+      if (!x64_colorOverrides[0]) {
         x0_drawStrOpts.x4_colors[0] = ConvertToTextureSpace(x54_colors[0]);
+      }
       break;
     default:
       break;


### PR DESCRIPTION
Same behavior, less code.

Unless I'm mistaken, this is identical behaviorally with what the game binary does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/197)
<!-- Reviewable:end -->
