### PR TITLE
CResFactory: Resolve use-after-move in AddToLoadList()

### DIFF
--- a/Runtime/CResFactory.cpp
+++ b/Runtime/CResFactory.cpp
@@ -7,7 +7,8 @@ namespace urde {
 static logvisor::Module Log("CResFactory");
 
 void CResFactory::AddToLoadList(SLoadingData&& data) {
-  m_loadMap[data.x0_tag] = m_loadList.insert(m_loadList.end(), std::move(data));
+  const SObjectTag tag = data.x0_tag;
+  m_loadMap.insert_or_assign(tag, m_loadList.insert(m_loadList.end(), std::move(data)));
 }
 
 CFactoryFnReturn CResFactory::BuildSync(const SObjectTag& tag, const CVParamTransfer& xfer, CObjectReference* selfRef) {


### PR DESCRIPTION
The behavior on the right hand side would occur before the actual assignment, making the tag value invalidated. Instead, we copy the tag before the move is performed to keep the data valid when inserting it into the map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/198)
<!-- Reviewable:end -->
