### PR TITLE
CPVSVisOctree: Use static qualifying name for ReadBoundingBoxBig()

### DIFF
--- a/Runtime/Graphics/CPVSVisOctree.cpp
+++ b/Runtime/Graphics/CPVSVisOctree.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/Graphics/CPVSVisOctree.hpp"
 
+#include <array>
+
 namespace urde {
 
 CPVSVisOctree CPVSVisOctree::MakePVSVisOctree(const u8* data) {
@@ -17,9 +19,10 @@ CPVSVisOctree::CPVSVisOctree(const zeus::CAABox& aabb, u32 numObjects, u32 numLi
   x20_bufferFlag = 0;
 }
 
-static const u32 NumChildTable[] = {0, 2, 2, 4, 2, 4, 4, 8};
-
-u32 CPVSVisOctree::GetNumChildren(u8 byte) const { return NumChildTable[byte & 0x7]; }
+u32 CPVSVisOctree::GetNumChildren(u8 byte) const {
+  static constexpr std::array<u32, 8> numChildTable{0, 2, 2, 4, 2, 4, 4, 8};
+  return numChildTable[byte & 0x7];
+}
 
 u32 CPVSVisOctree::GetChildIndex(const u8*, const zeus::CVector3f&) const { return 0; }
 
@@ -29,7 +32,7 @@ s32 CPVSVisOctree::IterateSearch(u8 nodeData, const zeus::CVector3f& tp) const {
 
   zeus::CVector3f newMin = x2c_searchAabb.center();
   zeus::CVector3f newMax;
-  bool highFlags[3];
+  std::array<bool, 3> highFlags{};
 
   if (tp.x() > newMin.x()) {
     newMax.x() = x2c_searchAabb.max.x();
@@ -58,7 +61,7 @@ s32 CPVSVisOctree::IterateSearch(u8 nodeData, const zeus::CVector3f& tp) const {
     highFlags[2] = false;
   }
 
-  u8 axisCounts[2] = {1, 1};
+  std::array<u8, 2> axisCounts{1, 1};
   if (nodeData & 0x1)
     axisCounts[0] = 2;
   if (nodeData & 0x2)

--- a/Runtime/Graphics/CPVSVisOctree.cpp
+++ b/Runtime/Graphics/CPVSVisOctree.cpp
@@ -4,9 +4,9 @@ namespace urde {
 
 CPVSVisOctree CPVSVisOctree::MakePVSVisOctree(const u8* data) {
   CMemoryInStream r(data, 68);
-  zeus::CAABox aabb = aabb.ReadBoundingBoxBig(r);
-  u32 numObjects = r.readUint32Big();
-  u32 numLights = r.readUint32Big();
+  const zeus::CAABox aabb = zeus::CAABox::ReadBoundingBoxBig(r);
+  const u32 numObjects = r.readUint32Big();
+  const u32 numLights = r.readUint32Big();
   r.readUint32Big();
   return CPVSVisOctree(aabb, numObjects, numLights, data + r.position());
 }

--- a/Runtime/Graphics/CPVSVisOctree.cpp
+++ b/Runtime/Graphics/CPVSVisOctree.cpp
@@ -14,9 +14,13 @@ CPVSVisOctree CPVSVisOctree::MakePVSVisOctree(const u8* data) {
 }
 
 CPVSVisOctree::CPVSVisOctree(const zeus::CAABox& aabb, u32 numObjects, u32 numLights, const u8* c)
-: x0_aabb(aabb), x18_numObjects(numObjects), x1c_numLights(numLights), x20_bufferFlag(c != nullptr), x24_octreeData(c) {
-  x2c_searchAabb = x0_aabb;
-  x20_bufferFlag = 0;
+: x0_aabb(aabb)
+, x18_numObjects(numObjects)
+, x1c_numLights(numLights)
+, x20_bufferFlag(c != nullptr)
+, x24_octreeData(c)
+, x2c_searchAabb(x0_aabb) {
+  x20_bufferFlag = false;
 }
 
 u32 CPVSVisOctree::GetNumChildren(u8 byte) const {

--- a/Runtime/Graphics/CPVSVisOctree.hpp
+++ b/Runtime/Graphics/CPVSVisOctree.hpp
@@ -10,10 +10,10 @@ namespace urde {
 
 class CPVSVisOctree {
   zeus::CAABox x0_aabb;
-  u32 x18_numObjects;
-  u32 x1c_numLights;
-  bool x20_bufferFlag;
-  const u8* x24_octreeData;
+  u32 x18_numObjects = 0;
+  u32 x1c_numLights = 0;
+  bool x20_bufferFlag = false;
+  const u8* x24_octreeData = nullptr;
   zeus::CAABox x2c_searchAabb;
 
 public:


### PR DESCRIPTION
It looks very odd using the name of the object being initialized to call through to a static member function. We can disambiguate this by making use of the qualifying name directly.

While we're in the same area we can do a little bit of tidying up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/199)
<!-- Reviewable:end -->
