### PR TITLE
CToken: Add HasReference() member function

### DIFF
--- a/Runtime/CToken.hpp
+++ b/Runtime/CToken.hpp
@@ -74,7 +74,9 @@ class CToken {
 
 public:
   /* Added to test for non-null state */
-  explicit operator bool() const { return x0_objRef != nullptr; }
+  explicit operator bool() const { return HasReference(); }
+  bool HasReference() const { return x0_objRef != nullptr; }
+
   void Unlock();
   void Lock();
   bool IsLocked() const { return x4_lockHeld; }

--- a/Runtime/Character/CAnimSourceReader.cpp
+++ b/Runtime/Character/CAnimSourceReader.cpp
@@ -10,7 +10,7 @@ namespace urde {
 
 CAnimSourceInfo::CAnimSourceInfo(const TSubAnimTypeToken<CAnimSource>& token) : x4_token(token) {}
 
-bool CAnimSourceInfo::HasPOIData() const { return bool(x4_token->x58_evntData); }
+bool CAnimSourceInfo::HasPOIData() const { return x4_token->x58_evntData.HasReference(); }
 
 const std::vector<CBoolPOINode>& CAnimSourceInfo::GetBoolPOIStream() const { return x4_token->GetBoolPOIStream(); }
 

--- a/Runtime/Character/CFBStreamedCompression.hpp
+++ b/Runtime/Character/CFBStreamedCompression.hpp
@@ -75,7 +75,7 @@ public:
   CCharAnimTime GetAnimationDuration() const { return MainHeader().duration; }
   float GetAverageVelocity() const { return x10_averageVelocity; }
   const zeus::CVector3f& GetRootOffset() const { return x14_rootOffset; }
-  bool HasPOIData() const { return bool(x8_evntToken); }
+  bool HasPOIData() const { return x8_evntToken.HasReference(); }
   const std::vector<CBoolPOINode>& GetBoolPOIStream() const { return x8_evntToken->GetBoolPOIStream(); }
   const std::vector<CInt32POINode>& GetInt32POIStream() const { return x8_evntToken->GetInt32POIStream(); }
   const std::vector<CParticlePOINode>& GetParticlePOIStream() const { return x8_evntToken->GetParticlePOIStream(); }

--- a/Runtime/Character/CModelData.hpp
+++ b/Runtime/Character/CModelData.hpp
@@ -148,16 +148,16 @@ public:
   const zeus::CVector3f& GetScale() const { return x0_scale; }
   void SetScale(const zeus::CVector3f& scale) { x0_scale = scale; }
   bool HasAnimData() const { return x10_animData != nullptr; }
-  bool HasNormalModel() const { return bool(x1c_normalModel); }
+  bool HasNormalModel() const { return x1c_normalModel.HasReference(); }
   bool HasModel(EWhichModel which) const {
     if (x10_animData) {
       switch (which) {
       case EWhichModel::Normal:
         return true;
       case EWhichModel::XRay:
-        return x10_animData->GetXRayModel().operator bool();
+        return x10_animData->GetXRayModel() != nullptr;
       case EWhichModel::Thermal:
-        return x10_animData->GetInfraModel().operator bool();
+        return x10_animData->GetInfraModel() != nullptr;
       default:
         return false;
       }
@@ -165,11 +165,11 @@ public:
 
     switch (which) {
     case EWhichModel::Normal:
-      return bool(x1c_normalModel);
+      return x1c_normalModel.HasReference();
     case EWhichModel::XRay:
-      return bool(x2c_xrayModel);
+      return x2c_xrayModel.HasReference();
     case EWhichModel::Thermal:
-      return bool(x3c_infraModel);
+      return x3c_infraModel.HasReference();
     default:
       return false;
     }


### PR DESCRIPTION
Has the same semantics of operator bool(), but explains at the call site what is actually being tested for in the relation to the object itself.

Aims to make readability slightly better (and removed the need for casts).

I'm open to better naming suggestions as well if this doesn't seem like an adequate name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/201)
<!-- Reviewable:end -->
