### PR TITLE
CStaticRes: Make operator bool explicit

### DIFF
--- a/Runtime/Character/CModelData.hpp
+++ b/Runtime/Character/CModelData.hpp
@@ -32,7 +32,7 @@ public:
 
   CAssetId GetId() const { return x0_cmdlId; }
   const zeus::CVector3f& GetScale() const { return x4_scale; }
-  operator bool() const { return x0_cmdlId != 0; }
+  explicit operator bool() const { return x0_cmdlId != 0; }
 };
 
 class CAnimRes {

--- a/Runtime/Character/CModelData.hpp
+++ b/Runtime/Character/CModelData.hpp
@@ -27,12 +27,12 @@ class CStaticRes {
   zeus::CVector3f x4_scale;
 
 public:
-  constexpr  CStaticRes()=default;
+  constexpr CStaticRes() = default;
   CStaticRes(CAssetId id, const zeus::CVector3f& scale) : x0_cmdlId(id), x4_scale(scale) {}
 
   CAssetId GetId() const { return x0_cmdlId; }
   const zeus::CVector3f& GetScale() const { return x4_scale; }
-  explicit operator bool() const { return x0_cmdlId != 0; }
+  explicit operator bool() const { return x0_cmdlId.IsValid(); }
 };
 
 class CAnimRes {


### PR DESCRIPTION
Prevents potentially error-prone conversions to bool. Similar to the changes recently made to CToken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/202)
<!-- Reviewable:end -->
