### PR TITLE
CBallCamera: Collapse identical switch cases within AvoidGeometry()

### DIFF
--- a/Runtime/Camera/CBallCamera.cpp
+++ b/Runtime/Camera/CBallCamera.cpp
@@ -1004,8 +1004,6 @@ zeus::CVector3f CBallCamera::AvoidGeometry(const zeus::CTransform& xf,
     UpdateColliders(xf, x274_mediumColliders, x2d4_mediumColliderIt, 3, 4.f, nearList, dt, mgr);
     break;
   case 2:
-    UpdateColliders(xf, x284_largeColliders, x2d8_largeColliderIt, 4, 4.f, nearList, dt, mgr);
-    break;
   case 3:
     UpdateColliders(xf, x284_largeColliders, x2d8_largeColliderIt, 4, 4.f, nearList, dt, mgr);
     break;


### PR DESCRIPTION
Same behavior, but less code.

This is identical in behavior to the code within the GM8E v0 binary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/203)
<!-- Reviewable:end -->
