### PR TITLE
Character/*: std::move constructor parameters where applicable

### DIFF
--- a/Runtime/Character/CAnimData.cpp
+++ b/Runtime/Character/CAnimData.cpp
@@ -40,19 +40,19 @@ void CAnimData::FreeCache() {}
 void CAnimData::InitializeCache() {}
 
 CAnimData::CAnimData(CAssetId id, const CCharacterInfo& character, int defaultAnim, int charIdx, bool loop,
-                     const TLockedToken<CCharLayoutInfo>& layout, const TToken<CSkinnedModel>& model,
+                     TLockedToken<CCharLayoutInfo> layout, TToken<CSkinnedModel> model,
                      const std::optional<TToken<CMorphableSkinnedModel>>& iceModel,
-                     const std::weak_ptr<CAnimSysContext>& ctx, const std::shared_ptr<CAnimationManager>& animMgr,
-                     const std::shared_ptr<CTransitionManager>& transMgr,
-                     const TLockedToken<CCharacterFactory>& charFactory, int drawInstCount)
-: x0_charFactory(charFactory)
+                     const std::weak_ptr<CAnimSysContext>& ctx, std::shared_ptr<CAnimationManager> animMgr,
+                     std::shared_ptr<CTransitionManager> transMgr, TLockedToken<CCharacterFactory> charFactory,
+                     int drawInstCount)
+: x0_charFactory(std::move(charFactory))
 , xc_charInfo(character)
-, xcc_layoutData(layout)
-, xd8_modelData(model)
+, xcc_layoutData(std::move(layout))
+, xd8_modelData(std::move(model))
 , xfc_animCtx(ctx.lock())
-, x100_animMgr(animMgr)
+, x100_animMgr(std::move(animMgr))
 , x1d8_selfId(id)
-, x1fc_transMgr(transMgr)
+, x1fc_transMgr(std::move(transMgr))
 , x204_charIdx(charIdx)
 , x208_defaultAnim(defaultAnim)
 , x224_pose(layout->GetSegIdList().GetList().size())
@@ -82,10 +82,11 @@ CAnimData::CAnimData(CAssetId id, const CCharacterInfo& character, int defaultAn
                character.GetCharacterName());
   }
 
-  std::shared_ptr<CAnimTreeNode> treeNode = GetAnimationManager()->GetAnimationTree(
-      character.GetAnimationIndex(defaultAnim), CMetaAnimTreeBuildOrders::NoSpecialOrders());
-  if (treeNode != x1f8_animRoot)
-    x1f8_animRoot = treeNode;
+  auto treeNode = GetAnimationManager()->GetAnimationTree(character.GetAnimationIndex(defaultAnim),
+                                                          CMetaAnimTreeBuildOrders::NoSpecialOrders());
+  if (treeNode != x1f8_animRoot) {
+    x1f8_animRoot = std::move(treeNode);
+  }
 }
 
 void CAnimData::SetParticleEffectState(std::string_view effectName, bool active, CStateManager& mgr) {

--- a/Runtime/Character/CAnimData.hpp
+++ b/Runtime/Character/CAnimData.hpp
@@ -155,11 +155,10 @@ private:
 
 public:
   CAnimData(CAssetId, const CCharacterInfo& character, int defaultAnim, int charIdx, bool loop,
-            const TLockedToken<CCharLayoutInfo>& layout, const TToken<CSkinnedModel>& model,
-            const std::optional<TToken<CMorphableSkinnedModel>>& iceModel,
-            const std::weak_ptr<CAnimSysContext>& ctx, const std::shared_ptr<CAnimationManager>& animMgr,
-            const std::shared_ptr<CTransitionManager>& transMgr, const TLockedToken<CCharacterFactory>& charFactory,
-            int drawInstCount);
+            TLockedToken<CCharLayoutInfo> layout, TToken<CSkinnedModel> model,
+            const std::optional<TToken<CMorphableSkinnedModel>>& iceModel, const std::weak_ptr<CAnimSysContext>& ctx,
+            std::shared_ptr<CAnimationManager> animMgr, std::shared_ptr<CTransitionManager> transMgr,
+            TLockedToken<CCharacterFactory> charFactory, int drawInstCount);
 
   void SetParticleEffectState(std::string_view effectName, bool active, CStateManager& mgr);
   void InitializeEffects(CStateManager&, TAreaId, const zeus::CVector3f&);

--- a/Runtime/Character/CAnimSourceReader.cpp
+++ b/Runtime/Character/CAnimSourceReader.cpp
@@ -8,7 +8,7 @@
 
 namespace urde {
 
-CAnimSourceInfo::CAnimSourceInfo(const TSubAnimTypeToken<CAnimSource>& token) : x4_token(token) {}
+CAnimSourceInfo::CAnimSourceInfo(TSubAnimTypeToken<CAnimSource> token) : x4_token(std::move(token)) {}
 
 bool CAnimSourceInfo::HasPOIData() const { return x4_token->x58_evntData.HasReference(); }
 

--- a/Runtime/Character/CAnimSourceReader.hpp
+++ b/Runtime/Character/CAnimSourceReader.hpp
@@ -28,7 +28,7 @@ class CAnimSourceInfo : public IAnimSourceInfo {
   TSubAnimTypeToken<CAnimSource> x4_token;
 
 public:
-  CAnimSourceInfo(const TSubAnimTypeToken<CAnimSource>& token);
+  explicit CAnimSourceInfo(TSubAnimTypeToken<CAnimSource> token);
   bool HasPOIData() const override;
   const std::vector<CBoolPOINode>& GetBoolPOIStream() const override;
   const std::vector<CInt32POINode>& GetInt32POIStream() const override;

--- a/Runtime/Character/CAnimSysContext.hpp
+++ b/Runtime/Character/CAnimSysContext.hpp
@@ -15,8 +15,8 @@ struct CAnimSysContext {
   std::shared_ptr<CRandom16> x8_random;
   CSimplePool& xc_store;
 
-  CAnimSysContext(const TToken<CTransitionDatabaseGame>& transDB, u32 randomSeed, CSimplePool& store)
-  : x0_transDB(transDB), x8_random(std::make_shared<CRandom16>(randomSeed)), xc_store(store) {}
+  CAnimSysContext(TToken<CTransitionDatabaseGame> transDB, u32 randomSeed, CSimplePool& store)
+  : x0_transDB(std::move(transDB)), x8_random(std::make_shared<CRandom16>(randomSeed)), xc_store(store) {}
 };
 
 } // namespace urde

--- a/Runtime/Character/CAnimTreeAnimReaderContainer.cpp
+++ b/Runtime/Character/CAnimTreeAnimReaderContainer.cpp
@@ -6,7 +6,7 @@ namespace urde {
 
 CAnimTreeAnimReaderContainer::CAnimTreeAnimReaderContainer(std::string_view name, std::shared_ptr<IAnimReader> reader,
                                                            u32 dbIdx)
-: CAnimTreeNode(name), x14_reader(reader), x1c_animDbIdx(dbIdx) {}
+: CAnimTreeNode(name), x14_reader(std::move(reader)), x1c_animDbIdx(dbIdx) {}
 
 u32 CAnimTreeAnimReaderContainer::Depth() const { return 1; }
 

--- a/Runtime/Character/CAnimTreeLoopIn.cpp
+++ b/Runtime/Character/CAnimTreeLoopIn.cpp
@@ -19,13 +19,13 @@ CAnimTreeLoopIn::CAnimTreeLoopIn(const std::weak_ptr<CAnimTreeNode>& a, const st
 , x30_fundamentals(CSequenceHelper(x14_child, x18_nextAnim, animCtx).ComputeSequenceFundamentals()) {}
 
 CAnimTreeLoopIn::CAnimTreeLoopIn(const std::weak_ptr<CAnimTreeNode>& a, const std::weak_ptr<CAnimTreeNode>& b,
-                                 bool didLoopIn, const CAnimSysContext& animCtx, std::string_view name,
-                                 const CSequenceFundamentals& fundamentals, const CCharAnimTime& time)
+                                 bool didLoopIn, CAnimSysContext animCtx, std::string_view name,
+                                 CSequenceFundamentals fundamentals, const CCharAnimTime& time)
 : CAnimTreeSingleChild(a, name)
 , x18_nextAnim(b.lock())
 , x1c_didLoopIn(didLoopIn)
-, x20_animCtx(animCtx)
-, x30_fundamentals(fundamentals)
+, x20_animCtx(std::move(animCtx))
+, x30_fundamentals(std::move(fundamentals))
 , x88_curTime(time) {}
 
 CAnimTreeEffectiveContribution CAnimTreeLoopIn::VGetContributionOfHighestInfluence() const {

--- a/Runtime/Character/CAnimTreeLoopIn.hpp
+++ b/Runtime/Character/CAnimTreeLoopIn.hpp
@@ -23,7 +23,7 @@ public:
   CAnimTreeLoopIn(const std::weak_ptr<CAnimTreeNode>& a, const std::weak_ptr<CAnimTreeNode>& b,
                   const std::weak_ptr<CAnimTreeNode>& c, const CAnimSysContext& animCtx, std::string_view name);
   CAnimTreeLoopIn(const std::weak_ptr<CAnimTreeNode>& a, const std::weak_ptr<CAnimTreeNode>& b, bool didLoopIn,
-                  const CAnimSysContext& animCtx, std::string_view name, const CSequenceFundamentals& fundamentals,
+                  CAnimSysContext animCtx, std::string_view name, CSequenceFundamentals fundamentals,
                   const CCharAnimTime& time);
   CAnimTreeEffectiveContribution VGetContributionOfHighestInfluence() const override;
   bool VSupportsReverseView() const { return false; }

--- a/Runtime/Character/CAnimTreeSequence.cpp
+++ b/Runtime/Character/CAnimTreeSequence.cpp
@@ -6,22 +6,22 @@
 
 namespace urde {
 
-CAnimTreeSequence::CAnimTreeSequence(const std::vector<std::shared_ptr<IMetaAnim>>& seq, const CAnimSysContext& animSys,
+CAnimTreeSequence::CAnimTreeSequence(std::vector<std::shared_ptr<IMetaAnim>> seq, CAnimSysContext animSys,
                                      std::string_view name)
 : CAnimTreeSingleChild(seq[0]->GetAnimationTree(animSys, CMetaAnimTreeBuildOrders::NoSpecialOrders()), name)
-, x18_animCtx(animSys)
-, x28_sequence(seq)
-, x3c_fundamentals(CSequenceHelper(seq, animSys).ComputeSequenceFundamentals())
+, x18_animCtx(std::move(animSys))
+, x28_sequence(std::move(seq))
+, x3c_fundamentals(CSequenceHelper(x28_sequence, x18_animCtx).ComputeSequenceFundamentals())
 , x94_curTime(0.f) {}
 
 CAnimTreeSequence::CAnimTreeSequence(const std::shared_ptr<CAnimTreeNode>& curNode,
-                                     const std::vector<std::shared_ptr<IMetaAnim>>& metaAnims,
-                                     const CAnimSysContext& animSys, std::string_view name,
-                                     const CSequenceFundamentals& fundamentals, const CCharAnimTime& time)
+                                     std::vector<std::shared_ptr<IMetaAnim>> metaAnims,
+                                     CAnimSysContext animSys, std::string_view name,
+                                     CSequenceFundamentals fundamentals, const CCharAnimTime& time)
 : CAnimTreeSingleChild(curNode, name)
-, x18_animCtx(animSys)
-, x28_sequence(metaAnims)
-, x3c_fundamentals(fundamentals)
+, x18_animCtx(std::move(animSys))
+, x28_sequence(std::move(metaAnims))
+, x3c_fundamentals(std::move(fundamentals))
 , x94_curTime(time) {}
 
 CAnimTreeEffectiveContribution CAnimTreeSequence::VGetContributionOfHighestInfluence() const {

--- a/Runtime/Character/CAnimTreeSequence.hpp
+++ b/Runtime/Character/CAnimTreeSequence.hpp
@@ -20,11 +20,10 @@ class CAnimTreeSequence : public CAnimTreeSingleChild {
   CCharAnimTime x94_curTime;
 
 public:
-  CAnimTreeSequence(const std::vector<std::shared_ptr<IMetaAnim>>& seq, const CAnimSysContext& animSys,
-                    std::string_view name);
-  CAnimTreeSequence(const std::shared_ptr<CAnimTreeNode>& curNode,
-                    const std::vector<std::shared_ptr<IMetaAnim>>& metaAnims, const CAnimSysContext& animSys,
-                    std::string_view name, const CSequenceFundamentals& fundamentals, const CCharAnimTime& time);
+  CAnimTreeSequence(std::vector<std::shared_ptr<IMetaAnim>> seq, CAnimSysContext animSys, std::string_view name);
+  CAnimTreeSequence(const std::shared_ptr<CAnimTreeNode>& curNode, std::vector<std::shared_ptr<IMetaAnim>> metaAnims,
+                    CAnimSysContext animSys, std::string_view name, CSequenceFundamentals fundamentals,
+                    const CCharAnimTime& time);
 
   CAnimTreeEffectiveContribution VGetContributionOfHighestInfluence() const override;
   std::shared_ptr<IAnimReader> VGetBestUnblendedChild() const override;

--- a/Runtime/Character/CAnimationManager.hpp
+++ b/Runtime/Character/CAnimationManager.hpp
@@ -19,8 +19,8 @@ class CAnimationManager {
   CAnimSysContext x8_sysCtx;
 
 public:
-  CAnimationManager(const TToken<CAnimationDatabaseGame>& animDB, const CAnimSysContext& sysCtx)
-  : x0_animDB(animDB), x8_sysCtx(sysCtx) {}
+  CAnimationManager(TToken<CAnimationDatabaseGame> animDB, CAnimSysContext sysCtx)
+  : x0_animDB(std::move(animDB)), x8_sysCtx(std::move(sysCtx)) {}
 
   const CAnimationDatabaseGame* GetAnimationDatabase() const;
   std::shared_ptr<CAnimTreeNode> GetAnimationTree(s32, const CMetaAnimTreeBuildOrders& orders) const;

--- a/Runtime/Character/CCharacterFactory.cpp
+++ b/Runtime/Character/CCharacterFactory.cpp
@@ -78,19 +78,20 @@ std::unique_ptr<CAnimData> CCharacterFactory::CreateCharacter(int charIdx, bool 
                                                               const TLockedToken<CCharacterFactory>& factory,
                                                               int defaultAnim, int drawInsts) const {
   const CCharacterInfo& charInfo = x4_charInfoDB[charIdx];
-  CVParamTransfer charParm(new TObjOwnerParam<const CCharacterInfo*>(&charInfo));
+  const CVParamTransfer charParm(new TObjOwnerParam<const CCharacterInfo*>(&charInfo));
 
   TToken<CSkinnedModel> skinnedModel = const_cast<CCharacterFactory*>(this)->x70_cacheResPool.GetObj(
       {FourCC(drawInsts << 16), charInfo.GetModelId()}, charParm);
 
   std::optional<TToken<CMorphableSkinnedModel>> iceModel;
-  if (charInfo.GetIceModelId().IsValid() && charInfo.GetIceSkinRulesId().IsValid())
+  if (charInfo.GetIceModelId().IsValid() && charInfo.GetIceSkinRulesId().IsValid()) {
     iceModel.emplace(const_cast<CCharacterFactory*>(this)->x70_cacheResPool.GetObj(
         {FourCC((drawInsts << 16) | 1), charInfo.GetIceModelId()}, charParm));
+  }
 
   return std::make_unique<CAnimData>(x68_selfId, charInfo, defaultAnim, charIdx, loop, x14_charLayoutInfoDB[charIdx],
-                                     skinnedModel, iceModel, x24_sysContext, x28_animMgr, x2c_transMgr, factory,
-                                     drawInsts);
+                                     std::move(skinnedModel), iceModel, x24_sysContext, x28_animMgr, x2c_transMgr,
+                                     factory, drawInsts);
 }
 
 CAssetId CCharacterFactory::GetEventResourceIdForAnimResourceId(CAssetId id) const {

--- a/Runtime/Character/CFBStreamedAnimReader.hpp
+++ b/Runtime/Character/CFBStreamedAnimReader.hpp
@@ -14,7 +14,7 @@ class TAnimSourceInfo : public IAnimSourceInfo {
   TSubAnimTypeToken<T> x4_token;
 
 public:
-  TAnimSourceInfo(const TSubAnimTypeToken<T>& token) : x4_token(token) {}
+  explicit TAnimSourceInfo(TSubAnimTypeToken<T> token) : x4_token(std::move(token)) {}
   bool HasPOIData() const override { return x4_token->HasPOIData(); }
   const std::vector<CBoolPOINode>& GetBoolPOIStream() const override { return x4_token->GetBoolPOIStream(); }
   const std::vector<CInt32POINode>& GetInt32POIStream() const override { return x4_token->GetInt32POIStream(); }

--- a/Runtime/Character/CSequenceHelper.cpp
+++ b/Runtime/Character/CSequenceHelper.cpp
@@ -10,30 +10,29 @@
 
 namespace urde {
 
-CSequenceFundamentals::CSequenceFundamentals(const CSteadyStateAnimInfo& ssInfo,
-                                             const std::vector<CBoolPOINode>& boolNodes,
-                                             const std::vector<CInt32POINode>& int32Nodes,
-                                             const std::vector<CParticlePOINode>& particleNodes,
-                                             const std::vector<CSoundPOINode>& soundNodes)
+CSequenceFundamentals::CSequenceFundamentals(const CSteadyStateAnimInfo& ssInfo, std::vector<CBoolPOINode> boolNodes,
+                                             std::vector<CInt32POINode> int32Nodes,
+                                             std::vector<CParticlePOINode> particleNodes,
+                                             std::vector<CSoundPOINode> soundNodes)
 : x0_ssInfo(ssInfo)
-, x18_boolNodes(boolNodes)
-, x28_int32Nodes(int32Nodes)
-, x38_particleNodes(particleNodes)
-, x48_soundNodes(soundNodes) {}
+, x18_boolNodes(std::move(boolNodes))
+, x28_int32Nodes(std::move(int32Nodes))
+, x38_particleNodes(std::move(particleNodes))
+, x48_soundNodes(std::move(soundNodes)) {}
 
 CSequenceHelper::CSequenceHelper(const std::shared_ptr<CAnimTreeNode>& a, const std::shared_ptr<CAnimTreeNode>& b,
-                                 const CAnimSysContext& animCtx)
-: x0_animCtx(animCtx) {
+                                 CAnimSysContext animCtx)
+: x0_animCtx(std::move(animCtx)) {
   x10_treeNodes.reserve(2);
   x10_treeNodes.push_back(a);
   x10_treeNodes.push_back(b);
 }
 
-CSequenceHelper::CSequenceHelper(const std::vector<std::shared_ptr<IMetaAnim>>& nodes, const CAnimSysContext& animCtx)
-: x0_animCtx(animCtx) {
+CSequenceHelper::CSequenceHelper(const std::vector<std::shared_ptr<IMetaAnim>>& nodes, CAnimSysContext animCtx)
+: x0_animCtx(std::move(animCtx)) {
   x10_treeNodes.reserve(nodes.size());
   for (const std::shared_ptr<IMetaAnim>& meta : nodes)
-    x10_treeNodes.push_back(meta->GetAnimationTree(animCtx, CMetaAnimTreeBuildOrders::NoSpecialOrders()));
+    x10_treeNodes.push_back(meta->GetAnimationTree(x0_animCtx, CMetaAnimTreeBuildOrders::NoSpecialOrders()));
 }
 
 CSequenceFundamentals CSequenceHelper::ComputeSequenceFundamentals() {

--- a/Runtime/Character/CSequenceHelper.hpp
+++ b/Runtime/Character/CSequenceHelper.hpp
@@ -22,10 +22,9 @@ class CSequenceFundamentals {
   std::vector<CSoundPOINode> x48_soundNodes;
 
 public:
-  CSequenceFundamentals(const CSteadyStateAnimInfo& ssInfo, const std::vector<CBoolPOINode>& boolNodes,
-                        const std::vector<CInt32POINode>& int32Nodes,
-                        const std::vector<CParticlePOINode>& particleNodes,
-                        const std::vector<CSoundPOINode>& soundNodes);
+  CSequenceFundamentals(const CSteadyStateAnimInfo& ssInfo, std::vector<CBoolPOINode> boolNodes,
+                        std::vector<CInt32POINode> int32Nodes, std::vector<CParticlePOINode> particleNodes,
+                        std::vector<CSoundPOINode> soundNodes);
 
   const CSteadyStateAnimInfo& GetSteadyStateAnimInfo() const { return x0_ssInfo; }
   const std::vector<CBoolPOINode>& GetBoolPointsOfInterest() const { return x18_boolNodes; }
@@ -41,8 +40,8 @@ class CSequenceHelper {
 
 public:
   CSequenceHelper(const std::shared_ptr<CAnimTreeNode>& a, const std::shared_ptr<CAnimTreeNode>& b,
-                  const CAnimSysContext& animCtx);
-  CSequenceHelper(const std::vector<std::shared_ptr<IMetaAnim>>& nodes, const CAnimSysContext& animCtx);
+                  CAnimSysContext animCtx);
+  CSequenceHelper(const std::vector<std::shared_ptr<IMetaAnim>>& nodes, CAnimSysContext animCtx);
   CSequenceFundamentals ComputeSequenceFundamentals();
 };
 

--- a/Runtime/Character/CTransitionDatabaseGame.cpp
+++ b/Runtime/Character/CTransitionDatabaseGame.cpp
@@ -11,8 +11,8 @@ namespace urde {
 
 CTransitionDatabaseGame::CTransitionDatabaseGame(const std::vector<CTransition>& transitions,
                                                  const std::vector<CHalfTransition>& halfTransitions,
-                                                 const std::shared_ptr<IMetaTrans>& defaultTrans)
-: x10_defaultTrans(defaultTrans) {
+                                                 std::shared_ptr<IMetaTrans> defaultTrans)
+: x10_defaultTrans(std::move(defaultTrans)) {
   x14_transitions.reserve(transitions.size());
   for (const CTransition& trans : transitions)
     x14_transitions.emplace_back(trans.GetAnimPair(), trans.GetMetaTrans());

--- a/Runtime/Character/CTransitionDatabaseGame.hpp
+++ b/Runtime/Character/CTransitionDatabaseGame.hpp
@@ -18,7 +18,7 @@ class CTransitionDatabaseGame final : public CTransitionDatabase {
 public:
   CTransitionDatabaseGame(const std::vector<CTransition>& transitions,
                           const std::vector<CHalfTransition>& halfTransitions,
-                          const std::shared_ptr<IMetaTrans>& defaultTrans);
+                          std::shared_ptr<IMetaTrans> defaultTrans);
   const std::shared_ptr<IMetaTrans>& GetMetaTrans(u32, u32) const override;
 };
 

--- a/Runtime/Character/CTransitionManager.hpp
+++ b/Runtime/Character/CTransitionManager.hpp
@@ -15,7 +15,7 @@ class CTransitionManager {
   CAnimSysContext x0_animCtx;
 
 public:
-  CTransitionManager(const CAnimSysContext& sysCtx) : x0_animCtx(sysCtx) {}
+  explicit CTransitionManager(CAnimSysContext sysCtx) : x0_animCtx(std::move(sysCtx)) {}
   std::shared_ptr<CAnimTreeNode> GetTransitionTree(const std::shared_ptr<CAnimTreeNode>& a,
                                                    const std::shared_ptr<CAnimTreeNode>& b) const;
 };


### PR DESCRIPTION
Makes the interfaces more flexible by allowing parameters to be moved into if permissible in calling code. This prevents unnecessary copies in some cases and also prevents some avoidable atomic reference count increments and decrements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/204)
<!-- Reviewable:end -->
