### PR TITLE
CFactoryMgr: Minor cleanup

### DIFF
--- a/Runtime/CFactoryMgr.cpp
+++ b/Runtime/CFactoryMgr.cpp
@@ -1,9 +1,22 @@
 #include "Runtime/CFactoryMgr.hpp"
 
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <iterator>
+
 #include "Runtime/CStopwatch.hpp"
 #include "Runtime/IObj.hpp"
 
 namespace urde {
+constexpr std::array TypeTable{
+    FOURCC('CLSN'), FOURCC('CMDL'), FOURCC('CSKR'), FOURCC('ANIM'), FOURCC('CINF'), FOURCC('TXTR'), FOURCC('PLTT'),
+    FOURCC('FONT'), FOURCC('ANCS'), FOURCC('EVNT'), FOURCC('MADF'), FOURCC('MLVL'), FOURCC('MREA'), FOURCC('MAPW'),
+    FOURCC('MAPA'), FOURCC('SAVW'), FOURCC('SAVA'), FOURCC('PART'), FOURCC('WPSC'), FOURCC('SWHC'), FOURCC('DPSC'),
+    FOURCC('ELSC'), FOURCC('CRSC'), FOURCC('AFSM'), FOURCC('DCLN'), FOURCC('AGSC'), FOURCC('ATBL'), FOURCC('CSNG'),
+    FOURCC('STRG'), FOURCC('SCAN'), FOURCC('PATH'), FOURCC('DGRP'), FOURCC('HMAP'), FOURCC('CTWK'), FOURCC('FRME'),
+    FOURCC('HINT'), FOURCC('MAPU'), FOURCC('DUMB'), FOURCC('OIDS'),
+};
 
 CFactoryFnReturn CFactoryMgr::MakeObject(const SObjectTag& tag, urde::CInputStream& in,
                                          const CVParamTransfer& paramXfer, CObjectReference* selfRef) {
@@ -52,24 +65,19 @@ CFactoryFnReturn CFactoryMgr::MakeObjectFromMemory(const SObjectTag& tag, std::u
   }
 }
 
-static const FourCC TypeTable[] = {
-    FOURCC('CLSN'), FOURCC('CMDL'), FOURCC('CSKR'), FOURCC('ANIM'), FOURCC('CINF'), FOURCC('TXTR'), FOURCC('PLTT'),
-    FOURCC('FONT'), FOURCC('ANCS'), FOURCC('EVNT'), FOURCC('MADF'), FOURCC('MLVL'), FOURCC('MREA'), FOURCC('MAPW'),
-    FOURCC('MAPA'), FOURCC('SAVW'), FOURCC('SAVA'), FOURCC('PART'), FOURCC('WPSC'), FOURCC('SWHC'), FOURCC('DPSC'),
-    FOURCC('ELSC'), FOURCC('CRSC'), FOURCC('AFSM'), FOURCC('DCLN'), FOURCC('AGSC'), FOURCC('ATBL'), FOURCC('CSNG'),
-    FOURCC('STRG'), FOURCC('SCAN'), FOURCC('PATH'), FOURCC('DGRP'), FOURCC('HMAP'), FOURCC('CTWK'), FOURCC('FRME'),
-    FOURCC('HINT'), FOURCC('MAPU'), FOURCC('DUMB'), FOURCC('OIDS')};
-
 CFactoryMgr::ETypeTable CFactoryMgr::FourCCToTypeIdx(FourCC fcc) {
-  for (int i = 0; i < 4; ++i)
-    fcc.getChars()[i] = char(toupper(fcc.getChars()[i]));
-  auto search =
-      std::find_if(std::begin(TypeTable), std::end(TypeTable), [fcc](const FourCC& test) { return test == fcc; });
-  if (search == std::end(TypeTable))
+  for (size_t i = 0; i < 4; ++i) {
+    fcc.getChars()[i] = char(std::toupper(fcc.getChars()[i]));
+  }
+
+  const auto search =
+      std::find_if(TypeTable.cbegin(), TypeTable.cend(), [fcc](const FourCC& test) { return test == fcc; });
+  if (search == TypeTable.cend()) {
     return ETypeTable::Invalid;
-  return ETypeTable(search - std::begin(TypeTable));
+  }
+  return ETypeTable(std::distance(TypeTable.cbegin(), search));
 }
 
-FourCC CFactoryMgr::TypeIdxToFourCC(ETypeTable fcc) { return TypeTable[int(fcc)]; }
+FourCC CFactoryMgr::TypeIdxToFourCC(ETypeTable fcc) { return TypeTable[size_t(fcc)]; }
 
 } // namespace urde

--- a/Runtime/CFactoryMgr.cpp
+++ b/Runtime/CFactoryMgr.cpp
@@ -37,30 +37,31 @@ CFactoryFnReturn CFactoryMgr::MakeObjectFromMemory(const SObjectTag& tag, std::u
                                                    CObjectReference* selfRef) {
   std::unique_ptr<u8[]> localBuf = std::move(buf);
 
-  auto search = m_memFactories.find(tag.type);
-  if (search != m_memFactories.cend()) {
+  const auto memFactoryIter = m_memFactories.find(tag.type);
+  if (memFactoryIter != m_memFactories.cend()) {
     if (compressed) {
       std::unique_ptr<CInputStream> compRead = std::make_unique<athena::io::MemoryReader>(localBuf.get(), size);
-      u32 decompLen = compRead->readUint32Big();
+      const u32 decompLen = compRead->readUint32Big();
       CZipInputStream r(std::move(compRead));
       std::unique_ptr<u8[]> decompBuf = r.readUBytes(decompLen);
-      return search->second(tag, std::move(decompBuf), decompLen, paramXfer, selfRef);
+      return memFactoryIter->second(tag, std::move(decompBuf), decompLen, paramXfer, selfRef);
     } else {
-      return search->second(tag, std::move(localBuf), size, paramXfer, selfRef);
+      return memFactoryIter->second(tag, std::move(localBuf), size, paramXfer, selfRef);
     }
   } else {
-    auto search = m_factories.find(tag.type);
-    if (search == m_factories.end())
+    const auto factoryIter = m_factories.find(tag.type);
+    if (factoryIter == m_factories.end()) {
       return {};
+    }
 
     if (compressed) {
       std::unique_ptr<CInputStream> compRead = std::make_unique<athena::io::MemoryReader>(localBuf.get(), size);
       compRead->readUint32Big();
       CZipInputStream r(std::move(compRead));
-      return search->second(tag, r, paramXfer, selfRef);
+      return factoryIter->second(tag, r, paramXfer, selfRef);
     } else {
       CMemoryInStream r(localBuf.get(), size);
-      return search->second(tag, r, paramXfer, selfRef);
+      return factoryIter->second(tag, r, paramXfer, selfRef);
     }
   }
 }

--- a/Runtime/CFactoryMgr.hpp
+++ b/Runtime/CFactoryMgr.hpp
@@ -21,8 +21,8 @@ public:
   bool CanMakeMemory(const urde::SObjectTag& tag) const;
   CFactoryFnReturn MakeObjectFromMemory(const SObjectTag& tag, std::unique_ptr<u8[]>&& buf, int size, bool compressed,
                                         const CVParamTransfer& paramXfer, CObjectReference* selfRef);
-  void AddFactory(FourCC key, FFactoryFunc func) { m_factories[key] = func; }
-  void AddFactory(FourCC key, FMemFactoryFunc func) { m_memFactories[key] = func; }
+  void AddFactory(FourCC key, FFactoryFunc func) { m_factories.insert_or_assign(key, std::move(func)); }
+  void AddFactory(FourCC key, FMemFactoryFunc func) { m_memFactories.insert_or_assign(key, std::move(func)); }
 
   enum class ETypeTable : u8 {
     CLSN,


### PR DESCRIPTION
- `std::move`s `std::function` arguments to `AddFactory()` and also gets rid of unnecessary default construction
- Makes use of `std::array` where applicable
- Resolves a variable shadowing warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/205)
<!-- Reviewable:end -->
