### PR TITLE
CElementGen: Minor cleanup

### DIFF
--- a/Runtime/Graphics/Shaders/CElementGenShaders.cpp
+++ b/Runtime/Graphics/Shaders/CElementGenShaders.cpp
@@ -249,28 +249,28 @@ void CElementGenShaders::BuildShaderDataBinding(boo::IGraphicsDataFactory::Conte
     const std::array<boo::ObjToken<boo::IGraphicsBuffer>, 1> uniforms{gen.m_uniformBuf.get()};
 
     if (regPipeline != nullptr) {
-      for (size_t i = 0; i < std::size(gen.m_normalDataBind); ++i) {
+      for (size_t i = 0; i < gen.m_normalDataBind.size(); ++i) {
         gen.m_normalDataBind[i] =
             ctx.newShaderDataBinding((*regPipeline)[i], nullptr, gen.m_instBuf.get(), nullptr, uniforms.size(),
                                      uniforms.data(), nullptr, texCount, textures.data(), nullptr, nullptr);
       }
     }
     if (regPipelineSub != nullptr) {
-      for (size_t i = 0; i < std::size(gen.m_normalSubDataBind); ++i) {
+      for (size_t i = 0; i < gen.m_normalSubDataBind.size(); ++i) {
         gen.m_normalSubDataBind[i] =
             ctx.newShaderDataBinding((*regPipelineSub)[i], nullptr, gen.m_instBuf.get(), nullptr, uniforms.size(),
                                      uniforms.data(), nullptr, texCount, textures.data(), nullptr, nullptr);
       }
     }
     if (redToAlphaPipeline != nullptr) {
-      for (size_t i = 0; i < std::size(gen.m_redToAlphaDataBind); ++i) {
+      for (size_t i = 0; i < gen.m_redToAlphaDataBind.size(); ++i) {
         gen.m_redToAlphaDataBind[i] =
             ctx.newShaderDataBinding((*redToAlphaPipeline)[i], nullptr, gen.m_instBuf.get(), nullptr, uniforms.size(),
                                      uniforms.data(), nullptr, texCount, textures.data(), nullptr, nullptr);
       }
     }
     if (redToAlphaPipelineSub != nullptr) {
-      for (size_t i = 0; i < std::size(gen.m_redToAlphaSubDataBind); ++i) {
+      for (size_t i = 0; i < gen.m_redToAlphaSubDataBind.size(); ++i) {
         gen.m_redToAlphaSubDataBind[i] = ctx.newShaderDataBinding(
             (*redToAlphaPipelineSub)[i], nullptr, gen.m_instBuf.get(), nullptr, uniforms.size(), uniforms.data(),
             nullptr, texCount, textures.data(), nullptr, nullptr);
@@ -283,14 +283,14 @@ void CElementGenShaders::BuildShaderDataBinding(boo::IGraphicsDataFactory::Conte
     texCount = std::min(texCount, 1);
 
     if (regPipelinePmus != nullptr) {
-      for (size_t i = 0; i < std::size(gen.m_normalDataBindPmus); ++i) {
+      for (size_t i = 0; i < gen.m_normalDataBindPmus.size(); ++i) {
         gen.m_normalDataBindPmus[i] =
             ctx.newShaderDataBinding((*regPipelinePmus)[i], nullptr, gen.m_instBufPmus.get(), nullptr, uniforms.size(),
                                      uniforms.data(), nullptr, texCount, textures.data(), nullptr, nullptr);
       }
     }
     if (redToAlphaPipelinePmus != nullptr) {
-      for (size_t i = 0; i < std::size(gen.m_redToAlphaDataBindPmus); ++i) {
+      for (size_t i = 0; i < gen.m_redToAlphaDataBindPmus.size(); ++i) {
         gen.m_redToAlphaDataBindPmus[i] = ctx.newShaderDataBinding(
             (*redToAlphaPipelinePmus)[i], nullptr, gen.m_instBufPmus.get(), nullptr, uniforms.size(), uniforms.data(),
             nullptr, texCount, textures.data(), nullptr, nullptr);

--- a/Runtime/Particle/CElementGen.cpp
+++ b/Runtime/Particle/CElementGen.cpp
@@ -925,7 +925,7 @@ void CElementGen::RenderModels(const CActorLights* actorLights) {
 
   zeus::CVector3f pmopVec;
   auto matrixIt = x50_parentMatrices.begin();
-  for (int i = 0; i < x30_particles.size(); ++i) {
+  for (size_t i = 0; i < x30_particles.size(); ++i) {
     CParticle& particle = x30_particles[i];
     g_currentParticle = &particle;
 
@@ -1124,7 +1124,7 @@ void CElementGen::RenderLines() {
 
   m_lineRenderer->Reset();
 
-  for (int i = 0; i < x30_particles.size(); ++i) {
+  for (size_t i = 0; i < x30_particles.size(); ++i) {
     CParticle& particle = x30_particles[i];
     g_currentParticle = &particle;
 
@@ -1227,9 +1227,9 @@ void CElementGen::RenderParticles() {
   if (desc->x44_28_x30_28_SORT) {
     sortItems.reserve(x30_particles.size());
 
-    for (int i = 0; i < x30_particles.size(); ++i) {
+    for (size_t i = 0; i < x30_particles.size(); ++i) {
       const CParticle& particle = x30_particles[i];
-      sortItems.emplace_back(i);
+      sortItems.emplace_back(s16(i));
       CParticleListItem& sortItem = sortItems.back();
       sortItem.x4_viewPoint =
           systemCameraMatrix * ((particle.x4_pos - particle.x10_prevPos) * x80_timeDeltaScale + particle.x10_prevPos);
@@ -1303,18 +1303,19 @@ void CElementGen::RenderParticles() {
     }
 
     if (!x26c_29_ORNT) {
-      for (int i = 0; i < x30_particles.size(); ++i) {
-        int partIdx = desc->x44_28_x30_28_SORT ? sortItems[i].x0_partIdx : i;
+      for (size_t i = 0; i < x30_particles.size(); ++i) {
+        const int partIdx = desc->x44_28_x30_28_SORT ? sortItems[i].x0_partIdx : int(i);
         CParticle& particle = x30_particles[partIdx];
         g_currentParticle = &particle;
 
-        int partFrame = x74_curFrame - particle.x28_startFrame - 1;
+        const int partFrame = x74_curFrame - particle.x28_startFrame - 1;
         zeus::CVector3f viewPoint;
-        if (desc->x44_28_x30_28_SORT)
+        if (desc->x44_28_x30_28_SORT) {
           viewPoint = sortItems[i].x4_viewPoint;
-        else
+        } else {
           viewPoint = systemCameraMatrix *
                       ((particle.x4_pos - particle.x10_prevPos) * x80_timeDeltaScale + particle.x10_prevPos);
+        }
 
         if (!constUVs) {
           CParticleGlobals::instance()->SetParticleLifetime(particle.x0_endFrame - particle.x28_startFrame);
@@ -1322,7 +1323,7 @@ void CElementGen::RenderParticles() {
           texr->GetValueUV(partFrame, uvs);
         }
 
-        float size = 0.5f * particle.x2c_lineLengthOrSize;
+        const float size = 0.5f * particle.x2c_lineLengthOrSize;
         if (0.f == particle.x30_lineWidthOrRota) {
           switch (m_shaderClass) {
           case CElementGenShaders::EShaderClass::Tex: {
@@ -1392,15 +1393,15 @@ void CElementGen::RenderParticles() {
         }
       }
     } else {
-      for (int i = 0; i < x30_particles.size(); ++i) {
-        int partIdx = desc->x44_28_x30_28_SORT ? sortItems[i].x0_partIdx : i;
+      for (size_t i = 0; i < x30_particles.size(); ++i) {
+        const int partIdx = desc->x44_28_x30_28_SORT ? sortItems[i].x0_partIdx : int(i);
         CParticle& particle = x30_particles[partIdx];
         g_currentParticle = &particle;
 
-        int partFrame = x74_curFrame - particle.x28_startFrame - 1;
+        const int partFrame = x74_curFrame - particle.x28_startFrame - 1;
         zeus::CVector3f viewPoint =
             ((particle.x4_pos - particle.x10_prevPos) * x80_timeDeltaScale + particle.x10_prevPos);
-        float width = !desc->x50_x3c_ROTA ? 1.f : particle.x30_lineWidthOrRota;
+        const float width = !desc->x50_x3c_ROTA ? 1.f : particle.x30_lineWidthOrRota;
         zeus::CVector3f dir;
         if (particle.x1c_vel.canBeNormalized()) {
           dir = particle.x1c_vel.normalized();
@@ -1495,13 +1496,13 @@ void CElementGen::RenderParticles() {
       Log.report(logvisor::Fatal, fmt("unexpected particle shader class"));
       break;
     }
-    float mbspFac = 1.f / float(mbspVal);
-    for (int i = 0; i < x30_particles.size(); ++i) {
-      int partIdx = desc->x44_28_x30_28_SORT ? sortItems[i].x0_partIdx : i;
+    const float mbspFac = 1.f / float(mbspVal);
+    for (size_t i = 0; i < x30_particles.size(); ++i) {
+      const int partIdx = desc->x44_28_x30_28_SORT ? sortItems[i].x0_partIdx : int(i);
       CParticle& particle = x30_particles[partIdx];
       g_currentParticle = &particle;
 
-      int partFrame = x74_curFrame - particle.x28_startFrame - 1;
+      const int partFrame = x74_curFrame - particle.x28_startFrame - 1;
 
       if (!constUVs) {
         CParticleGlobals::instance()->SetParticleLifetime(particle.x0_endFrame - particle.x28_startFrame);
@@ -1652,9 +1653,9 @@ void CElementGen::RenderParticlesIndirectTexture() {
   if (desc->x44_28_x30_28_SORT) {
     sortItems.reserve(x30_particles.size());
 
-    for (int i = 0; i < x30_particles.size(); ++i) {
+    for (size_t i = 0; i < x30_particles.size(); ++i) {
       const CParticle& particle = x30_particles[i];
-      sortItems.emplace_back(i);
+      sortItems.emplace_back(s16(i));
       CParticleListItem& sortItem = sortItems.back();
       sortItem.x4_viewPoint =
           systemCameraMatrix * ((particle.x4_pos - particle.x10_prevPos) * x80_timeDeltaScale + particle.x10_prevPos);
@@ -1671,18 +1672,19 @@ void CElementGen::RenderParticlesIndirectTexture() {
   if (!x30_particles.empty())
     CGraphics::SetShaderDataBinding(m_normalDataBind[g_Renderer->IsThermalVisorHotPass()]);
 
-  for (int i = 0; i < x30_particles.size(); ++i) {
-    int partIdx = desc->x44_28_x30_28_SORT ? sortItems[i].x0_partIdx : i;
+  for (size_t i = 0; i < x30_particles.size(); ++i) {
+    const int partIdx = desc->x44_28_x30_28_SORT ? sortItems[i].x0_partIdx : int(i);
     CParticle& particle = x30_particles[partIdx];
     g_currentParticle = &particle;
 
-    int thisPartFrame = x74_curFrame - particle.x28_startFrame;
+    const int thisPartFrame = x74_curFrame - particle.x28_startFrame;
     zeus::CVector3f viewPoint;
-    if (desc->x44_28_x30_28_SORT)
+    if (desc->x44_28_x30_28_SORT) {
       viewPoint = sortItems[i].x4_viewPoint;
-    else
+    } else {
       viewPoint =
           systemCameraMatrix * ((particle.x4_pos - particle.x10_prevPos) * x80_timeDeltaScale + particle.x10_prevPos);
+    }
 
     if (!constTexr) {
       CTexture* tex = texr->GetValueTexture(thisPartFrame).GetObj();

--- a/Runtime/Particle/CElementGen.cpp
+++ b/Runtime/Particle/CElementGen.cpp
@@ -53,9 +53,8 @@ void CElementGen::Initialize() {
 
 void CElementGen::Shutdown() { CElementGenShaders::Shutdown(); }
 
-CElementGen::CElementGen(const TToken<CGenDescription>& gen, EModelOrientationType orientType,
-                         EOptionalSystemFlags flags)
-: x1c_genDesc(gen), x2c_orientType(orientType), x27c_randState(x94_randomSeed) {
+CElementGen::CElementGen(TToken<CGenDescription> gen, EModelOrientationType orientType, EOptionalSystemFlags flags)
+: x1c_genDesc(std::move(gen)), x2c_orientType(orientType), x27c_randState(x94_randomSeed) {
   CGenDescription* desc = x1c_genDesc.GetObj();
   x28_loadedGenDesc = desc;
 

--- a/Runtime/Particle/CElementGen.cpp
+++ b/Runtime/Particle/CElementGen.cpp
@@ -786,16 +786,17 @@ void CElementGen::BuildParticleSystemBounds() {
     x2f0_systemBounds.accumulateBounds(aabb);
 }
 
-u32 CElementGen::GetSystemCount() {
+u32 CElementGen::GetSystemCount() const {
   u32 ret = 0;
   for (const std::unique_ptr<CParticleGen>& child : x290_activePartChildren) {
-    if (child->Get4CharId() == FOURCC('PART'))
-      ret += static_cast<CElementGen&>(*child).GetSystemCount();
-    else
+    if (child->Get4CharId() == FOURCC('PART')) {
+      ret += static_cast<const CElementGen&>(*child).GetSystemCount();
+    } else {
       ret += 1;
+    }
   }
 
-  return (ret + (x25c_activeParticleCount != 0));
+  return ret + (x25c_activeParticleCount != 0);
 }
 
 void CElementGen::Render(const CActorLights* actorLights) {

--- a/Runtime/Particle/CElementGen.cpp
+++ b/Runtime/Particle/CElementGen.cpp
@@ -16,7 +16,15 @@
 #define MAX_GLOBAL_PARTICLES 2560
 
 namespace urde {
-static logvisor::Module Log("urde::CElementGen");
+namespace {
+logvisor::Module Log("urde::CElementGen");
+
+constexpr std::array ShadClsSizes{
+    sizeof(SParticleInstanceTex),
+    sizeof(SParticleInstanceIndTex),
+    sizeof(SParticleInstanceNoTex),
+};
+} // Anonymous namespace
 
 u16 CElementGen::g_GlobalSeed = 99;
 bool CElementGen::g_subtractBlend = false;
@@ -44,9 +52,6 @@ void CElementGen::Initialize() {
 }
 
 void CElementGen::Shutdown() { CElementGenShaders::Shutdown(); }
-
-static const size_t ShadClsSizes[] = {sizeof(SParticleInstanceTex), sizeof(SParticleInstanceIndTex),
-                                      sizeof(SParticleInstanceNoTex)};
 
 CElementGen::CElementGen(const TToken<CGenDescription>& gen, EModelOrientationType orientType,
                          EOptionalSystemFlags flags)
@@ -212,11 +217,11 @@ CElementGen::CElementGen(const TToken<CGenDescription>& gen, EModelOrientationTy
 
   CGraphics::CommitResources([&](boo::IGraphicsDataFactory::Context& ctx) {
     if (!x26c_31_LINE) {
-      m_instBuf = ctx.newDynamicBuffer(boo::BufferUse::Vertex, ShadClsSizes[int(m_shaderClass)], maxInsts);
+      m_instBuf = ctx.newDynamicBuffer(boo::BufferUse::Vertex, ShadClsSizes[size_t(m_shaderClass)], maxInsts);
       m_uniformBuf = ctx.newDynamicBuffer(boo::BufferUse::Uniform, sizeof(SParticleUniforms), 1);
     }
     if (desc->x45_24_x31_26_PMUS) {
-      m_instBufPmus = ctx.newDynamicBuffer(boo::BufferUse::Vertex, ShadClsSizes[int(m_shaderClass)], maxInsts);
+      m_instBufPmus = ctx.newDynamicBuffer(boo::BufferUse::Vertex, ShadClsSizes[size_t(m_shaderClass)], maxInsts);
       m_uniformBufPmus = ctx.newDynamicBuffer(boo::BufferUse::Uniform, sizeof(SParticleUniforms), 1);
     }
     CElementGenShaders::BuildShaderDataBinding(ctx, *this);
@@ -366,7 +371,7 @@ void CElementGen::UpdateAdvanceAccessParameters(u32 activeParticleCount, u32 par
     adv8->GetValue(particleFrame, arr[7]);
 }
 
-bool CElementGen::UpdateVelocitySource(u32 idx, u32 particleFrame, CParticle& particle) {
+bool CElementGen::UpdateVelocitySource(size_t idx, u32 particleFrame, CParticle& particle) {
   bool err;
   if (x278_hasVMD[idx]) {
     zeus::CVector3f localVel = x208_orientationInverse * particle.x1c_vel;
@@ -433,9 +438,10 @@ void CElementGen::UpdateExistingParticles() {
 
     ++x25c_activeParticleCount;
 
-    for (int i = 0; i < 4; ++i) {
-      if (!x280_VELSources[i])
+    for (size_t i = 0; i < x280_VELSources.size(); ++i) {
+      if (!x280_VELSources[i]) {
         break;
+      }
       UpdateVelocitySource(i, particleFrame, particle);
     }
 

--- a/Runtime/Particle/CElementGen.hpp
+++ b/Runtime/Particle/CElementGen.hpp
@@ -180,7 +180,7 @@ public:
   void UpdateLightParameters();
   void BuildParticleSystemBounds();
   u32 GetEmitterTime() const { return x74_curFrame; }
-  u32 GetSystemCount();
+  u32 GetSystemCount() const;
   u32 GetCumulativeParticleCount() const { return x260_cumulativeParticles; }
   u32 GetParticleCountAllInternal() const;
   u32 GetParticleCountAll() const { return x264_recursiveParticleCount; }

--- a/Runtime/Particle/CElementGen.hpp
+++ b/Runtime/Particle/CElementGen.hpp
@@ -68,7 +68,7 @@ private:
   int m_maxMAXP = 256;
   u16 x94_randomSeed = g_GlobalSeed;
   float x98_generatorRate = 1.f;
-  float x9c_externalVars[16] = {};
+  std::array<float, 16> x9c_externalVars{};
 
   zeus::CVector3f xdc_translation;
   zeus::CVector3f xe8_globalTranslation;
@@ -110,9 +110,9 @@ private:
   int x270_MBSP = 0;
   int m_maxMBSP = 0;
   ERglLightBits x274_backupLightActive = ERglLightBits::None;
-  bool x278_hasVMD[4] = {};
+  std::array<bool, 4> x278_hasVMD{};
   CRandom16 x27c_randState;
-  CModVectorElement* x280_VELSources[4] = {};
+  std::array<CModVectorElement*, 4> x280_VELSources{};
 
   std::vector<std::unique_ptr<CParticleGen>> x290_activePartChildren;
   int x2a0_CSSD = 0;
@@ -148,15 +148,15 @@ public:
               EOptionalSystemFlags flags = EOptionalSystemFlags::One);
   ~CElementGen() override;
 
-  boo::ObjToken<boo::IShaderDataBinding> m_normalDataBind[2];
-  boo::ObjToken<boo::IShaderDataBinding> m_normalSubDataBind[2];
-  boo::ObjToken<boo::IShaderDataBinding> m_redToAlphaDataBind[2];
-  boo::ObjToken<boo::IShaderDataBinding> m_redToAlphaSubDataBind[2];
+  std::array<boo::ObjToken<boo::IShaderDataBinding>, 2> m_normalDataBind;
+  std::array<boo::ObjToken<boo::IShaderDataBinding>, 2> m_normalSubDataBind;
+  std::array<boo::ObjToken<boo::IShaderDataBinding>, 2> m_redToAlphaDataBind;
+  std::array<boo::ObjToken<boo::IShaderDataBinding>, 2> m_redToAlphaSubDataBind;
   boo::ObjToken<boo::IGraphicsBufferD> m_instBuf;
   boo::ObjToken<boo::IGraphicsBufferD> m_uniformBuf;
 
-  boo::ObjToken<boo::IShaderDataBinding> m_normalDataBindPmus[2];
-  boo::ObjToken<boo::IShaderDataBinding> m_redToAlphaDataBindPmus[2];
+  std::array<boo::ObjToken<boo::IShaderDataBinding>, 2> m_normalDataBindPmus;
+  std::array<boo::ObjToken<boo::IShaderDataBinding>, 2> m_redToAlphaDataBindPmus;
   boo::ObjToken<boo::IGraphicsBufferD> m_instBufPmus;
   boo::ObjToken<boo::IGraphicsBufferD> m_uniformBufPmus;
 
@@ -171,7 +171,7 @@ public:
   static void Shutdown();
 
   void UpdateAdvanceAccessParameters(u32 activeParticleCount, u32 particleFrame);
-  bool UpdateVelocitySource(u32 idx, u32 particleFrame, CParticle& particle);
+  bool UpdateVelocitySource(size_t idx, u32 particleFrame, CParticle& particle);
   void UpdateExistingParticles();
   void CreateNewParticles(int);
   void UpdatePSTranslationAndOrientation();

--- a/Runtime/Particle/CElementGen.hpp
+++ b/Runtime/Particle/CElementGen.hpp
@@ -144,8 +144,8 @@ private:
   void AccumulateBounds(const zeus::CVector3f& pos, float size);
 
 public:
-  CElementGen(const TToken<CGenDescription>& gen, EModelOrientationType orientType = EModelOrientationType::Normal,
-              EOptionalSystemFlags flags = EOptionalSystemFlags::One);
+  explicit CElementGen(TToken<CGenDescription> gen, EModelOrientationType orientType = EModelOrientationType::Normal,
+                       EOptionalSystemFlags flags = EOptionalSystemFlags::One);
   ~CElementGen() override;
 
   std::array<boo::ObjToken<boo::IShaderDataBinding>, 2> m_normalDataBind;

--- a/Runtime/Particle/CElementGen.hpp
+++ b/Runtime/Particle/CElementGen.hpp
@@ -19,13 +19,13 @@
 #include <zeus/CVector3f.hpp>
 
 namespace urde {
-class CWarp;
-class CLight;
-class IGenDescription;
-class CGenDescription;
-class CParticleSwoosh;
-class CParticleElectric;
 class CActorLights;
+class CGenDescription;
+class CLight;
+class CParticleElectric;
+class CParticleSwoosh;
+class CWarp;
+class IGenDescription;
 
 class CElementGen : public CParticleGen {
   static u16 g_GlobalSeed;


### PR DESCRIPTION
- Makes the use of `std::array` more consistent.
- Resolves avoidable implicit sign-conversion warnings
- Makes `GetSystemCount()` a const member function
- `std::move`s the TToken instance in the constructor to allow calling code to move into it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/206)
<!-- Reviewable:end -->
