### PR TITLE
CElectricBeamProjectile: Remove unnecessary get() calls in PreRender()

### DIFF
--- a/Runtime/Weapon/CElectricBeamProjectile.cpp
+++ b/Runtime/Weapon/CElectricBeamProjectile.cpp
@@ -42,8 +42,8 @@ void CElectricBeamProjectile::PreRender(CStateManager&, const zeus::CFrustum&) {
   if (!GetActive())
     return;
 
-  g_Renderer->AddParticleGen(*x478_elementGen.get());
-  g_Renderer->AddParticleGen(*x468_electric.get());
+  g_Renderer->AddParticleGen(*x478_elementGen);
+  g_Renderer->AddParticleGen(*x468_electric);
 }
 
 void CElectricBeamProjectile::UpdateFx(const zeus::CTransform& xf, float dt, CStateManager& mgr) {


### PR DESCRIPTION
Same behavior, less code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/207)
<!-- Reviewable:end -->
