### PR TITLE
CWaveBuster: Implement GetTouchBounds()

### DIFF
--- a/Runtime/Weapon/CWaveBuster.cpp
+++ b/Runtime/Weapon/CWaveBuster.cpp
@@ -37,4 +37,12 @@ void CWaveBuster::ResetBeam(bool deactivate) {}
 
 void CWaveBuster::SetNewTarget(TUniqueId id) {}
 
+std::optional<zeus::CAABox> CWaveBuster::GetTouchBounds() const {
+  if (x3d0_28_) {
+    return std::nullopt;
+  }
+
+  return GetProjectileBounds();
+}
+
 } // namespace urde

--- a/Runtime/Weapon/CWaveBuster.hpp
+++ b/Runtime/Weapon/CWaveBuster.hpp
@@ -54,6 +54,8 @@ public:
   void UpdateFx(const zeus::CTransform& xf, float dt, CStateManager& mgr);
   void ResetBeam(bool deactivate);
   void SetNewTarget(TUniqueId id);
+
+  std::optional<zeus::CAABox> GetTouchBounds() const override;
 };
 
 } // namespace urde


### PR DESCRIPTION
Implements GetTouchBounds() according to the implementation within the GM8E v0 binary.

Fills out the implementation of CWaveBuster a little bit, getting rid of some low-hanging fruit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/208)
<!-- Reviewable:end -->
