### PR TITLE
CPlayerCameraBob: Minor cleanup

### DIFF
--- a/Runtime/Weapon/CPlayerGun.cpp
+++ b/Runtime/Weapon/CPlayerGun.cpp
@@ -29,9 +29,8 @@ float CPlayerGun::skTractorBeamFactor = 0.5f / CPlayerState::GetMissileComboChar
 CPlayerGun::CPlayerGun(TUniqueId playerId)
 : x0_lights(8, zeus::CVector3f{-30.f, 0.f, 30.f}, 4, 4, 0, 0, 0, 0.1f)
 , x538_playerId(playerId)
-, x550_camBob(CPlayerCameraBob::ECameraBobType::One,
-              zeus::CVector2f(CPlayerCameraBob::kCameraBobExtentX, CPlayerCameraBob::kCameraBobExtentY),
-              CPlayerCameraBob::kCameraBobPeriod)
+, x550_camBob(CPlayerCameraBob::ECameraBobType::One, CPlayerCameraBob::GetCameraBobExtent(),
+              CPlayerCameraBob::GetCameraBobPeriod())
 , x678_morph(g_tweakPlayerGun->GetGunTransformTime(), g_tweakPlayerGun->GetHoloHoldTime())
 , x6c8_hologramClipCube(zeus::CVector3f(-0.29329199f, 0.f, -0.2481945f),
                         zeus::CVector3f(0.29329199f, 1.292392f, 0.2481945f))

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -225,10 +225,9 @@ CPlayer::CPlayer(TUniqueId uid, const zeus::CTransform& xf, const zeus::CAABox& 
   x490_gun = std::make_unique<CPlayerGun>(uid);
   x49c_gunHolsterRemTime = g_tweakPlayerGun->GetGunNotFiringTime();
   x4a0_failsafeTest = std::make_unique<CFailsafeTest>();
-  x76c_cameraBob.reset(
-      new CPlayerCameraBob(CPlayerCameraBob::ECameraBobType::One,
-                           zeus::CVector2f{CPlayerCameraBob::kCameraBobExtentX, CPlayerCameraBob::kCameraBobExtentY},
-                           CPlayerCameraBob::kCameraBobPeriod));
+  x76c_cameraBob.reset(new CPlayerCameraBob(CPlayerCameraBob::ECameraBobType::One,
+                                            CPlayerCameraBob::GetCameraBobExtent(),
+                                            CPlayerCameraBob::GetCameraBobPeriod()));
   x9c4_26_ = true;
   x9c4_27_canEnterMorphBall = true;
   x9c4_28_canLeaveMorphBall = true;
@@ -722,8 +721,8 @@ float CPlayer::UpdateCameraBob(float dt, CStateManager& mgr) {
     const float strafeDist =
         skStrafeDistances[size_t(x2b0_outOfWaterTicks == 2 ? x2ac_surfaceRestraint : ESurfaceRestraints::Water)];
     bobMag = std::min(std::sqrt(f30 * f30 + f29 * f29) / std::sqrt(strafeDist * strafeDist + maxVel * maxVel) *
-                          CPlayerCameraBob::kOrbitBobScale,
-                      CPlayerCameraBob::kMaxOrbitBobScale);
+                          CPlayerCameraBob::GetOrbitBobScale(),
+                      CPlayerCameraBob::GetMaxOrbitBobScale());
     if (bobMag < 0.01f)
       bobMag = 0.f;
   }
@@ -770,8 +769,8 @@ float CPlayer::UpdateCameraBob(float dt, CStateManager& mgr) {
   x76c_cameraBob->SetPlayerVelocity(backupVel);
   x76c_cameraBob->SetState(state, mgr);
   x76c_cameraBob->SetBobMagnitude(bobMag);
-  x76c_cameraBob->SetBobTimeScale((1.f - CPlayerCameraBob::kSlowSpeedPeriodScale) * bobMag +
-                                  CPlayerCameraBob::kSlowSpeedPeriodScale);
+  x76c_cameraBob->SetBobTimeScale((1.f - CPlayerCameraBob::GetSlowSpeedPeriodScale()) * bobMag +
+                                  CPlayerCameraBob::GetSlowSpeedPeriodScale());
   x76c_cameraBob->Update(dt, mgr);
 
   return bobMag;
@@ -799,9 +798,9 @@ void CPlayer::PostUpdate(float dt, CStateManager& mgr) {
 
   float cameraBobT = 0.f;
   if (mgr.GetCameraManager()->IsInCinematicCamera()) {
-    const zeus::CVector2f bobExtent(CPlayerCameraBob::kCameraBobExtentX, CPlayerCameraBob::kCameraBobExtentY);
-    x76c_cameraBob = std::make_unique<CPlayerCameraBob>(CPlayerCameraBob::ECameraBobType::One, bobExtent,
-                                                        CPlayerCameraBob::kCameraBobPeriod);
+    x76c_cameraBob = std::make_unique<CPlayerCameraBob>(CPlayerCameraBob::ECameraBobType::One,
+                                                        CPlayerCameraBob::GetCameraBobExtent(),
+                                                        CPlayerCameraBob::GetCameraBobPeriod());
   } else {
     cameraBobT = UpdateCameraBob(dt, mgr);
   }

--- a/Runtime/World/CPlayerCameraBob.cpp
+++ b/Runtime/World/CPlayerCameraBob.cpp
@@ -29,7 +29,7 @@ const float CPlayerCameraBob::kCameraDamping = 6.f * std::sqrt(80.f);
 
 CPlayerCameraBob::CPlayerCameraBob(ECameraBobType type, const zeus::CVector2f& vec, float bobPeriod)
 : x0_type(type), x4_vec(vec), xc_bobPeriod(bobPeriod) {
-  std::fill(std::begin(x7c_wanderPoints), std::end(x7c_wanderPoints), zeus::skForward);
+  x7c_wanderPoints.fill(zeus::skForward);
 }
 
 zeus::CTransform CPlayerCameraBob::GetViewWanderTransform() const { return xd0_viewWanderXf; }

--- a/Runtime/World/CPlayerCameraBob.hpp
+++ b/Runtime/World/CPlayerCameraBob.hpp
@@ -27,6 +27,13 @@ public:
     Unspecified
   };
 
+  static zeus::CVector2f GetCameraBobExtent() { return {kCameraBobExtentX, kCameraBobExtentY}; }
+  static float GetCameraBobPeriod() { return kCameraBobPeriod; }
+  static float GetOrbitBobScale() { return kOrbitBobScale; }
+  static float GetMaxOrbitBobScale() { return kMaxOrbitBobScale; }
+  static float GetSlowSpeedPeriodScale() { return kSlowSpeedPeriodScale; }
+
+private:
   static float kCameraBobExtentX;
   static float kCameraBobExtentY;
   static float kCameraBobPeriod;
@@ -46,7 +53,6 @@ public:
   static const float kLandingBobDamping2;
   static const float kCameraDamping;
 
-private:
   ECameraBobType x0_type;
   zeus::CVector2f x4_vec;
   float xc_bobPeriod;

--- a/Runtime/World/CPlayerCameraBob.hpp
+++ b/Runtime/World/CPlayerCameraBob.hpp
@@ -65,8 +65,8 @@ private:
   float x70_landingTranslation = 0.f;
   float x74_camVelocity = 0.f;
   float x78_camTranslation = 0.f;
-  zeus::CVector3f x7c_wanderPoints[4];
-  float xb0_wanderPitches[4] = {};
+  std::array<zeus::CVector3f, 4> x7c_wanderPoints;
+  std::array<float, 4> xb0_wanderPitches{};
   float xc4_wanderTime = 0.f;
   float xc8_viewWanderSpeed = kViewWanderSpeedMin;
   u32 xcc_wanderIndex = 0;


### PR DESCRIPTION
- Makes use of `std::array` where applicable
- Makes static data members private. Many of them aren't even used outside of the class. Prevents accidental modification of the values across refactors, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/210)
<!-- Reviewable:end -->
