### PR TITLE
CPlayerEnergyDrain: Initialize x10_energyDrainTime on construction

### DIFF
--- a/Runtime/World/CPlayer.hpp
+++ b/Runtime/World/CPlayer.hpp
@@ -138,7 +138,7 @@ private:
   std::vector<CToken> x25c_ballTransitionsRes;
   TUniqueId x26c_attachedActor = kInvalidUniqueId;
   float x270_attachedActorTime = 0.f;
-  CPlayerEnergyDrain x274_energyDrain = CPlayerEnergyDrain(4);
+  CPlayerEnergyDrain x274_energyDrain{4};
   float x288_startingJumpTimeout = 0.f;
   float x28c_sjTimer = 0.f;
   float x290_minJumpTimeout = 0.f;

--- a/Runtime/World/CPlayerEnergyDrain.cpp
+++ b/Runtime/World/CPlayerEnergyDrain.cpp
@@ -4,7 +4,7 @@
 
 namespace urde {
 
-CPlayerEnergyDrain::CPlayerEnergyDrain(u32 capacity) { x0_sources.reserve(capacity); }
+CPlayerEnergyDrain::CPlayerEnergyDrain(u32 numSources) { x0_sources.reserve(numSources); }
 
 void CPlayerEnergyDrain::AddEnergyDrainSource(TUniqueId id, float intensity) { x0_sources.emplace_back(id, intensity); }
 

--- a/Runtime/World/CPlayerEnergyDrain.hpp
+++ b/Runtime/World/CPlayerEnergyDrain.hpp
@@ -9,7 +9,7 @@ namespace urde {
 class CStateManager;
 class CPlayerEnergyDrain {
   std::vector<CEnergyDrainSource> x0_sources;
-  float x10_energyDrainTime;
+  float x10_energyDrainTime = 0.0f;
 
 public:
   CPlayerEnergyDrain(u32);

--- a/Runtime/World/CPlayerEnergyDrain.hpp
+++ b/Runtime/World/CPlayerEnergyDrain.hpp
@@ -12,7 +12,7 @@ class CPlayerEnergyDrain {
   float x10_energyDrainTime = 0.0f;
 
 public:
-  CPlayerEnergyDrain(u32);
+  explicit CPlayerEnergyDrain(u32 numSources);
   const std::vector<CEnergyDrainSource>& GetEnergyDrainSources() const { return x0_sources; }
   void AddEnergyDrainSource(TUniqueId, float);
   void RemoveEnergyDrainSource(TUniqueId id);


### PR DESCRIPTION
GM8E v0 initializes this to zero when constructing the class. This also makes the entire class have a consistent initial state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/211)
<!-- Reviewable:end -->
