### PR TITLE
CPowerBomb: Make kFadeColor internally linked

### DIFF
--- a/Runtime/Weapon/CPowerBomb.cpp
+++ b/Runtime/Weapon/CPowerBomb.cpp
@@ -12,9 +12,10 @@
 
 #include "TCastTo.hpp" // Generated file, do not modify include path
 
-namespace urde {
+#include <zeus/CColor.hpp>
 
-const zeus::CColor CPowerBomb::kFadeColor(COLOR(0xffffff7));
+namespace urde {
+constexpr zeus::CColor kFadeColor(COLOR(0xffffff7));
 
 CPowerBomb::CPowerBomb(const TToken<CGenDescription>& particle, TUniqueId uid, TAreaId aid, TUniqueId playerId,
                        const zeus::CTransform& xf, const CDamageInfo& dInfo)

--- a/Runtime/Weapon/CPowerBomb.hpp
+++ b/Runtime/Weapon/CPowerBomb.hpp
@@ -7,13 +7,11 @@
 #include "Runtime/Weapon/CWeapon.hpp"
 
 #include <zeus/CAABox.hpp>
-#include <zeus/CColor.hpp>
 
 namespace urde {
 class CElementGen;
 
 class CPowerBomb : public CWeapon {
-  static const zeus::CColor kFadeColor;
   bool x158_24_canStartFilter : 1;
   bool x158_25_filterEnabled : 1;
   float x15c_curTime = 0.f;


### PR DESCRIPTION
Hides the name from external view entirely and allows the color instance to be constexpr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/212)
<!-- Reviewable:end -->
