### PR TITLE
CGunWeapon: Make destructor virtual

### DIFF
--- a/Runtime/Weapon/CGunWeapon.cpp
+++ b/Runtime/Weapon/CGunWeapon.cpp
@@ -75,6 +75,8 @@ CGunWeapon::CGunWeapon(CAssetId ancsId, EWeaponType type, TUniqueId playerId, EM
   BuildDependencyList(x200_beamId);
 }
 
+CGunWeapon::~CGunWeapon() = default;
+
 void CGunWeapon::AllocResPools(CPlayerState::EBeamId beam) {
   const auto& wPair = g_tweakGunRes->GetWeaponPair(beam);
   const char* const* muzzleNames = &skMuzzleNames[size_t(beam) * 2];

--- a/Runtime/Weapon/CGunWeapon.hpp
+++ b/Runtime/Weapon/CGunWeapon.hpp
@@ -116,6 +116,8 @@ protected:
 public:
   CGunWeapon(CAssetId ancsId, EWeaponType type, TUniqueId playerId, EMaterialTypes playerMaterial,
              const zeus::CVector3f& scale);
+  virtual ~CGunWeapon();
+
   void AsyncLoadSuitArm(CStateManager& mgr);
   virtual void Reset(CStateManager& mgr);
   virtual void PlayAnim(NWeaponTypes::EGunAnimType type, bool loop);


### PR DESCRIPTION
This class is used as polymorphic type, so the destructor should be marked as virtual to prevent any potential undefined behavior.

This also more closely matches the GM8E v0 binary itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/214)
<!-- Reviewable:end -->
