### PR TITLE
CFrontEndUI: Default initialize SFrontEndFrame's x4_action to EAction::None

### DIFF
--- a/Runtime/MP1/CFrontEndUI.hpp
+++ b/Runtime/MP1/CFrontEndUI.hpp
@@ -225,7 +225,7 @@ public:
     enum class EAction { None, StartGame, FusionBonus, GameOptions, SlideShow };
 
     u32 x0_rnd;
-    EAction x4_action;
+    EAction x4_action = EAction::None;
     TLockedToken<CGuiFrame> x8_frme;
     CGuiFrame* x14_loadedFrme = nullptr;
     CGuiTableGroup* x18_tablegroup_mainmenu = nullptr;


### PR DESCRIPTION
This is the initial value that GM8E v0 assigns to this member variable. Previously it was being left uninitialized on construction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/215)
<!-- Reviewable:end -->
