### PR TITLE
CLineRenderer: Silence -Wmaybe-uninitialized warning

### DIFF
--- a/Runtime/Graphics/CLineRenderer.cpp
+++ b/Runtime/Graphics/CLineRenderer.cpp
@@ -29,7 +29,7 @@ CLineRenderer::CLineRenderer(boo::IGraphicsDataFactory::Context& ctx, EPrimitive
   }
   m_textured = bool(texture);
 
-  u32 maxTriVerts;
+  u32 maxTriVerts = 0;
   switch (mode) {
   case EPrimitiveMode::Lines:
   case EPrimitiveMode::LineStrip:
@@ -59,7 +59,7 @@ CLineRenderer::CLineRenderer(EPrimitiveMode mode, u32 maxVerts, const boo::ObjTo
   }
   m_textured = bool(texture);
 
-  u32 maxTriVerts;
+  u32 maxTriVerts = 0;
   switch (mode) {
   case EPrimitiveMode::Lines:
   case EPrimitiveMode::LineStrip:


### PR DESCRIPTION
We can just initialize maxTriVerts to zero to prevent warnings from occurring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/216)
<!-- Reviewable:end -->
