### PR TITLE
CHud*: Make use of std::array where applicable

### DIFF
--- a/Runtime/GuiSys/CHudEnergyInterface.cpp
+++ b/Runtime/GuiSys/CHudEnergyInterface.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/GuiSys/CHudEnergyInterface.hpp"
 
+#include <array>
+
 #include "Runtime/GameGlobalObjects.hpp"
 #include "Runtime/Audio/CSfxManager.hpp"
 #include "Runtime/GuiSys/CAuiEnergyBarT01.hpp"
@@ -10,12 +12,15 @@
 
 namespace urde {
 
-static const CAuiEnergyBarT01::FCoordFunc CoordFuncs[] = {
+constexpr std::array<CAuiEnergyBarT01::FCoordFunc, 5> CoordFuncs{
     CHudEnergyInterface::CombatEnergyCoordFunc, CHudEnergyInterface::CombatEnergyCoordFunc,
-    CHudEnergyInterface::XRayEnergyCoordFunc, CHudEnergyInterface::ThermalEnergyCoordFunc,
-    CHudEnergyInterface::BallEnergyCoordFunc};
+    CHudEnergyInterface::XRayEnergyCoordFunc,   CHudEnergyInterface::ThermalEnergyCoordFunc,
+    CHudEnergyInterface::BallEnergyCoordFunc,
+};
 
-static const float Tesselations[] = {0.2f, 0.2f, 0.1f, 0.2f, 1.f};
+constexpr std::array Tesselations{
+    0.2f, 0.2f, 0.1f, 0.2f, 1.f,
+};
 
 CHudEnergyInterface::CHudEnergyInterface(CGuiFrame& selHud, float tankEnergy, int totalEnergyTanks, int numTanksFilled,
                                          bool energyLow, EHudType hudType)
@@ -33,8 +38,8 @@ CHudEnergyInterface::CHudEnergyInterface(CGuiFrame& selHud, float tankEnergy, in
   x28_textpane_energywarning = static_cast<CGuiTextPane*>(selHud.FindWidget("textpane_energywarning"));
   x2c_energybart01_energybar = static_cast<CAuiEnergyBarT01*>(selHud.FindWidget("energybart01_energybar"));
 
-  x2c_energybart01_energybar->SetCoordFunc(CoordFuncs[int(hudType)]);
-  x2c_energybart01_energybar->SetTesselation(Tesselations[int(hudType)]);
+  x2c_energybart01_energybar->SetCoordFunc(CoordFuncs[size_t(hudType)]);
+  x2c_energybart01_energybar->SetTesselation(Tesselations[size_t(hudType)]);
 
   ITweakGuiColors::VisorEnergyBarColors barColors = g_tweakGuiColors->GetVisorEnergyBarColors(int(hudType));
   ITweakGuiColors::VisorEnergyInitColors initColors = g_tweakGuiColors->GetVisorEnergyInitColors(int(hudType));

--- a/Runtime/GuiSys/CHudMissileInterface.cpp
+++ b/Runtime/GuiSys/CHudMissileInterface.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/GuiSys/CHudMissileInterface.hpp"
 
+#include <array>
+
 #include "Runtime/CStateManager.hpp"
 #include "Runtime/GameGlobalObjects.hpp"
 #include "Runtime/GuiSys/CAuiEnergyBarT01.hpp"
@@ -10,11 +12,14 @@
 
 namespace urde {
 
-static const CAuiEnergyBarT01::FCoordFunc CoordFuncs[] = {CHudMissileInterface::CombatMissileBarCoordFunc, nullptr,
-                                                          CHudMissileInterface::XRayMissileBarCoordFunc,
-                                                          CHudMissileInterface::ThermalMissileBarCoordFunc, nullptr};
+constexpr std::array<CAuiEnergyBarT01::FCoordFunc, 5> CoordFuncs{
+    CHudMissileInterface::CombatMissileBarCoordFunc,  nullptr, CHudMissileInterface::XRayMissileBarCoordFunc,
+    CHudMissileInterface::ThermalMissileBarCoordFunc, nullptr,
+};
 
-static const float IconTranslateRanges[] = {6.05f, 0.f, 0.f, 8.4f, 0.f};
+constexpr std::array IconTranslateRanges{
+    6.05f, 0.f, 0.f, 8.4f, 0.f,
+};
 
 CHudMissileInterface::CHudMissileInterface(CGuiFrame& selHud, int missileCapacity, int numMissiles, float chargeFactor,
                                            bool missilesActive, EHudType hudType, const CStateManager& mgr)
@@ -45,7 +50,7 @@ CHudMissileInterface::CHudMissileInterface(CGuiFrame& selHud, int missileCapacit
   x64_energybart01_missilebar->SetEmptyColor(g_tweakGuiColors->GetMissileBarEmpty());
   x64_energybart01_missilebar->SetFilledColor(g_tweakGuiColors->GetMissileBarFilled());
   x64_energybart01_missilebar->SetShadowColor(g_tweakGuiColors->GetMissileBarShadow());
-  x64_energybart01_missilebar->SetCoordFunc(CoordFuncs[int(hudType)]);
+  x64_energybart01_missilebar->SetCoordFunc(CoordFuncs[size_t(hudType)]);
   x64_energybart01_missilebar->SetTesselation(hudType == EHudType::Combat ? 1.f : 0.1f);
   x64_energybart01_missilebar->SetMaxEnergy(5.f);
   x64_energybart01_missilebar->SetFilledDrainSpeed(g_tweakGui->GetEnergyBarFilledSpeed());
@@ -121,8 +126,8 @@ void CHudMissileInterface::Update(float dt, const CStateManager& mgr) {
   if (x58_28_notXRay) {
     x74_basewidget_missileicon->SetLocalTransform(
         x10_missleIconXf *
-        zeus::CTransform::Translate(0.f, 0.f,
-                                    x8_numMissles * IconTranslateRanges[int(x0_hudType)] / float(x4_missileCapacity)));
+        zeus::CTransform::Translate(
+            0.f, 0.f, x8_numMissles * IconTranslateRanges[size_t(x0_hudType)] / float(x4_missileCapacity)));
   }
 
   if (x58_27_hasArrows) {
@@ -236,28 +241,30 @@ CHudMissileInterface::EInventoryStatus CHudMissileInterface::GetMissileInventory
 }
 
 std::pair<zeus::CVector3f, zeus::CVector3f> CHudMissileInterface::CombatMissileBarCoordFunc(float t) {
-  float z = t * IconTranslateRanges[int(EHudType::Combat)];
+  const float z = t * IconTranslateRanges[size_t(EHudType::Combat)];
   return {zeus::CVector3f(0.f, 0.f, z), zeus::CVector3f(0.3f, 0.f, z)};
 }
 
 std::pair<zeus::CVector3f, zeus::CVector3f> CHudMissileInterface::XRayMissileBarCoordFunc(float t) {
-  float theta = 0.8f * (t - 0.5f);
-  float x = 9.55f * std::cos(theta);
-  float z = 9.55f * std::sin(theta);
+  const float theta = 0.8f * (t - 0.5f);
+  const float x = 9.55f * std::cos(theta);
+  const float z = 9.55f * std::sin(theta);
   return {zeus::CVector3f(x - 0.4f, 0.f, z), zeus::CVector3f(x, 0.f, z)};
 }
 
 std::pair<zeus::CVector3f, zeus::CVector3f> CHudMissileInterface::ThermalMissileBarCoordFunc(float t) {
-  float transRange = IconTranslateRanges[int(EHudType::Thermal)];
-  float a = 0.08f * transRange;
-  float b = t * transRange;
+  const float transRange = IconTranslateRanges[size_t(EHudType::Thermal)];
+  const float a = 0.08f * transRange;
+  const float b = t * transRange;
+
   float c;
-  if (b < a)
+  if (b < a) {
     c = b / a;
-  else if (b < transRange - a)
+  } else if (b < transRange - a) {
     c = 1.f;
-  else
+  } else {
     c = 1.f - (b - (transRange - a)) / a;
+  }
 
   return {zeus::CVector3f(-0.5f * c - 0.1f, 0.f, b), zeus::CVector3f(-0.1f, 0.f, b)};
 }

--- a/Runtime/GuiSys/CHudThreatInterface.cpp
+++ b/Runtime/GuiSys/CHudThreatInterface.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/GuiSys/CHudThreatInterface.hpp"
 
+#include <array>
+
 #include "Runtime/GameGlobalObjects.hpp"
 #include "Runtime/GuiSys/CAuiEnergyBarT01.hpp"
 #include "Runtime/GuiSys/CGuiFrame.hpp"
@@ -10,11 +12,14 @@
 
 namespace urde {
 
-static const CAuiEnergyBarT01::FCoordFunc CoordFuncs[] = {CHudThreatInterface::CombatThreatBarCoordFunc, nullptr,
-                                                          CHudThreatInterface::XRayThreatBarCoordFunc,
-                                                          CHudThreatInterface::ThermalThreatBarCoordFunc, nullptr};
+constexpr std::array<CAuiEnergyBarT01::FCoordFunc, 5> CoordFuncs{
+    CHudThreatInterface::CombatThreatBarCoordFunc,  nullptr, CHudThreatInterface::XRayThreatBarCoordFunc,
+    CHudThreatInterface::ThermalThreatBarCoordFunc, nullptr,
+};
 
-static const float IconTranslateRanges[] = {6.05f, 0.f, 0.f, 8.4f, 0.f};
+constexpr std::array IconTranslateRanges{
+    6.05f, 0.f, 0.f, 8.4f, 0.f,
+};
 
 CHudThreatInterface::CHudThreatInterface(CGuiFrame& selHud, EHudType hudType, float threatDist)
 : x4_hudType(hudType), x10_threatDist(threatDist) {
@@ -42,7 +47,7 @@ CHudThreatInterface::CHudThreatInterface(CGuiFrame& selHud, EHudType hudType, fl
   x6c_energybart01_threatbar->SetFilledColor(g_tweakGuiColors->GetThreatBarFilled());
   x6c_energybart01_threatbar->SetShadowColor(g_tweakGuiColors->GetThreatBarShadow());
   x6c_energybart01_threatbar->SetEmptyColor(g_tweakGuiColors->GetThreatBarEmpty());
-  x6c_energybart01_threatbar->SetCoordFunc(CoordFuncs[int(hudType)]);
+  x6c_energybart01_threatbar->SetCoordFunc(CoordFuncs[size_t(hudType)]);
   x6c_energybart01_threatbar->SetTesselation(hudType == EHudType::Combat ? 1.f : 0.1f);
   x6c_energybart01_threatbar->SetMaxEnergy(g_tweakGui->GetThreatRange());
   x6c_energybart01_threatbar->SetFilledDrainSpeed(9999.f);
@@ -133,7 +138,7 @@ void CHudThreatInterface::Update(float dt) {
     x5c_basewidget_threaticon->SetLocalTransform(
         x18_threatIconXf * zeus::CTransform::Translate(0.f, 0.f,
                                                        std::max(0.f, maxThreatEnergy - x10_threatDist) *
-                                                           IconTranslateRanges[int(x4_hudType)] / maxThreatEnergy));
+                                                           IconTranslateRanges[size_t(x4_hudType)] / maxThreatEnergy));
   }
 
   if (x68_textpane_threatwarning) {
@@ -203,28 +208,30 @@ void CHudThreatInterface::Update(float dt) {
 }
 
 std::pair<zeus::CVector3f, zeus::CVector3f> CHudThreatInterface::CombatThreatBarCoordFunc(float t) {
-  float z = IconTranslateRanges[int(EHudType::Combat)] * t;
+  const float z = IconTranslateRanges[size_t(EHudType::Combat)] * t;
   return {zeus::CVector3f(-0.3f, 0.f, z), zeus::CVector3f(0.f, 0.f, z)};
 }
 
 std::pair<zeus::CVector3f, zeus::CVector3f> CHudThreatInterface::XRayThreatBarCoordFunc(float t) {
-  float theta = 0.8f * (t - 0.5f);
-  float x = -9.55f * std::cos(theta);
-  float z = 9.55f * std::sin(theta);
+  const float theta = 0.8f * (t - 0.5f);
+  const float x = -9.55f * std::cos(theta);
+  const float z = 9.55f * std::sin(theta);
   return {zeus::CVector3f(0.4f + x, 0.f, z), zeus::CVector3f(x, 0.f, z)};
 }
 
 std::pair<zeus::CVector3f, zeus::CVector3f> CHudThreatInterface::ThermalThreatBarCoordFunc(float t) {
-  float transRange = IconTranslateRanges[int(EHudType::Thermal)];
-  float a = 0.08f * transRange;
-  float b = t * transRange;
+  const float transRange = IconTranslateRanges[size_t(EHudType::Thermal)];
+  const float a = 0.08f * transRange;
+  const float b = t * transRange;
+
   float c;
-  if (b < a)
+  if (b < a) {
     c = b / a;
-  else if (b < transRange - a)
+  } else if (b < transRange - a) {
     c = 1.f;
-  else
+  } else {
     c = 1.f - (b - (transRange - a)) / a;
+  }
 
   return {zeus::CVector3f(0.1f, 0.f, b), zeus::CVector3f(0.5f * c + 0.1f, 0.f, b)};
 }

--- a/Runtime/GuiSys/CHudVisorBeamMenu.cpp
+++ b/Runtime/GuiSys/CHudVisorBeamMenu.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/GuiSys/CHudVisorBeamMenu.hpp"
 
+#include <array>
+
 #include "Runtime/CGameState.hpp"
 #include "Runtime/GameGlobalObjects.hpp"
 #include "Runtime/Audio/CSfxManager.hpp"
@@ -10,22 +12,40 @@
 
 namespace urde {
 
-static const char* BaseMenuNames[] = {"BaseWidget_VisorMenu", "BaseWidget_BeamMenu"};
-
-static const char* TextNames[] = {"TextPane_VisorMenu", "TextPane_BeamMenu"};
-
-static const char* BaseTitleNames[] = {"basewidget_visormenutitle", "basewidget_beammenutitle"};
-
-static const char* ModelNames[] = {"model_visor", "model_beam"};
-
-static const char MenuItemOrders[2][4] = {{'1', '0', '3', '2'}, {'3', '2', '1', '0'}};
-
-static const int MenuStringIdx[2][4] = {
-    {0, 2, 1, 3}, // Combat, XRay, Scan, Thermal
-    {4, 5, 6, 7}  // Power, Ice, Wave, Plasma
+constexpr std::array BaseMenuNames{
+    "BaseWidget_VisorMenu",
+    "BaseWidget_BeamMenu",
 };
 
-static const u16 SelectionSfxs[] = {SFXui_select_visor, SFXui_select_beam};
+constexpr std::array TextNames{
+    "TextPane_VisorMenu",
+    "TextPane_BeamMenu",
+};
+
+constexpr std::array BaseTitleNames{
+    "basewidget_visormenutitle",
+    "basewidget_beammenutitle",
+};
+
+constexpr std::array ModelNames{
+    "model_visor",
+    "model_beam",
+};
+
+constexpr std::array<std::array<char, 4>, 2> MenuItemOrders{{
+    {'1', '0', '3', '2'},
+    {'3', '2', '1', '0'},
+}};
+
+constexpr std::array<std::array<int, 4>, 2> MenuStringIdx{{
+    {0, 2, 1, 3}, // Combat, XRay, Scan, Thermal
+    {4, 5, 6, 7}, // Power, Ice, Wave, Plasma
+}};
+
+constexpr std::array<u16, 2> SelectionSfxs{
+    SFXui_select_visor,
+    SFXui_select_beam,
+};
 
 CHudVisorBeamMenu::CHudVisorBeamMenu(CGuiFrame& baseHud, EHudVisorBeamMenu type,
                                      const rstl::reserved_vector<bool, 4>& enables)
@@ -43,19 +63,23 @@ CHudVisorBeamMenu::CHudVisorBeamMenu(CGuiFrame& baseHud, EHudVisorBeamMenu type,
   else
     swappedType = x4_type;
 
-  x20_textpane_menu = static_cast<CGuiTextPane*>(x0_baseHud.FindWidget(TextNames[int(swappedType)]));
-  x1c_basewidget_menutitle = x0_baseHud.FindWidget(BaseTitleNames[int(swappedType)]);
-  x18_basewidget_menu = x0_baseHud.FindWidget(BaseMenuNames[int(swappedType)]);
+  x20_textpane_menu = static_cast<CGuiTextPane*>(x0_baseHud.FindWidget(TextNames[size_t(swappedType)]));
+  x1c_basewidget_menutitle = x0_baseHud.FindWidget(BaseTitleNames[size_t(swappedType)]);
+  x18_basewidget_menu = x0_baseHud.FindWidget(BaseMenuNames[size_t(swappedType)]);
 
-  x24_model_ghost = static_cast<CGuiModel*>(x0_baseHud.FindWidget(fmt::format(fmt("{}ghost"), ModelNames[int(x4_type)])));
+  x24_model_ghost =
+      static_cast<CGuiModel*>(x0_baseHud.FindWidget(fmt::format(fmt("{}ghost"), ModelNames[size_t(x4_type)])));
 
   x28_menuItems.resize(4);
-  for (int i = 0; i < 4; ++i) {
+  for (size_t i = 0; i < x28_menuItems.size(); i++) {
+    const auto modelName = ModelNames[size_t(x4_type)];
+    const auto menuItemOrder = MenuItemOrders[size_t(x4_type)][i];
+
     SMenuItem& item = x28_menuItems[i];
-    item.x0_model_loz = static_cast<CGuiModel*>(
-        x0_baseHud.FindWidget(fmt::format(fmt("{}loz{}"), ModelNames[int(x4_type)], MenuItemOrders[int(x4_type)][i])));
-    item.x4_model_icon = static_cast<CGuiModel*>(
-        x0_baseHud.FindWidget(fmt::format(fmt("{}icon{}"), ModelNames[int(x4_type)], MenuItemOrders[int(x4_type)][i])));
+    item.x0_model_loz =
+        static_cast<CGuiModel*>(x0_baseHud.FindWidget(fmt::format(fmt("{}loz{}"), modelName, menuItemOrder)));
+    item.x4_model_icon =
+        static_cast<CGuiModel*>(x0_baseHud.FindWidget(fmt::format(fmt("{}icon{}"), modelName, menuItemOrder)));
     item.xc_opacity = enables[i] ? 1.f : 0.f;
   }
 
@@ -71,7 +95,8 @@ CHudVisorBeamMenu::CHudVisorBeamMenu(CGuiFrame& baseHud, EHudVisorBeamMenu type,
   titleColor.a() = 0.f;
   x1c_basewidget_menutitle->SetColor(titleColor);
 
-  x20_textpane_menu->TextSupport().SetText(g_MainStringTable->GetString(MenuStringIdx[int(x4_type)][x8_selectedItem]));
+  x20_textpane_menu->TextSupport().SetText(
+      g_MainStringTable->GetString(MenuStringIdx[size_t(x4_type)][x8_selectedItem]));
 
   for (int i = 0; i < 4; ++i) {
     SMenuItem& item = x28_menuItems[i];
@@ -130,9 +155,9 @@ void CHudVisorBeamMenu::Update(float dt, bool init) {
     else
       swappedType = x4_type;
 
-    x18_basewidget_menu = x0_baseHud.FindWidget(BaseMenuNames[int(swappedType)]);
-    x20_textpane_menu = static_cast<CGuiTextPane*>(x0_baseHud.FindWidget(TextNames[int(swappedType)]));
-    x1c_basewidget_menutitle = x0_baseHud.FindWidget(BaseTitleNames[int(swappedType)]);
+    x18_basewidget_menu = x0_baseHud.FindWidget(BaseMenuNames[size_t(swappedType)]);
+    x20_textpane_menu = static_cast<CGuiTextPane*>(x0_baseHud.FindWidget(TextNames[size_t(swappedType)]));
+    x1c_basewidget_menutitle = x0_baseHud.FindWidget(BaseTitleNames[size_t(swappedType)]);
 
     for (int i = 0; i < 4; ++i) {
       SMenuItem& item = x28_menuItems[i];
@@ -146,7 +171,7 @@ void CHudVisorBeamMenu::Update(float dt, bool init) {
   zeus::CColor activeColor = g_tweakGuiColors->GetVisorBeamMenuItemActive();
   zeus::CColor inactiveColor = g_tweakGuiColors->GetVisorBeamMenuItemInactive();
   zeus::CColor lozColor = g_tweakGuiColors->GetVisorBeamMenuLozColor();
-  zeus::CColor tmpColors[4];
+  std::array<zeus::CColor, 4> tmpColors;
 
   for (int i = 0; i < 4; ++i) {
     SMenuItem& item = x28_menuItems[i];
@@ -262,13 +287,14 @@ void CHudVisorBeamMenu::SetSelection(int selection, int pending, float interp) {
     return;
 
   if (pending != selection) {
-    if (x6c_animPhase != EAnimPhase::SelectFlash)
-      CSfxManager::SfxStart(SelectionSfxs[int(x4_type)], 1.f, 0.f, false, 0x7f, false, kInvalidAreaId);
+    if (x6c_animPhase != EAnimPhase::SelectFlash) {
+      CSfxManager::SfxStart(SelectionSfxs[size_t(x4_type)], 1.f, 0.f, false, 0x7f, false, kInvalidAreaId);
+    }
     x6c_animPhase = EAnimPhase::SelectFlash;
   } else if (interp < 1.f) {
     x6c_animPhase = EAnimPhase::Animate;
     x20_textpane_menu->TextSupport().SetText(
-        g_MainStringTable->GetString(MenuStringIdx[int(x4_type)][x8_selectedItem]));
+        g_MainStringTable->GetString(MenuStringIdx[size_t(x4_type)][x8_selectedItem]));
     x20_textpane_menu->TextSupport().SetTypeWriteEffectOptions(true, 0.1f, 16.f);
   } else {
     if (x6c_animPhase != EAnimPhase::Steady)


### PR DESCRIPTION
Same behavior, but more strongly typed. While we're at it, we can mark them all as constexpr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/220)
<!-- Reviewable:end -->
