### PR TITLE
CMemoryCardSys: Make CardResult's conversion operator explicit

### DIFF
--- a/Runtime/CMemoryCardSys.hpp
+++ b/Runtime/CMemoryCardSys.hpp
@@ -76,7 +76,7 @@ public:
     ECardResult result;
     CardResult(ECardResult res) : result(res) {}
     operator ECardResult() const { return result; }
-    operator bool() const { return result != ECardResult::READY; }
+    explicit operator bool() const { return result != ECardResult::READY; }
   };
 
   struct CardFileHandle {


### PR DESCRIPTION
Prevents implicit error-prone conversions to bool

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/224)
<!-- Reviewable:end -->
