### PR TITLE
CCharAnimTime: Make constructors constexpr where applicable

### DIFF
--- a/Runtime/Character/CCharAnimTime.cpp
+++ b/Runtime/Character/CCharAnimTime.cpp
@@ -5,10 +5,6 @@
 
 namespace urde {
 
-CCharAnimTime CCharAnimTime::Infinity() {
-  return {EType::Infinity, 1.f};
-}
-
 bool CCharAnimTime::EqualsZero() const {
   if (x4_type == EType::ZeroIncreasing || x4_type == EType::ZeroSteady || x4_type == EType::ZeroDecreasing)
     return true;

--- a/Runtime/Character/CCharAnimTime.hpp
+++ b/Runtime/Character/CCharAnimTime.hpp
@@ -16,13 +16,12 @@ private:
   EType x4_type = EType::ZeroSteady;
 
 public:
-  CCharAnimTime() = default;
-  CCharAnimTime(CInputStream& in) : x0_time(in.readFloatBig()), x4_type(EType(in.readUint32Big())) {}
-  CCharAnimTime(float time) : x0_time(time), x4_type(x0_time != 0.f ? EType::NonZero : EType::ZeroSteady) {}
+  constexpr CCharAnimTime() = default;
+  constexpr CCharAnimTime(float time) : x0_time(time), x4_type(x0_time != 0.f ? EType::NonZero : EType::ZeroSteady) {}
+  constexpr CCharAnimTime(EType type, float t) : x0_time(t), x4_type(type) {}
+  explicit CCharAnimTime(CInputStream& in) : x0_time(in.readFloatBig()), x4_type(EType(in.readUint32Big())) {}
 
-  CCharAnimTime(EType type, const float& t) : x0_time(t), x4_type(type) {}
-
-  static CCharAnimTime Infinity();
+  static constexpr CCharAnimTime Infinity() { return {EType::Infinity, 1.0f}; }
   float GetSeconds() const { return x0_time; }
 
   bool EqualsZero() const;


### PR DESCRIPTION
These can be made constexpr to allow use at compile-time, given these only hold an enum and a floating point value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/228)
<!-- Reviewable:end -->
