### PR TITLE
CPuddleSpore: Make static const class data internally linked

### DIFF
--- a/Runtime/MP1/World/CPuddleSpore.cpp
+++ b/Runtime/MP1/World/CPuddleSpore.cpp
@@ -13,11 +13,14 @@
 #include "TCastTo.hpp" // Generated file, do not modify include path
 
 namespace urde::MP1 {
-const std::string_view CPuddleSpore::kEyeLocators[16] = {
+constexpr u32 kEyeCount = 16;
+
+constexpr std::array kEyeLocators{
     "Glow_1_LCTR"sv,  "Glow_2_LCTR"sv,  "Glow_3_LCTR"sv,  "Glow_4_LCTR"sv,  "Glow_5_LCTR"sv,  "Glow_6_LCTR"sv,
     "Glow_7_LCTR"sv,  "Glow_8_LCTR"sv,  "Glow_9_LCTR"sv,  "Glow_10_LCTR"sv, "Glow_11_LCTR"sv, "Glow_12_LCTR"sv,
     "Glow_13_LCTR"sv, "Glow_14_LCTR"sv, "Glow_15_LCTR"sv, "Glow_16_LCTR"sv,
 };
+
 CPuddleSpore::CPuddleSpore(TUniqueId uid, std::string_view name, EFlavorType flavor, const CEntityInfo& info,
                            const zeus::CTransform& xf, CModelData&& mData, const CPatternedInfo& pInfo,
                            EColliderType colType, CAssetId glowFx, float f1, float f2, float f3, float f4, float f5,
@@ -121,7 +124,7 @@ void CPuddleSpore::Think(float dt, CStateManager& mgr) {
   HealthInfo(mgr)->SetHP(1000000.0f);
   float t = (x56c_ / x570_) - 1.f >= -0.f ? 1.f : x56c_ / x570_;
   zeus::CColor modColor = zeus::CColor::lerp(zeus::skWhite, zeus::CColor(1.f, 1.f, 1.f, 0.f), t);
-  for (u32 i = 0; i < kEyeCount; ++i) {
+  for (size_t i = 0; i < kEyeCount; ++i) {
     const auto& elemGen = x5dc_elemGens[i];
     elemGen->SetModulationColor(modColor);
     elemGen->SetTranslation(GetLctrTransform(kEyeLocators[i]).origin);

--- a/Runtime/MP1/World/CPuddleSpore.hpp
+++ b/Runtime/MP1/World/CPuddleSpore.hpp
@@ -11,8 +11,6 @@
 
 namespace urde::MP1 {
 class CPuddleSpore : public CPatterned {
-  static constexpr u32 kEyeCount = 16;
-  static const std::string_view kEyeLocators[16];
   float x568_ = 0.f;
   float x56c_ = 0.f;
   float x570_;


### PR DESCRIPTION
Makes the data an implementation detail and also allows for the string_view array to be declared constexpr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/234)
<!-- Reviewable:end -->
