### PR TITLE
CFogVolumeFilter: Make use of std::array where applicable

### DIFF
--- a/Runtime/Graphics/Shaders/CFogVolumeFilter.cpp
+++ b/Runtime/Graphics/Shaders/CFogVolumeFilter.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/Graphics/Shaders/CFogVolumeFilter.hpp"
 
+#include <array>
+
 #include "Runtime/GameGlobalObjects.hpp"
 #include "Runtime/Graphics/CBooRenderer.hpp"
 #include "Runtime/Graphics/CGraphics.hpp"
@@ -28,24 +30,30 @@ CFogVolumeFilter::CFogVolumeFilter() {
     struct Vert {
       zeus::CVector2f m_pos;
       zeus::CVector2f m_uv;
-    } verts[4] = {
+    };
+    constexpr std::array<Vert, 4> verts{{
         {{-1.0, -1.0}, {0.0, 0.0}},
         {{-1.0, 1.0}, {0.0, 1.0}},
         {{1.0, -1.0}, {1.0, 0.0}},
         {{1.0, 1.0}, {1.0, 1.0}},
-    };
-    m_vbo = ctx.newStaticBuffer(boo::BufferUse::Vertex, verts, sizeof(Vert), 4);
+    }};
+    m_vbo = ctx.newStaticBuffer(boo::BufferUse::Vertex, verts.data(), sizeof(Vert), verts.size());
     m_uniBuf = ctx.newDynamicBuffer(boo::BufferUse::Uniform, sizeof(zeus::CColor), 1);
-    boo::ObjToken<boo::ITexture> texs[] = {CGraphics::g_SpareTexture.get(), CGraphics::g_SpareTexture.get(),
-                                           g_Renderer->GetFogRampTex().get()};
-    int bindIdxs[] = {0, 1, 0};
-    bool bindDepth[] = {true, true, false};
-    boo::ObjToken<boo::IGraphicsBuffer> ubufs[] = {m_uniBuf.get()};
+    const std::array<boo::ObjToken<boo::ITexture>, 3> texs{
+        CGraphics::g_SpareTexture.get(),
+        CGraphics::g_SpareTexture.get(),
+        g_Renderer->GetFogRampTex().get(),
+    };
+    constexpr std::array bindIdxs{0, 1, 0};
+    constexpr std::array bindDepth{true, true, false};
+    const std::array<boo::ObjToken<boo::IGraphicsBuffer>, 1> ubufs{m_uniBuf.get()};
 
-    m_dataBind1Way = ctx.newShaderDataBinding(s_1WayPipeline, m_vbo.get(), nullptr, nullptr, 1, ubufs, nullptr, nullptr,
-                                              nullptr, 3, texs, bindIdxs, bindDepth);
-    m_dataBind2Way = ctx.newShaderDataBinding(s_2WayPipeline, m_vbo.get(), nullptr, nullptr, 1, ubufs, nullptr, nullptr,
-                                              nullptr, 3, texs, bindIdxs, bindDepth);
+    m_dataBind1Way =
+        ctx.newShaderDataBinding(s_1WayPipeline, m_vbo.get(), nullptr, nullptr, ubufs.size(), ubufs.data(), nullptr,
+                                 nullptr, nullptr, texs.size(), texs.data(), bindIdxs.data(), bindDepth.data());
+    m_dataBind2Way =
+        ctx.newShaderDataBinding(s_2WayPipeline, m_vbo.get(), nullptr, nullptr, ubufs.size(), ubufs.data(), nullptr,
+                                 nullptr, nullptr, texs.size(), texs.data(), bindIdxs.data(), bindDepth.data());
     return true;
   } BooTrace);
 }


### PR DESCRIPTION
Makes data strongly typed and also allows for the removal of some
hardcoded array sizes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/238)
<!-- Reviewable:end -->
