### PR TITLE
CMainFlow: std::move shared_ptr in SetGameState

### DIFF
--- a/Runtime/MP1/CMainFlow.cpp
+++ b/Runtime/MP1/CMainFlow.cpp
@@ -90,9 +90,9 @@ void CMainFlow::SetGameState(EClientFlowStates state, CArchitectureQueue& queue)
   }
   case EClientFlowStates::Game: {
     g_GameState->GameOptions().EnsureSettings();
-    std::shared_ptr<CMFGameLoader> gameLoader = std::make_shared<CMFGameLoader>();
+    auto gameLoader = std::make_shared<CMFGameLoader>();
     main->SetFlowState(EFlowState::Default);
-    queue.Push(MakeMsg::CreateCreateIOWin(EArchMsgTarget::IOWinManager, 10, 1000, gameLoader));
+    queue.Push(MakeMsg::CreateCreateIOWin(EArchMsgTarget::IOWinManager, 10, 1000, std::move(gameLoader)));
     break;
   }
   default:


### PR DESCRIPTION
Same behavior, but without a redundant atomic reference count increment/decrement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/240)
<!-- Reviewable:end -->
