### PR TITLE
CDrawStringOptions: Resize vector within constructor

### DIFF
--- a/Runtime/GuiSys/CDrawStringOptions.hpp
+++ b/Runtime/GuiSys/CDrawStringOptions.hpp
@@ -18,7 +18,7 @@ class CDrawStringOptions {
   std::vector<CTextColor> x4_colors;
 
 public:
-  CDrawStringOptions() { x4_colors.resize(16); }
+  CDrawStringOptions() : x4_colors(16) {}
 };
 
 } // namespace urde


### PR DESCRIPTION
Same behavior, but constructs the vector with the necessary size, rather than constructing and resizing after the fact.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/245)
<!-- Reviewable:end -->
