### PR TITLE
CRumbleVoice: Resize vectors within constructor initializer list

### DIFF
--- a/Runtime/Input/CRumbleVoice.cpp
+++ b/Runtime/Input/CRumbleVoice.cpp
@@ -2,9 +2,7 @@
 
 namespace urde {
 
-CRumbleVoice::CRumbleVoice() {
-  x0_datas.resize(4);
-  x10_deltas.resize(4, SAdsrDelta::Stopped());
+CRumbleVoice::CRumbleVoice() : x0_datas(4), x10_deltas(4, SAdsrDelta::Stopped()) {
   x20_handleIds.resize(4);
 }
 

--- a/Runtime/Input/CRumbleVoice.cpp
+++ b/Runtime/Input/CRumbleVoice.cpp
@@ -22,10 +22,12 @@ bool CRumbleVoice::OwnsSustained(s16 handle) const {
 }
 
 s16 CRumbleVoice::GetFreeChannel() const {
-  for (s16 i = 0; i < 4; ++i)
-    if (!((1 << i) & x2c_usedChannels))
+  for (s16 i = 0; i < 4; ++i) {
+    if (!((1 << i) & x2c_usedChannels)) {
       return i;
-  return false;
+    }
+  }
+  return 0;
 }
 
 float CRumbleVoice::GetIntensity() const {

--- a/Runtime/Input/CRumbleVoice.cpp
+++ b/Runtime/Input/CRumbleVoice.cpp
@@ -31,9 +31,8 @@ s16 CRumbleVoice::GetFreeChannel() const {
 }
 
 float CRumbleVoice::GetIntensity() const {
-  return std::min(2.f, std::max(x10_deltas[0].x0_curIntensity,
-                                std::max(x10_deltas[1].x0_curIntensity,
-                                         std::max(x10_deltas[2].x0_curIntensity, x10_deltas[3].x0_curIntensity))));
+  return std::min(2.f, std::max({x10_deltas[0].x0_curIntensity, x10_deltas[1].x0_curIntensity,
+                                 x10_deltas[2].x0_curIntensity, x10_deltas[3].x0_curIntensity}));
 }
 
 bool CRumbleVoice::UpdateChannel(SAdsrDelta& delta, const SAdsrData& data, float dt) {


### PR DESCRIPTION
Same behavior, but constructs in place with the size, rather than constructing and then resizing.

`x20_handleIds` cannot be done the same way unfortunately, as `reserved_vector` doesn't have a constructor accepting a size argument like `std::vector` does.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/252)
<!-- Reviewable:end -->
