### PR TITLE
CRelayTracker: Make HasRelay() a const member function

### DIFF
--- a/Runtime/CRelayTracker.cpp
+++ b/Runtime/CRelayTracker.cpp
@@ -23,18 +23,24 @@ CRelayTracker::CRelayTracker(CBitStreamReader& in, const CSaveWorld& saveworld) 
   }
 }
 
-bool CRelayTracker::HasRelay(TEditorId id) {
-  return std::find(x0_relayStates.begin(), x0_relayStates.end(), id) != x0_relayStates.end();
+bool CRelayTracker::HasRelay(TEditorId id) const {
+  return std::find(x0_relayStates.cbegin(), x0_relayStates.cend(), id) != x0_relayStates.cend();
 }
 
 void CRelayTracker::AddRelay(TEditorId id) {
-  if (std::find(x0_relayStates.begin(), x0_relayStates.end(), id) == x0_relayStates.end())
-    x0_relayStates.push_back(id);
+  if (HasRelay(id)) {
+    return;
+  }
+
+  x0_relayStates.push_back(id);
 }
 
 void CRelayTracker::RemoveRelay(TEditorId id) {
-  if (std::find(x0_relayStates.begin(), x0_relayStates.end(), id) != x0_relayStates.end())
-    x0_relayStates.erase(std::remove(x0_relayStates.begin(), x0_relayStates.end(), id), x0_relayStates.end());
+  if (!HasRelay(id)) {
+    return;
+  }
+
+  x0_relayStates.erase(std::remove(x0_relayStates.begin(), x0_relayStates.end(), id), x0_relayStates.end());
 }
 
 void CRelayTracker::SendMsgs(TAreaId areaId, CStateManager& stateMgr) {

--- a/Runtime/CRelayTracker.hpp
+++ b/Runtime/CRelayTracker.hpp
@@ -31,7 +31,7 @@ public:
   CRelayTracker() = default;
   CRelayTracker(CBitStreamReader&, const CSaveWorld&);
 
-  bool HasRelay(TEditorId);
+  bool HasRelay(TEditorId) const;
   void AddRelay(TEditorId);
   void RemoveRelay(TEditorId);
   void SendMsgs(TAreaId, CStateManager&);


### PR DESCRIPTION
While we're at it, we can make use of HasRelay() internally where applicable to simplify code a little bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/253)
<!-- Reviewable:end -->
