### PR TITLE
CModelBoo: Remove usages of const_cast

### DIFF
--- a/Runtime/Graphics/CBooRenderer.cpp
+++ b/Runtime/Graphics/CBooRenderer.cpp
@@ -1352,12 +1352,14 @@ int CBooRenderer::DrawOverlappingWorldModelIDs(int alphaVal, const std::vector<u
             return alphaVal;
 
           flags.x4_color.a() = alphaVal / 255.f;
-          const CBooModel& model = *item.x10_models[wordModel + j];
-          const_cast<CBooModel&>(model).UpdateUniformData(flags, nullptr, nullptr, 3);
-          const_cast<CBooModel&>(model).VerifyCurrentShader(0);
-          for (const CBooSurface* surf = model.x38_firstUnsortedSurface; surf; surf = surf->m_next)
-            if (surf->GetBounds().intersects(aabb))
+          CBooModel& model = *item.x10_models[wordModel + j];
+          model.UpdateUniformData(flags, nullptr, nullptr, 3);
+          model.VerifyCurrentShader(0);
+          for (const CBooSurface* surf = model.x38_firstUnsortedSurface; surf; surf = surf->m_next) {
+            if (surf->GetBounds().intersects(aabb)) {
               model.DrawSurface(*surf, flags);
+            }
+          }
           alphaVal += 4;
         }
       }

--- a/Runtime/Graphics/CModel.hpp
+++ b/Runtime/Graphics/CModel.hpp
@@ -210,16 +210,16 @@ public:
   void DisableAllLights();
   void RemapMaterialData(SShader& shader);
   void RemapMaterialData(SShader& shader, const std::unordered_map<int, CModelShaders::ShaderPipelines>& pipelines);
-  bool TryLockTextures() const;
-  void UnlockTextures() const;
-  void SyncLoadTextures() const;
-  void Touch(int shaderIdx) const;
+  bool TryLockTextures();
+  void UnlockTextures();
+  void SyncLoadTextures();
+  void Touch(int shaderIdx);
   void VerifyCurrentShader(int shaderIdx);
   boo::ObjToken<boo::IGraphicsBufferD> UpdateUniformData(const CModelFlags& flags, const CSkinRules* cskr,
-                                                         const CPoseAsTransforms* pose, int sharedLayoutBuf = -1) const;
-  void DrawAlpha(const CModelFlags& flags, const CSkinRules* cskr, const CPoseAsTransforms* pose) const;
-  void DrawNormal(const CModelFlags& flags, const CSkinRules* cskr, const CPoseAsTransforms* pose) const;
-  void Draw(const CModelFlags& flags, const CSkinRules* cskr, const CPoseAsTransforms* pose) const;
+                                                         const CPoseAsTransforms* pose, int sharedLayoutBuf = -1);
+  void DrawAlpha(const CModelFlags& flags, const CSkinRules* cskr, const CPoseAsTransforms* pose);
+  void DrawNormal(const CModelFlags& flags, const CSkinRules* cskr, const CPoseAsTransforms* pose);
+  void Draw(const CModelFlags& flags, const CSkinRules* cskr, const CPoseAsTransforms* pose);
   void DrawFlat(ESurfaceSelection sel, EExtendedShader extendedIdx) const;
 
   void LockParent() { m_modelTok.Lock(); }

--- a/Runtime/GuiSys/CAuiEnergyBarT01.cpp
+++ b/Runtime/GuiSys/CAuiEnergyBarT01.cpp
@@ -53,14 +53,14 @@ void CAuiEnergyBarT01::Update(float dt) {
   CGuiWidget::Update(dt);
 }
 
-void CAuiEnergyBarT01::Draw(const CGuiWidgetDrawParms& drawParms) const {
+void CAuiEnergyBarT01::Draw(const CGuiWidgetDrawParms& drawParms) {
   if (!xbc_tex || !xbc_tex.IsLoaded() || !xd8_coordFunc) {
     return;
   }
   SCOPED_GRAPHICS_DEBUG_GROUP(fmt::format(fmt("CAuiEnergyBarT01::Draw {}"), m_name).c_str(), zeus::skCyan);
 
   CGraphics::SetModelMatrix(x34_worldXF);
-  const_cast<CEnergyBarShader&>(m_energyBarShader).updateModelMatrix();
+  m_energyBarShader.updateModelMatrix();
 
   const float filledT = xe0_maxEnergy > 0.f ? xf8_filledEnergy / xe0_maxEnergy : 0.f;
   const float shadowT = xe0_maxEnergy > 0.f ? xfc_shadowEnergy / xe0_maxEnergy : 0.f;
@@ -78,7 +78,7 @@ void CAuiEnergyBarT01::Draw(const CGuiWidgetDrawParms& drawParms) const {
   emptyColor *= xa8_color2;
 
   for (size_t i = 0; i < m_verts.size(); ++i) {
-    std::vector<CEnergyBarShader::Vertex>& verts = const_cast<CAuiEnergyBarT01&>(*this).m_verts[i];
+    std::vector<CEnergyBarShader::Vertex>& verts = m_verts[i];
     verts.clear();
 
     float start;
@@ -118,8 +118,7 @@ void CAuiEnergyBarT01::Draw(const CGuiWidgetDrawParms& drawParms) const {
     }
   }
 
-  const_cast<CEnergyBarShader&>(m_energyBarShader)
-      .draw(filledColor, m_verts[0], shadowColor, m_verts[1], emptyColor, m_verts[2], xbc_tex.GetObj());
+  m_energyBarShader.draw(filledColor, m_verts[0], shadowColor, m_verts[1], emptyColor, m_verts[2], xbc_tex.GetObj());
 }
 
 void CAuiEnergyBarT01::SetCurrEnergy(float e, ESetMode mode) {

--- a/Runtime/GuiSys/CAuiEnergyBarT01.hpp
+++ b/Runtime/GuiSys/CAuiEnergyBarT01.hpp
@@ -46,7 +46,7 @@ public:
   FourCC GetWidgetTypeID() const override { return FOURCC('ENRG'); }
   static std::pair<zeus::CVector3f, zeus::CVector3f> DownloadBarCoordFunc(float t);
   void Update(float dt) override;
-  void Draw(const CGuiWidgetDrawParms& drawParms) const override;
+  void Draw(const CGuiWidgetDrawParms& drawParms) override;
   float GetActualFraction() const { return xe0_maxEnergy == 0.f ? 0.f : xf4_setEnergy / xe0_maxEnergy; }
   float GetSetEnergy() const { return xf4_setEnergy; }
   float GetMaxEnergy() const { return xe0_maxEnergy; }

--- a/Runtime/GuiSys/CAuiImagePane.cpp
+++ b/Runtime/GuiSys/CAuiImagePane.cpp
@@ -101,15 +101,17 @@ void CAuiImagePane::DoDrawImagePane(const zeus::CColor& color, const CTexture& t
   }
 }
 
-void CAuiImagePane::Draw(const CGuiWidgetDrawParms& params) const {
+void CAuiImagePane::Draw(const CGuiWidgetDrawParms& params) {
   CGraphics::SetModelMatrix(x34_worldXF);
-  if (!GetIsVisible() || !xb8_tex0Tok.IsLoaded())
+  if (!GetIsVisible() || !xb8_tex0Tok.IsLoaded()) {
     return;
+  }
   SCOPED_GRAPHICS_DEBUG_GROUP(fmt::format(fmt("CAuiImagePane::Draw {}"), m_name).c_str(), zeus::skCyan);
   GetIsFinishedLoadingWidgetSpecific();
-  if (!m_filters || m_filters->m_texId != xb8_tex0Tok.GetObjectTag()->id)
-    const_cast<CAuiImagePane*>(this)->m_filters.emplace(const_cast<CAuiImagePane*>(this)->xb8_tex0Tok);
-  Filters& filters = const_cast<Filters&>(*m_filters);
+  if (!m_filters || m_filters->m_texId != xb8_tex0Tok.GetObjectTag()->id) {
+    m_filters.emplace(xb8_tex0Tok);
+  }
+  Filters& filters = *m_filters;
   zeus::CColor color = xa8_color2;
   color.a() *= params.x0_alphaMod;
   // SetZUpdate(xac_drawFlags == EGuiModelDrawFlags::Shadeless || xac_drawFlags == EGuiModelDrawFlags::Opaque);
@@ -174,7 +176,7 @@ void CAuiImagePane::Draw(const CGuiWidgetDrawParms& params) const {
   }
 }
 
-bool CAuiImagePane::GetIsFinishedLoadingWidgetSpecific() const { return !xb8_tex0Tok || xb8_tex0Tok.IsLoaded(); }
+bool CAuiImagePane::GetIsFinishedLoadingWidgetSpecific() { return !xb8_tex0Tok || xb8_tex0Tok.IsLoaded(); }
 
 void CAuiImagePane::SetTextureID0(CAssetId tex, CSimplePool* sp) {
   xc8_tex0 = tex;

--- a/Runtime/GuiSys/CAuiImagePane.hpp
+++ b/Runtime/GuiSys/CAuiImagePane.hpp
@@ -53,8 +53,8 @@ public:
 
   void Reset(ETraversalMode mode) override;
   void Update(float dt) override;
-  void Draw(const CGuiWidgetDrawParms& params) const override;
-  bool GetIsFinishedLoadingWidgetSpecific() const override;
+  void Draw(const CGuiWidgetDrawParms& params) override;
+  bool GetIsFinishedLoadingWidgetSpecific() override;
   void SetTextureID0(CAssetId tex, CSimplePool* sp);
   void SetAnimationParms(const zeus::CVector2f& vec, float interval, float duration);
   void SetDeResFactor(float d) { x14c_deResFactor = d; }

--- a/Runtime/GuiSys/CGuiCamera.cpp
+++ b/Runtime/GuiSys/CGuiCamera.cpp
@@ -24,12 +24,13 @@ zeus::CVector3f CGuiCamera::ConvertToScreenSpace(const zeus::CVector3f& vec) con
   return mat.multiplyOneOverW(local);
 }
 
-void CGuiCamera::Draw(const CGuiWidgetDrawParms& parms) const {
-  if (xb8_projtype == EProjection::Perspective)
+void CGuiCamera::Draw(const CGuiWidgetDrawParms& parms) {
+  if (xb8_projtype == EProjection::Perspective) {
     CGraphics::SetPerspective(m_proj.xbc_fov, m_proj.xc0_aspect, m_proj.xc4_znear, m_proj.xc8_zfar);
-  else
+  } else {
     CGraphics::SetOrtho(m_proj.xbc_left, m_proj.xc0_right, m_proj.xc4_top, m_proj.xc8_bottom, m_proj.xcc_znear,
                         m_proj.xd0_zfar);
+  }
   CGraphics::SetViewPointMatrix(GetGuiFrame()->GetAspectTransform() *
                                 zeus::CTransform::Translate(parms.x4_cameraOffset) * x34_worldXF);
   CGuiWidget::Draw(parms);

--- a/Runtime/GuiSys/CGuiCamera.hpp
+++ b/Runtime/GuiSys/CGuiCamera.hpp
@@ -46,7 +46,7 @@ public:
   zeus::CVector3f ConvertToScreenSpace(const zeus::CVector3f& vec) const;
   const SProjection& GetProjection() const { return m_proj; }
   void SetFov(float fov) { m_proj.xbc_fov = fov; }
-  void Draw(const CGuiWidgetDrawParms& parms) const override;
+  void Draw(const CGuiWidgetDrawParms& parms) override;
 
   std::shared_ptr<CGuiCamera> shared_from_this() {
     return std::static_pointer_cast<CGuiCamera>(CGuiObject::shared_from_this());

--- a/Runtime/GuiSys/CGuiFrame.cpp
+++ b/Runtime/GuiSys/CGuiFrame.cpp
@@ -107,7 +107,7 @@ bool CGuiFrame::GetIsFinishedLoading() const {
       continue;
     return false;
   }
-  const_cast<CGuiFrame*>(this)->x58_24_loaded = true;
+  x58_24_loaded = true;
   return true;
 }
 

--- a/Runtime/GuiSys/CGuiFrame.hpp
+++ b/Runtime/GuiSys/CGuiFrame.hpp
@@ -41,7 +41,7 @@ private:
   int x4c_a;
   int x50_b;
   int x54_c;
-  bool x58_24_loaded : 1;
+  mutable bool x58_24_loaded : 1;
 
   zeus::CTransform m_aspectTransform;
   float m_aspectConstraint = -1.f;

--- a/Runtime/GuiSys/CGuiModel.cpp
+++ b/Runtime/GuiSys/CGuiModel.cpp
@@ -16,36 +16,45 @@ CGuiModel::CGuiModel(const CGuiWidgetParms& parms, CSimplePool* sp, CAssetId mod
   xb8_model = sp->GetObj({SBIG('CMDL'), modelId});
 }
 
-bool CGuiModel::GetIsFinishedLoadingWidgetSpecific() const {
-  if (!xb8_model)
+bool CGuiModel::GetIsFinishedLoadingWidgetSpecific() {
+  if (!xb8_model) {
     return true;
-  if (!xb8_model.IsLoaded())
+  }
+  if (!xb8_model.IsLoaded()) {
     return false;
+  }
   xb8_model->GetInstance().Touch(0);
   return xb8_model->IsLoaded(0);
 }
 
-void CGuiModel::Touch() const {
-  const CModel* model = xb8_model.GetObj();
-  if (model)
-    model->GetInstance().Touch(0);
+void CGuiModel::Touch() {
+  CModel* const model = xb8_model.GetObj();
+
+  if (model == nullptr) {
+    return;
+  }
+
+  model->GetInstance().Touch(0);
 }
 
-void CGuiModel::Draw(const CGuiWidgetDrawParms& parms) const {
+void CGuiModel::Draw(const CGuiWidgetDrawParms& parms) {
   CGraphics::SetModelMatrix(x34_worldXF);
-  if (!xb8_model)
+  if (!xb8_model) {
     return;
-  if (!GetIsFinishedLoading())
+  }
+  if (!GetIsFinishedLoading()) {
     return;
-  const CModel* model = xb8_model.GetObj();
-  if (!model)
+  }
+  CModel* const model = xb8_model.GetObj();
+  if (!model) {
     return;
+  }
 
   if (GetIsVisible()) {
     SCOPED_GRAPHICS_DEBUG_GROUP(fmt::format(fmt("CGuiModel::Draw {}"), m_name).c_str(), zeus::skCyan);
     zeus::CColor moduCol = xa8_color2;
     moduCol.a() *= parms.x0_alphaMod;
-    xb0_frame->EnableLights(xcc_lightMask, const_cast<CBooModel&>(model->GetInstance()));
+    xb0_frame->EnableLights(xcc_lightMask, model->GetInstance());
     // if (xb6_29_cullFaces)
     //    CGraphics::SetCullMode(ERglCullMode::Front);
 

--- a/Runtime/GuiSys/CGuiModel.hpp
+++ b/Runtime/GuiSys/CGuiModel.hpp
@@ -20,9 +20,9 @@ public:
 
   std::vector<CAssetId> GetModelAssets() const { return {xc8_modelId}; }
   const TLockedToken<CModel>& GetModel() const { return xb8_model; }
-  bool GetIsFinishedLoadingWidgetSpecific() const override;
-  void Touch() const override;
-  void Draw(const CGuiWidgetDrawParms& parms) const override;
+  bool GetIsFinishedLoadingWidgetSpecific() override;
+  void Touch() override;
+  void Draw(const CGuiWidgetDrawParms& parms) override;
   bool TestCursorHit(const zeus::CMatrix4f& vp, const zeus::CVector2f& point) const override;
 
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);

--- a/Runtime/GuiSys/CGuiObject.cpp
+++ b/Runtime/GuiSys/CGuiObject.cpp
@@ -14,7 +14,7 @@ void CGuiObject::Update(float dt) {
     x6c_nextSibling->Update(dt);
 }
 
-void CGuiObject::Draw(const CGuiWidgetDrawParms& parms) const {
+void CGuiObject::Draw(const CGuiWidgetDrawParms& parms) {
   if (x68_child)
     x68_child->Draw(parms);
   if (x6c_nextSibling)

--- a/Runtime/GuiSys/CGuiObject.hpp
+++ b/Runtime/GuiSys/CGuiObject.hpp
@@ -21,7 +21,7 @@ protected:
 public:
   virtual ~CGuiObject() = default;
   virtual void Update(float dt);
-  virtual void Draw(const CGuiWidgetDrawParms& parms) const;
+  virtual void Draw(const CGuiWidgetDrawParms& parms);
   virtual bool TestCursorHit(const zeus::CMatrix4f& vp, const zeus::CVector2f& point) const { return false; }
   virtual void Initialize() = 0;
 

--- a/Runtime/GuiSys/CGuiTextPane.cpp
+++ b/Runtime/GuiSys/CGuiTextPane.cpp
@@ -20,7 +20,7 @@ void CGuiTextPane::Update(float dt) {
   xd4_textSupport.Update(dt);
 }
 
-bool CGuiTextPane::GetIsFinishedLoadingWidgetSpecific() const {
+bool CGuiTextPane::GetIsFinishedLoadingWidgetSpecific() {
   return xd4_textSupport.GetIsTextSupportFinishedLoading();
 }
 
@@ -32,30 +32,33 @@ void CGuiTextPane::SetDimensions(const zeus::CVector2f& dim, bool initVBO) {
 
 void CGuiTextPane::ScaleDimensions(const zeus::CVector3f& scale) {}
 
-void CGuiTextPane::Draw(const CGuiWidgetDrawParms& parms) const {
-  if (!GetIsVisible())
+void CGuiTextPane::Draw(const CGuiWidgetDrawParms& parms) {
+  if (!GetIsVisible()) {
     return;
+  }
   SCOPED_GRAPHICS_DEBUG_GROUP(fmt::format(fmt("CGuiTextPane::Draw {}"), m_name).c_str(), zeus::skCyan);
 
   zeus::CVector2f dims = GetDimensions();
 
-  if (xd4_textSupport.x34_extentX)
+  if (xd4_textSupport.x34_extentX) {
     dims.x() /= float(xd4_textSupport.x34_extentX);
-  else
+  } else {
     dims.x() = 0.f;
+  }
 
-  if (xd4_textSupport.x38_extentY)
+  if (xd4_textSupport.x38_extentY) {
     dims.y() /= float(xd4_textSupport.x38_extentY);
-  else
+  } else {
     dims.y() = 0.f;
+  }
 
-  zeus::CTransform local = zeus::CTransform::Translate(xc0_verts.front().m_pos + xc8_scaleCenter) *
-                           zeus::CTransform::Scale(dims.x(), 1.f, dims.y());
+  const zeus::CTransform local = zeus::CTransform::Translate(xc0_verts.front().m_pos + xc8_scaleCenter) *
+                                 zeus::CTransform::Scale(dims.x(), 1.f, dims.y());
   CGraphics::SetModelMatrix(x34_worldXF * local);
 
   zeus::CColor geomCol = xa8_color2;
   geomCol.a() *= parms.x0_alphaMod;
-  const_cast<CGuiTextPane*>(this)->xd4_textSupport.SetGeometryColor(geomCol);
+  xd4_textSupport.SetGeometryColor(geomCol);
 
 #if 0
     CGraphics::SetDepthWriteMode(xb6_31_depthTest, ERglEnum::LEqual, xb7_24_depthWrite);

--- a/Runtime/GuiSys/CGuiTextPane.hpp
+++ b/Runtime/GuiSys/CGuiTextPane.hpp
@@ -20,11 +20,11 @@ public:
   CGuiTextSupport& TextSupport() { return xd4_textSupport; }
   const CGuiTextSupport& GetTextSupport() const { return xd4_textSupport; }
   void Update(float dt) override;
-  bool GetIsFinishedLoadingWidgetSpecific() const override;
+  bool GetIsFinishedLoadingWidgetSpecific() override;
   std::vector<CAssetId> GetFontAssets() const { return {xd4_textSupport.x5c_fontId}; }
   void SetDimensions(const zeus::CVector2f& dim, bool initVBO) override;
   void ScaleDimensions(const zeus::CVector3f& scale) override;
-  void Draw(const CGuiWidgetDrawParms& parms) const override;
+  void Draw(const CGuiWidgetDrawParms& parms) override;
   bool TestCursorHit(const zeus::CMatrix4f& vp, const zeus::CVector2f& point) const override;
 
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);

--- a/Runtime/GuiSys/CGuiWidget.cpp
+++ b/Runtime/GuiSys/CGuiWidget.cpp
@@ -117,9 +117,9 @@ void CGuiWidget::Update(float dt) {
     sib->Update(dt);
 }
 
-void CGuiWidget::Draw(const CGuiWidgetDrawParms&) const {}
+void CGuiWidget::Draw(const CGuiWidgetDrawParms&) {}
 void CGuiWidget::ProcessUserInput(const CFinalInput& input) {}
-void CGuiWidget::Touch() const {}
+void CGuiWidget::Touch() {}
 
 bool CGuiWidget::GetIsVisible() const { return xb6_25_isVisible; }
 
@@ -136,7 +136,7 @@ void CGuiWidget::InitializeRGBAFactor() {
     nextSib->InitializeRGBAFactor();
 }
 
-bool CGuiWidget::GetIsFinishedLoadingWidgetSpecific() const { return true; }
+bool CGuiWidget::GetIsFinishedLoadingWidgetSpecific() { return true; }
 
 void CGuiWidget::SetTransform(const zeus::CTransform& xf) {
   x74_transform = xf;

--- a/Runtime/GuiSys/CGuiWidget.cpp
+++ b/Runtime/GuiSys/CGuiWidget.cpp
@@ -227,7 +227,7 @@ CGuiWidget* CGuiWidget::FindWidget(s16 id) {
   return nullptr;
 }
 
-bool CGuiWidget::GetIsFinishedLoading() const { return GetIsFinishedLoadingWidgetSpecific(); }
+bool CGuiWidget::GetIsFinishedLoading() { return GetIsFinishedLoadingWidgetSpecific(); }
 
 void CGuiWidget::DispatchInitialize() {
   Initialize();

--- a/Runtime/GuiSys/CGuiWidget.hpp
+++ b/Runtime/GuiSys/CGuiWidget.hpp
@@ -135,7 +135,7 @@ public:
   void SetColor(const zeus::CColor& color);
   void InitializeRGBAFactor();
   CGuiWidget* FindWidget(s16 id);
-  bool GetIsFinishedLoading() const;
+  bool GetIsFinishedLoading();
   void DispatchInitialize();
   void SetDepthGreater(bool v) { xb6_30_depthGreater = v; }
   void SetDepthTest(bool v) { xb6_31_depthTest = v; }

--- a/Runtime/GuiSys/CGuiWidget.hpp
+++ b/Runtime/GuiSys/CGuiWidget.hpp
@@ -96,18 +96,18 @@ public:
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 
   void Update(float dt) override;
-  void Draw(const CGuiWidgetDrawParms& drawParms) const override;
+  void Draw(const CGuiWidgetDrawParms& drawParms) override;
   void Initialize() override;
 
   virtual void Reset(ETraversalMode mode);
   virtual void ProcessUserInput(const CFinalInput& input);
-  virtual void Touch() const;
+  virtual void Touch();
   virtual bool GetIsVisible() const;
   virtual bool GetIsActive() const;
   virtual bool GetMouseActive() const;
   virtual FourCC GetWidgetTypeID() const { return FOURCC('BWIG'); }
   virtual bool AddWorkerWidget(CGuiWidget* worker);
-  virtual bool GetIsFinishedLoadingWidgetSpecific() const;
+  virtual bool GetIsFinishedLoadingWidgetSpecific();
   virtual void OnVisibleChange();
   virtual void OnActiveChange();
 

--- a/Runtime/World/CMorphBallShadow.cpp
+++ b/Runtime/World/CMorphBallShadow.cpp
@@ -73,8 +73,8 @@ void CMorphBallShadow::RenderIdBuffer(const zeus::CAABox& aabb, const CStateMana
 
     CModelFlags flags(0, 0, 3, zeus::CColor{1.f, 1.f, 1.f, alphaVal / 255.f});
     flags.m_extendedShader = EExtendedShader::SolidColor; // Do solid color draw
-    const CBooModel& model = *modelData->PickStaticModel(CModelData::EWhichModel::Normal);
-    const_cast<CBooModel&>(model).VerifyCurrentShader(flags.x1_matSetIdx);
+    CBooModel& model = *modelData->PickStaticModel(CModelData::EWhichModel::Normal);
+    model.VerifyCurrentShader(flags.x1_matSetIdx);
     model.DrawNormal(flags, nullptr, nullptr);
     alphaVal += 4;
   }
@@ -128,8 +128,8 @@ void CMorphBallShadow::Render(const CStateManager& mgr, float alpha) {
     CGraphics::SetModelMatrix(modelXf);
 
     flags.x4_color.r() = alphaVal / 255.f;
-    const CBooModel& model = *modelData->PickStaticModel(CModelData::EWhichModel::Normal);
-    const_cast<CBooModel&>(model).VerifyCurrentShader(flags.x1_matSetIdx);
+    CBooModel& model = *modelData->PickStaticModel(CModelData::EWhichModel::Normal);
+    model.VerifyCurrentShader(flags.x1_matSetIdx);
     model.DrawNormal(flags, nullptr, nullptr);
     alphaVal += 4;
   }


### PR DESCRIPTION
Many functions are modifying internals of CBooModel and const-casting is performed in order to work around functions being const when they really shouldn't be.

This amends the function signatures in order to allow these functions to exist without const_cast, making code much nicer to read.

Preferably it'd be nice if this one was run through CI before merging, to make sure I didn't miss anything that might have been platform-specific.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/255)
<!-- Reviewable:end -->
