### PR TITLE
CBomb: Make file-scope material filter constexpr

### DIFF
--- a/Runtime/Weapon/CBomb.cpp
+++ b/Runtime/Weapon/CBomb.cpp
@@ -62,7 +62,7 @@ void CBomb::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManag
   CActor::AcceptScriptMsg(msg, uid, mgr);
 }
 
-static CMaterialFilter kSolidFilter =
+constexpr CMaterialFilter kSolidFilter =
     CMaterialFilter::MakeIncludeExclude({EMaterialTypes::Solid}, {EMaterialTypes::Character, EMaterialTypes::Player,
                                                                   EMaterialTypes::ProjectilePassthrough});
 void CBomb::Think(float dt, urde::CStateManager& mgr) {


### PR DESCRIPTION
Allows the data to be placed into the read-only segment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/261)
<!-- Reviewable:end -->
