### PR TITLE
CBeamProjectile: Explicitly return std::nullopt in GetTouchBounds()

### DIFF
--- a/Runtime/Weapon/CBeamProjectile.cpp
+++ b/Runtime/Weapon/CBeamProjectile.cpp
@@ -25,13 +25,16 @@ CBeamProjectile::CBeamProjectile(const TToken<CWeaponDescription>& wDesc, std::s
 }
 
 std::optional<zeus::CAABox> CBeamProjectile::GetTouchBounds() const {
-  if (!GetActive())
-    return {};
+  if (!GetActive()) {
+    return std::nullopt;
+  }
+
   if (x464_25_enableTouchDamage) {
-    zeus::CVector3f pos = GetTranslation();
+    const zeus::CVector3f pos = GetTranslation();
     return {{pos - 0.1f, pos + 0.1f}};
   }
-  return {};
+
+  return std::nullopt;
 }
 
 void CBeamProjectile::CalculateRenderBounds() { x9c_renderBounds = x354_.getTransformedAABox(x324_xf); }


### PR DESCRIPTION
Allows some implementations to completely avoid zeroing out the internal buffer within the std::optional instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/262)
<!-- Reviewable:end -->
