### PR TITLE
CDecal: Make use of std::array where applicable

### DIFF
--- a/Runtime/Particle/CDecal.cpp
+++ b/Runtime/Particle/CDecal.cpp
@@ -25,16 +25,17 @@ CDecal::CDecal(const TToken<CDecalDescription>& desc, const zeus::CTransform& xf
 
     if (d->x50_DMRT)
       d->x50_DMRT->GetValue(0, x60_rotation);
-  } else
+  } else {
     x5c_29_modelInvalid = true;
+  }
 
   CGraphics::CommitResources([this](boo::IGraphicsDataFactory::Context& ctx) {
-    for (int i = 0; i < 2; ++i) {
-      CQuadDecal& decal = x3c_decalQuads[i];
-      if (decal.m_desc->x14_TEX)
+    for (auto& decal : x3c_decalQuads) {
+      if (decal.m_desc->x14_TEX) {
         decal.m_instBuf = ctx.newDynamicBuffer(boo::BufferUse::Vertex, sizeof(SParticleInstanceTex), 1);
-      else
+      } else {
         decal.m_instBuf = ctx.newDynamicBuffer(boo::BufferUse::Vertex, sizeof(SParticleInstanceNoTex), 1);
+      }
       decal.m_uniformBuf = ctx.newDynamicBuffer(boo::BufferUse::Uniform, sizeof(SParticleUniforms), 1);
       CDecalShaders::BuildShaderDataBinding(ctx, decal);
     }

--- a/Runtime/Particle/CDecal.hpp
+++ b/Runtime/Particle/CDecal.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "Runtime/CRandom16.hpp"
 #include "Runtime/CToken.hpp"
 #include "Runtime/RetroTypes.hpp"
@@ -36,7 +38,7 @@ class CDecal {
 
   TLockedToken<CDecalDescription> x0_description;
   zeus::CTransform xc_transform;
-  CQuadDecal x3c_decalQuads[2];
+  std::array<CQuadDecal, 2> x3c_decalQuads;
   s32 x54_modelLifetime = 0;
   s32 x58_frameIdx = 0;
   union {


### PR DESCRIPTION
Same behavior, but with stronger-typing and no implicit array to pointer decay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/263)
<!-- Reviewable:end -->
