### PR TITLE
CParticleElectric: Use std::make_unique where applicable

### DIFF
--- a/Runtime/Particle/CParticleElectric.cpp
+++ b/Runtime/Particle/CParticleElectric.cpp
@@ -42,7 +42,7 @@ CParticleElectric::CParticleElectric(const TToken<CElectricDescription>& token)
   if (desc->x40_SSWH) {
     x450_27_haveSSWH = true;
     for (int i = 0; i < x154_SCNT; ++i) {
-      x1e0_swooshGenerators.emplace_back(new CParticleSwoosh(desc->x40_SSWH.m_token, x150_SSEG));
+      x1e0_swooshGenerators.emplace_back(std::make_unique<CParticleSwoosh>(desc->x40_SSWH.m_token, x150_SSEG));
       x1e0_swooshGenerators.back()->DoElectricWarmup();
     }
   }
@@ -56,7 +56,7 @@ CParticleElectric::CParticleElectric(const TToken<CElectricDescription>& token)
     x450_25_haveGPSM = true;
     x400_gpsmGenerators.reserve(x154_SCNT);
     for (int i = 0; i < x154_SCNT; ++i) {
-      x400_gpsmGenerators.emplace_back(new CElementGen(desc->x50_GPSM.m_token));
+      x400_gpsmGenerators.emplace_back(std::make_unique<CElementGen>(desc->x50_GPSM.m_token));
       x400_gpsmGenerators.back()->SetParticleEmission(false);
     }
   }
@@ -65,15 +65,16 @@ CParticleElectric::CParticleElectric(const TToken<CElectricDescription>& token)
     x450_26_haveEPSM = true;
     x410_epsmGenerators.reserve(x154_SCNT);
     for (int i = 0; i < x154_SCNT; ++i) {
-      x410_epsmGenerators.emplace_back(new CElementGen(desc->x60_EPSM.m_token));
+      x410_epsmGenerators.emplace_back(std::make_unique<CElementGen>(desc->x60_EPSM.m_token));
       x410_epsmGenerators.back()->SetParticleEmission(false);
     }
   }
 
   if (x1c_elecDesc->x28_LWD1 || x1c_elecDesc->x2c_LWD2 || x1c_elecDesc->x30_LWD3) {
     x450_28_haveLWD = true;
-    for (int i = 0; i < x154_SCNT; ++i)
-      x2e4_lineManagers.emplace_back(new CLineManager());
+    for (int i = 0; i < x154_SCNT; ++i) {
+      x2e4_lineManagers.emplace_back(std::make_unique<CLineManager>());
+    }
   }
 }
 


### PR DESCRIPTION
Makes it obvious that std::unique_ptr instances are being created within the implementation code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/266)
<!-- Reviewable:end -->
