### PR TITLE
CAnimData: Give names to function prototype parameters

### DIFF
--- a/Runtime/Character/CAnimData.hpp
+++ b/Runtime/Character/CAnimData.hpp
@@ -161,36 +161,36 @@ public:
             TLockedToken<CCharacterFactory> charFactory, int drawInstCount);
 
   void SetParticleEffectState(std::string_view effectName, bool active, CStateManager& mgr);
-  void InitializeEffects(CStateManager&, TAreaId, const zeus::CVector3f&);
-  CAssetId GetEventResourceIdForAnimResourceId(CAssetId) const;
+  void InitializeEffects(CStateManager& mgr, TAreaId aId, const zeus::CVector3f& scale);
+  CAssetId GetEventResourceIdForAnimResourceId(CAssetId id) const;
   void AddAdditiveSegData(const CSegIdList& list, CSegStatementSet& stSet);
   static SAdvancementResults AdvanceAdditiveAnim(std::shared_ptr<CAnimTreeNode>& anim, const CCharAnimTime& time);
-  SAdvancementDeltas AdvanceAdditiveAnims(float);
-  SAdvancementDeltas UpdateAdditiveAnims(float);
-  bool IsAdditiveAnimation(s32) const;
-  bool IsAdditiveAnimationAdded(s32) const;
+  SAdvancementDeltas AdvanceAdditiveAnims(float dt);
+  SAdvancementDeltas UpdateAdditiveAnims(float dt);
+  bool IsAdditiveAnimation(s32 idx) const;
+  bool IsAdditiveAnimationAdded(s32 idx) const;
   const std::shared_ptr<CAnimTreeNode>& GetRootAnimationTree() const { return x1f8_animRoot; }
-  const std::shared_ptr<CAnimTreeNode>& GetAdditiveAnimationTree(s32) const;
-  bool IsAdditiveAnimationActive(s32) const;
-  void DelAdditiveAnimation(s32);
-  void AddAdditiveAnimation(s32, float, bool, bool);
+  const std::shared_ptr<CAnimTreeNode>& GetAdditiveAnimationTree(s32 idx) const;
+  bool IsAdditiveAnimationActive(s32 idx) const;
+  void DelAdditiveAnimation(s32 idx);
+  void AddAdditiveAnimation(s32 idx, float weight, bool active, bool fadeOut);
   float GetAdditiveAnimationWeight(s32 idx) const;
   std::shared_ptr<CAnimationManager> GetAnimationManager();
   const CCharacterInfo& GetCharacterInfo() const { return xc_charInfo; }
   const CCharLayoutInfo& GetCharLayoutInfo() const { return *xcc_layoutData.GetObj(); }
-  void SetPhase(float);
+  void SetPhase(float ph);
   void Touch(const CSkinnedModel& model, int shaderIdx) const;
   SAdvancementDeltas GetAdvancementDeltas(const CCharAnimTime& a, const CCharAnimTime& b) const;
-  CCharAnimTime GetTimeOfUserEvent(EUserEventType, const CCharAnimTime& time) const;
-  void MultiplyPlaybackRate(float);
-  void SetPlaybackRate(float);
-  void SetRandomPlaybackRate(CRandom16&);
+  CCharAnimTime GetTimeOfUserEvent(EUserEventType type, const CCharAnimTime& time) const;
+  void MultiplyPlaybackRate(float mul);
+  void SetPlaybackRate(float set);
+  void SetRandomPlaybackRate(CRandom16& r);
   void CalcPlaybackAlignmentParms(const CAnimPlaybackParms& parms, const std::shared_ptr<CAnimTreeNode>& node);
   zeus::CTransform GetLocatorTransform(CSegId id, const CCharAnimTime* time) const;
   zeus::CTransform GetLocatorTransform(std::string_view name, const CCharAnimTime* time) const;
-  bool IsAnimTimeRemaining(float, std::string_view name) const;
+  bool IsAnimTimeRemaining(float rem, std::string_view name) const;
   float GetAnimTimeRemaining(std::string_view name) const;
-  float GetAnimationDuration(int) const;
+  float GetAnimationDuration(int animIn) const;
   bool GetIsLoop() const { return x220_25_loop; }
   void EnableLooping(bool val) {
     x220_25_loop = val;
@@ -201,7 +201,7 @@ public:
   void SetAnimDir(EAnimDir dir) { x104_animDir = dir; }
   std::shared_ptr<CAnimSysContext> GetAnimSysContext() const;
   std::shared_ptr<CAnimationManager> GetAnimationManager() const;
-  void RecalcPoseBuilder(const CCharAnimTime*);
+  void RecalcPoseBuilder(const CCharAnimTime* time);
   void RenderAuxiliary(const zeus::CFrustum& frustum) const;
   void Render(CSkinnedModel& model, const CModelFlags& drawFlags,
               const std::optional<CVertexMorphEffect>& morphEffect, const float* morphMagnitudes);
@@ -214,11 +214,11 @@ public:
   static void PrimitiveSetToTokenVector(const std::set<CPrimitive>& primSet, std::vector<CToken>& tokensOut,
                                         bool preLock);
   void GetAnimationPrimitives(const CAnimPlaybackParms& parms, std::set<CPrimitive>& primsOut) const;
-  void SetAnimation(const CAnimPlaybackParms& parms, bool);
-  SAdvancementDeltas DoAdvance(float, bool& suspendParticles, CRandom16&, bool advTree);
-  SAdvancementDeltas Advance(float, const zeus::CVector3f&, CStateManager& stateMgr, TAreaId aid, bool advTree);
-  SAdvancementDeltas AdvanceIgnoreParticles(float, CRandom16&, bool advTree);
-  void AdvanceAnim(CCharAnimTime& time, zeus::CVector3f&, zeus::CQuaternion&);
+  void SetAnimation(const CAnimPlaybackParms& parms, bool noTrans);
+  SAdvancementDeltas DoAdvance(float dt, bool& suspendParticles, CRandom16& random, bool advTree);
+  SAdvancementDeltas Advance(float dt, const zeus::CVector3f& scale, CStateManager& stateMgr, TAreaId aid, bool advTree);
+  SAdvancementDeltas AdvanceIgnoreParticles(float dt, CRandom16& random, bool advTree);
+  void AdvanceAnim(CCharAnimTime& time, zeus::CVector3f& offset, zeus::CQuaternion& quat);
   void SetXRayModel(const TLockedToken<CModel>& model, const TLockedToken<CSkinRules>& skinRules);
   std::shared_ptr<CSkinnedModel> GetXRayModel() const { return xf4_xrayModel; }
   void SetInfraModel(const TLockedToken<CModel>& model, const TLockedToken<CSkinRules>& skinRules);


### PR DESCRIPTION
Provides at least some form of name for all functions in the interface. This allows IDEs to perform proper name inspection (as well as being slightly more informative to the reader in some cases).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/267)
<!-- Reviewable:end -->
