### PR TITLE
CIntElement: Remove const_cast

### DIFF
--- a/Runtime/Particle/CIntElement.cpp
+++ b/Runtime/Particle/CIntElement.cpp
@@ -189,12 +189,12 @@ bool CIESampleAndHold::GetValue(int frame, int& valOut) const {
     int b, c;
     xc_waitFramesMin->GetValue(frame, b);
     x10_waitFramesMax->GetValue(frame, c);
-    /* const-correctness, who needs it? */
-    const_cast<CIESampleAndHold*>(this)->x8_nextSampleFrame = CRandom16::GetRandomNumber()->Range(b, c) + frame;
+    x8_nextSampleFrame = CRandom16::GetRandomNumber()->Range(b, c) + frame;
     x4_sampleSource->GetValue(frame, valOut);
-    const_cast<CIESampleAndHold*>(this)->x14_holdVal = valOut;
-  } else
+    x14_holdVal = valOut;
+  } else {
     valOut = x14_holdVal;
+  }
   return false;
 }
 

--- a/Runtime/Particle/CIntElement.hpp
+++ b/Runtime/Particle/CIntElement.hpp
@@ -134,10 +134,10 @@ public:
 
 class CIESampleAndHold : public CIntElement {
   std::unique_ptr<CIntElement> x4_sampleSource;
-  int x8_nextSampleFrame = 0;
+  mutable int x8_nextSampleFrame = 0;
   std::unique_ptr<CIntElement> xc_waitFramesMin;
   std::unique_ptr<CIntElement> x10_waitFramesMax;
-  int x14_holdVal;
+  mutable int x14_holdVal;
 
 public:
   CIESampleAndHold(std::unique_ptr<CIntElement>&& a, std::unique_ptr<CIntElement>&& b, std::unique_ptr<CIntElement>&& c)


### PR DESCRIPTION
CIESampleAndHold caches values internally for use later in a non-visible manner to the user of the class. This is a good place for mutable to be used.

This improves the readability of the GetValue() implementation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/268)
<!-- Reviewable:end -->
