### PR TITLE
CFluidPlane: Always initialize mul to 0.0f in CalculateRippleIntensity()

### DIFF
--- a/Runtime/World/CFluidPlane.cpp
+++ b/Runtime/World/CFluidPlane.cpp
@@ -35,7 +35,7 @@ float CFluidPlane::ProjectRippleVelocity(float baseI, float velDot) const {
 }
 
 float CFluidPlane::CalculateRippleIntensity(float baseI) const {
-  float mul;
+  float mul = 0.0f;
   switch (x44_fluidType) {
   case EFluidType::NormalWater:
     mul = g_tweakGame->GetRippleIntensityNormal();


### PR DESCRIPTION
Avoids a -Wmaybe-uninitialized warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/272)
<!-- Reviewable:end -->
