### PR TITLE
CTeamAiMgr: Initialize x90_timeSinceMelee and x90_timeSinceRanged to 0.0f in constructor

### DIFF
--- a/Runtime/World/CTeamAiMgr.hpp
+++ b/Runtime/World/CTeamAiMgr.hpp
@@ -64,10 +64,10 @@ private:
   std::vector<CTeamAiRole> x58_roles;
   std::vector<TUniqueId> x68_meleeAttackers;
   std::vector<TUniqueId> x78_rangedAttackers;
-  float x88_timeDirty = 0.f;
+  float x88_timeDirty = 0.0f;
   TUniqueId x8c_teamCaptainId = kInvalidUniqueId;
-  float x90_timeSinceMelee;
-  float x94_timeSinceRanged;
+  float x90_timeSinceMelee = 0.0f;
+  float x94_timeSinceRanged = 0.0f;
 
   void UpdateTeamCaptain();
   bool ShouldUpdateRoles(float dt);


### PR DESCRIPTION
Makes all class members have a deterministic initial state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/273)
<!-- Reviewable:end -->
