### PR TITLE
CGameState: Set HP value in LoadGameFileState()

### DIFF
--- a/Runtime/CGameState.cpp
+++ b/Runtime/CGameState.cpp
@@ -111,6 +111,7 @@ CGameState::GameFileStateInfo CGameState::LoadGameFileState(const u8* data) {
 
   CPlayerState playerState(stream);
   ret.x10_energyTanks = playerState.GetItemCapacity(CPlayerState::EItemType::EnergyTanks);
+  ret.xc_health = playerState.GetHealthInfo().GetHP();
 
   u32 itemPercent;
   if (origMLVL == 0x158EFE17)


### PR DESCRIPTION
Unless I'm mistaken, GM8E v0 stores the HP value of the loaded player state into the returned
GameFileStateInfo instance.

This prevents the health value from being returned uninitialized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/274)
<!-- Reviewable:end -->
