### PR TITLE
CPlayerState: Rename HealthInfo() to GetHealthInfo()

### DIFF
--- a/Runtime/CPlayerState.cpp
+++ b/Runtime/CPlayerState.cpp
@@ -182,7 +182,7 @@ u32 CPlayerState::CalculateItemCollectionRate() const {
   return total + GetItemCapacity(EItemType::Wavebuster);
 }
 
-CHealthInfo& CPlayerState::HealthInfo() { return xc_health; }
+CHealthInfo& CPlayerState::GetHealthInfo() { return xc_health; }
 
 const CHealthInfo& CPlayerState::GetHealthInfo() const { return xc_health; }
 

--- a/Runtime/CPlayerState.hpp
+++ b/Runtime/CPlayerState.hpp
@@ -123,7 +123,7 @@ public:
   static constexpr float GetMissileComboChargeFactor() { return 1.8f; }
   u32 CalculateItemCollectionRate() const;
 
-  CHealthInfo& HealthInfo();
+  CHealthInfo& GetHealthInfo();
   const CHealthInfo& GetHealthInfo() const;
   u32 GetPickupTotal() { return 99; }
   void SetIsFusionEnabled(bool val) { x0_26_fusion = val; }

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -1049,7 +1049,7 @@ void CPlayer::TakeDamage(bool significant, const zeus::CVector3f& location, floa
 
 void CPlayer::Accept(IVisitor& visitor) { visitor.Visit(this); }
 
-CHealthInfo* CPlayer::HealthInfo(CStateManager& mgr) { return &mgr.GetPlayerState()->HealthInfo(); }
+CHealthInfo* CPlayer::HealthInfo(CStateManager& mgr) { return &mgr.GetPlayerState()->GetHealthInfo(); }
 
 bool CPlayer::IsUnderBetaMetroidAttack(const CStateManager& mgr) const {
   if (x274_energyDrain.GetEnergyDrainIntensity() > 0.f) {


### PR DESCRIPTION
Allows const overloading to function and prevents compilation errors from occurring if constness changes through future changes of any sort.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/275)
<!-- Reviewable:end -->
