### PR TITLE
General: Make use of explicit constructors where applicable

### DIFF
--- a/Runtime/CDependencyGroup.hpp
+++ b/Runtime/CDependencyGroup.hpp
@@ -8,7 +8,7 @@ class CDependencyGroup {
   std::vector<SObjectTag> x0_objectTags;
 
 public:
-  CDependencyGroup(CInputStream& in);
+  explicit CDependencyGroup(CInputStream& in);
   void ReadFromStream(CInputStream& in);
   const std::vector<SObjectTag>& GetObjectTagVector() const { return x0_objectTags; }
 };

--- a/Runtime/CGameOptions.hpp
+++ b/Runtime/CGameOptions.hpp
@@ -71,7 +71,7 @@ class CPersistentOptions {
 
 public:
   CPersistentOptions() = default;
-  CPersistentOptions(CBitStreamReader& stream);
+  explicit CPersistentOptions(CBitStreamReader& stream);
 
   bool GetCinematicState(CAssetId mlvlId, TEditorId cineId) const;
   void SetCinematicState(CAssetId mlvlId, TEditorId cineId, bool state);
@@ -134,7 +134,7 @@ class CGameOptions {
 
 public:
   CGameOptions();
-  CGameOptions(CBitStreamReader& stream);
+  explicit CGameOptions(CBitStreamReader& stream);
   void ResetToDefaults();
   void InitSoundMode();
   void EnsureSettings();
@@ -201,7 +201,7 @@ private:
 
 public:
   CHintOptions() = default;
-  CHintOptions(CBitStreamReader& stream);
+  explicit CHintOptions(CBitStreamReader& stream);
   void PutTo(CBitStreamWriter& writer) const;
   void SetNextHintTime();
   void InitializeMemoryState();

--- a/Runtime/CIOWin.hpp
+++ b/Runtime/CIOWin.hpp
@@ -16,7 +16,7 @@ class CIOWin {
 
 public:
   enum class EMessageReturn { Normal = 0, Exit = 1, RemoveIOWinAndExit = 2, RemoveIOWin = 3 };
-  CIOWin(std::string_view name) : x4_name(name) { m_nameHash = std::hash<std::string_view>()(name); }
+  explicit CIOWin(std::string_view name) : x4_name(name) { m_nameHash = std::hash<std::string_view>()(name); }
 
   virtual ~CIOWin() = default;
   virtual EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) = 0;

--- a/Runtime/CMFGameBase.hpp
+++ b/Runtime/CMFGameBase.hpp
@@ -6,12 +6,12 @@ namespace urde {
 
 class CMFGameBase : public CIOWin {
 public:
-  CMFGameBase(const char* name) : CIOWin(name) {}
+  explicit CMFGameBase(const char* name) : CIOWin(name) {}
 };
 
 class CMFGameLoaderBase : public CIOWin {
 public:
-  CMFGameLoaderBase(const char* name) : CIOWin(name) {}
+  explicit CMFGameLoaderBase(const char* name) : CIOWin(name) {}
 };
 
 } // namespace urde

--- a/Runtime/CMainFlowBase.hpp
+++ b/Runtime/CMainFlowBase.hpp
@@ -11,7 +11,7 @@ protected:
   EClientFlowStates x14_gameState = EClientFlowStates::Unspecified;
 
 public:
-  CMainFlowBase(const char* name) : CIOWin(name) {}
+  explicit CMainFlowBase(const char* name) : CIOWin(name) {}
   EMessageReturn OnMessage(const CArchitectureMessage& msg, CArchitectureQueue& queue) override;
   virtual void AdvanceGameState(CArchitectureQueue& queue) = 0;
   virtual void SetGameState(EClientFlowStates state, CArchitectureQueue& queue) = 0;

--- a/Runtime/CPlayerState.hpp
+++ b/Runtime/CPlayerState.hpp
@@ -170,7 +170,7 @@ public:
   CStaticInterference& GetStaticInterference() { return x188_staticIntf; }
   const std::vector<std::pair<CAssetId, float>>& GetScanTimes() const { return x170_scanTimes; }
   CPlayerState();
-  CPlayerState(CBitStreamReader& stream);
+  explicit CPlayerState(CBitStreamReader& stream);
   void PutTo(CBitStreamWriter& stream);
   static u32 GetPowerUpMaxValue(EItemType type);
   static EItemType ItemNameToType(std::string_view name);

--- a/Runtime/CStaticInterference.hpp
+++ b/Runtime/CStaticInterference.hpp
@@ -16,7 +16,7 @@ class CStaticInterference {
   std::vector<CStaticInterferenceSource> m_sources;
 
 public:
-  CStaticInterference(int sourceCount);
+  explicit CStaticInterference(int sourceCount);
   void RemoveSource(TUniqueId id);
   void Update(CStateManager&, float dt);
   float GetTotalInterference() const;

--- a/Runtime/CTextureCache.hpp
+++ b/Runtime/CTextureCache.hpp
@@ -8,7 +8,7 @@ class CPaletteInfo {
   u64 m_dolphinHash;
 
 public:
-  CPaletteInfo(CInputStream& in)
+  explicit CPaletteInfo(CInputStream& in)
       : m_format(in.readUint32Big()), m_elementCount(in.readUint32Big()), m_dolphinHash(in.readUint64Big()) {}
 };
 class CTextureInfo {
@@ -20,7 +20,7 @@ class CTextureInfo {
   std::optional<CPaletteInfo> m_paletteInfo;
 
 public:
-  CTextureInfo(CInputStream& in)
+  explicit CTextureInfo(CInputStream& in)
       : m_format(ETexelFormat(in.readUint32Big()))
       , m_mipCount(in.readUint32Big())
       , m_width(in.readUint16Big())
@@ -36,7 +36,7 @@ public:
   std::map<CAssetId, CTextureInfo> m_textureInfo;
 
 public:
-  CTextureCache(CInputStream& in);
+  explicit CTextureCache(CInputStream& in);
 
 
   const CTextureInfo* GetTextureInfo(CAssetId id) const;

--- a/Runtime/GuiSys/CCompoundTargetReticle.hpp
+++ b/Runtime/GuiSys/CCompoundTargetReticle.hpp
@@ -59,7 +59,7 @@ public:
     float x10_rotAng = 0.f;
     float x14_baseAngle = 0.f;
     float x18_offshootAngleDelta = 0.f;
-    SOuterItemInfo(std::string_view);
+    explicit SOuterItemInfo(std::string_view);
   };
 
 private:
@@ -135,7 +135,7 @@ private:
                         bool zEqual) const;
 
 public:
-  CCompoundTargetReticle(const CStateManager&);
+  explicit CCompoundTargetReticle(const CStateManager&);
 
   void SetLeadingOrientation(const zeus::CQuaternion& o) { x0_leadingOrientation = o; }
   bool CheckLoadComplete() { return true; }

--- a/Runtime/GuiSys/CErrorOutputWindow.hpp
+++ b/Runtime/GuiSys/CErrorOutputWindow.hpp
@@ -24,7 +24,7 @@ private:
   const wchar_t* x1c_msg;
 
 public:
-  CErrorOutputWindow(bool);
+  explicit CErrorOutputWindow(bool);
   EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
   bool GetIsContinueDraw() const override { return int(x14_state) < 2; }
   void Draw() const override;

--- a/Runtime/GuiSys/CGuiCompoundWidget.hpp
+++ b/Runtime/GuiSys/CGuiCompoundWidget.hpp
@@ -6,7 +6,7 @@ namespace urde {
 
 class CGuiCompoundWidget : public CGuiWidget {
 public:
-  CGuiCompoundWidget(const CGuiWidgetParms& parms);
+  explicit CGuiCompoundWidget(const CGuiWidgetParms& parms);
   FourCC GetWidgetTypeID() const override { return FourCC(-1); }
 
   void OnVisibleChange() override;

--- a/Runtime/GuiSys/CGuiHeadWidget.hpp
+++ b/Runtime/GuiSys/CGuiHeadWidget.hpp
@@ -7,7 +7,7 @@ namespace urde {
 class CGuiHeadWidget : public CGuiWidget {
 public:
   FourCC GetWidgetTypeID() const override { return FOURCC('HWIG'); }
-  CGuiHeadWidget(const CGuiWidgetParms& parms);
+  explicit CGuiHeadWidget(const CGuiWidgetParms& parms);
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);
 
   std::shared_ptr<CGuiHeadWidget> shared_from_this() {

--- a/Runtime/GuiSys/CGuiWidget.hpp
+++ b/Runtime/GuiSys/CGuiWidget.hpp
@@ -90,7 +90,7 @@ protected:
   std::string m_name;
 
 public:
-  CGuiWidget(const CGuiWidgetParms& parms);
+  explicit CGuiWidget(const CGuiWidgetParms& parms);
 
   static CGuiWidgetParms ReadWidgetHeader(CGuiFrame* frame, CInputStream& in);
   static std::shared_ptr<CGuiWidget> Create(CGuiFrame* frame, CInputStream& in, CSimplePool* sp);

--- a/Runtime/GuiSys/CHudBossEnergyInterface.hpp
+++ b/Runtime/GuiSys/CHudBossEnergyInterface.hpp
@@ -20,7 +20,7 @@ class CHudBossEnergyInterface {
   CGuiTextPane* x1c_textpane_boss;
 
 public:
-  CHudBossEnergyInterface(CGuiFrame& selHud);
+  explicit CHudBossEnergyInterface(CGuiFrame& selHud);
   void Update(float dt);
   void SetAlpha(float a) { x0_alpha = a; }
   void SetBossParams(bool visible, std::u16string_view name, float curEnergy, float maxEnergy);

--- a/Runtime/GuiSys/CHudDecoInterface.hpp
+++ b/Runtime/GuiSys/CHudDecoInterface.hpp
@@ -104,7 +104,7 @@ class CHudDecoInterfaceScan : public IHudDecoInterface {
   void UpdateVisibility();
 
 public:
-  CHudDecoInterfaceScan(CGuiFrame& selHud);
+  explicit CHudDecoInterfaceScan(CGuiFrame& selHud);
   void SetIsVisibleDebug(bool v) override;
   void SetIsVisibleGame(bool v) override;
   void SetHudRotation(const zeus::CQuaternion& rot) override;

--- a/Runtime/GuiSys/CHudHelmetInterface.hpp
+++ b/Runtime/GuiSys/CHudHelmetInterface.hpp
@@ -30,7 +30,7 @@ class CHudHelmetInterface {
   void UpdateVisibility();
 
 public:
-  CHudHelmetInterface(CGuiFrame& helmetFrame);
+  explicit CHudHelmetInterface(CGuiFrame& helmetFrame);
   void Update(float dt);
   void SetHudLagOffset(const zeus::CVector3f& off);
   void SetHudLagRotation(const zeus::CMatrix3f& rot);

--- a/Runtime/GuiSys/CInstruction.hpp
+++ b/Runtime/GuiSys/CInstruction.hpp
@@ -44,7 +44,7 @@ class CFontInstruction : public CInstruction {
   TLockedToken<CRasterFont> x4_font;
 
 public:
-  CFontInstruction(const TToken<CRasterFont>& font) : x4_font(font) {}
+  explicit CFontInstruction(const TToken<CRasterFont>& font) : x4_font(font) {}
   void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
   void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
   void GetAssets(std::vector<CToken>& assetsOut) const override;
@@ -55,7 +55,7 @@ class CLineExtraSpaceInstruction : public CInstruction {
   s32 x4_extraSpace;
 
 public:
-  CLineExtraSpaceInstruction(s32 extraSpace) : x4_extraSpace(extraSpace) {}
+  explicit CLineExtraSpaceInstruction(s32 extraSpace) : x4_extraSpace(extraSpace) {}
   void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
   void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
@@ -107,7 +107,7 @@ class CLineSpacingInstruction : public CInstruction {
   float x4_lineSpacing;
 
 public:
-  CLineSpacingInstruction(float spacing) : x4_lineSpacing(spacing) {}
+  explicit CLineSpacingInstruction(float spacing) : x4_lineSpacing(spacing) {}
   void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
   void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
@@ -128,7 +128,7 @@ class CRemoveColorOverrideInstruction : public CInstruction {
   int x4_idx;
 
 public:
-  CRemoveColorOverrideInstruction(int idx) : x4_idx(idx) {}
+  explicit CRemoveColorOverrideInstruction(int idx) : x4_idx(idx) {}
   void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
   void PageInvoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
 };
@@ -137,7 +137,7 @@ class CImageInstruction : public CInstruction {
   CFontImageDef x4_image;
 
 public:
-  CImageInstruction(const CFontImageDef& image) : x4_image(image) {}
+  explicit CImageInstruction(const CFontImageDef& image) : x4_image(image) {}
   void Invoke(CFontRenderState& state, CTextRenderBuffer* buf) const override;
   void GetAssets(std::vector<CToken>& assetsOut) const override;
   size_t GetAssetCount() const override;

--- a/Runtime/GuiSys/CSplashScreen.hpp
+++ b/Runtime/GuiSys/CSplashScreen.hpp
@@ -22,7 +22,7 @@ private:
   CTexturedQuadFilterAlpha m_quad;
 
 public:
-  CSplashScreen(ESplashScreen);
+  explicit CSplashScreen(ESplashScreen);
   EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
   void Draw() const override;
 };

--- a/Runtime/GuiSys/CStringTable.hpp
+++ b/Runtime/GuiSys/CStringTable.hpp
@@ -13,7 +13,7 @@ class CStringTable {
   u32 m_bufLen;
 
 public:
-  CStringTable(CInputStream& in);
+  explicit CStringTable(CInputStream& in);
   void LoadStringTable(CInputStream& in);
 
   const char16_t* GetString(s32) const;

--- a/Runtime/GuiSys/CTargetingManager.hpp
+++ b/Runtime/GuiSys/CTargetingManager.hpp
@@ -10,7 +10,7 @@ class CTargetingManager {
   COrbitPointMarker x21c_orbitPointMarker;
 
 public:
-  CTargetingManager(const CStateManager& stateMgr);
+  explicit CTargetingManager(const CStateManager& stateMgr);
   bool CheckLoadComplete();
   void Update(float, const CStateManager& stateMgr);
   void Draw(const CStateManager& stateMgr, bool hideLockon) const;

--- a/Runtime/GuiSys/CTextParser.hpp
+++ b/Runtime/GuiSys/CTextParser.hpp
@@ -27,7 +27,7 @@ class CTextParser {
   TToken<CRasterFont> GetFont(const char16_t* str, int len);
 
 public:
-  CTextParser(IObjectStore& store) : x0_store(store) {}
+  explicit CTextParser(IObjectStore& store) : x0_store(store) {}
   void ParseText(CTextExecuteBuffer& out, const char16_t* str, int len,
                  const std::vector<std::pair<CAssetId, CAssetId>>* txtrMap);
 };

--- a/Runtime/Particle/CColorElement.hpp
+++ b/Runtime/Particle/CColorElement.hpp
@@ -20,7 +20,7 @@ class CCEKeyframeEmitter : public CColorElement {
   std::vector<zeus::CColor> x18_keys;
 
 public:
-  CCEKeyframeEmitter(CInputStream& in);
+  explicit CCEKeyframeEmitter(CInputStream& in);
   bool GetValue(int frame, zeus::CColor& colorOut) const override;
 };
 

--- a/Runtime/Particle/CElementGen.hpp
+++ b/Runtime/Particle/CElementGen.hpp
@@ -43,7 +43,7 @@ public:
     zeus::CVector3f x4_viewPoint;
 
   public:
-    CParticleListItem(s16 idx) : x0_partIdx(idx) {}
+    explicit CParticleListItem(s16 idx) : x0_partIdx(idx) {}
   };
   static CParticle* g_currentParticle;
 

--- a/Runtime/Particle/CIntElement.hpp
+++ b/Runtime/Particle/CIntElement.hpp
@@ -19,7 +19,7 @@ class CIEKeyframeEmitter : public CIntElement {
   std::vector<int> x18_keys;
 
 public:
-  CIEKeyframeEmitter(CInputStream& in);
+  explicit CIEKeyframeEmitter(CInputStream& in);
   bool GetValue(int frame, int& valOut) const override;
   int GetMaxValue() const override;
 };
@@ -73,7 +73,7 @@ class CIEConstant : public CIntElement {
   int x4_val;
 
 public:
-  CIEConstant(int val) : x4_val(val) {}
+  explicit CIEConstant(int val) : x4_val(val) {}
   bool GetValue(int frame, int& valOut) const override;
   int GetMaxValue() const override;
 };
@@ -82,7 +82,7 @@ class CIEImpulse : public CIntElement {
   std::unique_ptr<CIntElement> x4_a;
 
 public:
-  CIEImpulse(std::unique_ptr<CIntElement>&& a) : x4_a(std::move(a)) {}
+  explicit CIEImpulse(std::unique_ptr<CIntElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, int& valOut) const override;
   int GetMaxValue() const override;
 };
@@ -91,7 +91,7 @@ class CIELifetimePercent : public CIntElement {
   std::unique_ptr<CIntElement> x4_percentVal;
 
 public:
-  CIELifetimePercent(std::unique_ptr<CIntElement>&& a) : x4_percentVal(std::move(a)) {}
+  explicit CIELifetimePercent(std::unique_ptr<CIntElement>&& a) : x4_percentVal(std::move(a)) {}
   bool GetValue(int frame, int& valOut) const override;
   int GetMaxValue() const override;
 };
@@ -161,7 +161,7 @@ class CIETimeScale : public CIntElement {
   std::unique_ptr<CRealElement> x4_a;
 
 public:
-  CIETimeScale(std::unique_ptr<CRealElement>&& a) : x4_a(std::move(a)) {}
+  explicit CIETimeScale(std::unique_ptr<CRealElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, int& valOut) const override;
   int GetMaxValue() const override;
 };

--- a/Runtime/Particle/CModVectorElement.hpp
+++ b/Runtime/Particle/CModVectorElement.hpp
@@ -112,7 +112,7 @@ class CMVEGravity : public CModVectorElement {
   std::unique_ptr<CVectorElement> x4_a;
 
 public:
-  CMVEGravity(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CMVEGravity(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 
@@ -130,7 +130,7 @@ class CMVESetPosition : public CModVectorElement {
   std::unique_ptr<CVectorElement> x4_a;
 
 public:
-  CMVESetPosition(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CMVESetPosition(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, zeus::CVector3f& pVel, zeus::CVector3f& pPos) const override;
 };
 

--- a/Runtime/Particle/CParticleElectric.hpp
+++ b/Runtime/Particle/CParticleElectric.hpp
@@ -115,7 +115,7 @@ private:
   void BuildBounds();
 
 public:
-  CParticleElectric(const TToken<CElectricDescription>& desc);
+  explicit CParticleElectric(const TToken<CElectricDescription>& desc);
 
   bool Update(double) override;
   void Render(const CActorLights* lights = nullptr) override;

--- a/Runtime/Particle/CRealElement.hpp
+++ b/Runtime/Particle/CRealElement.hpp
@@ -20,7 +20,7 @@ class CREKeyframeEmitter : public CRealElement {
   std::vector<float> x18_keys;
 
 public:
-  CREKeyframeEmitter(CInputStream& in);
+  explicit CREKeyframeEmitter(CInputStream& in);
   bool GetValue(int frame, float& valOut) const override;
 };
 
@@ -38,7 +38,7 @@ class CREConstant : public CRealElement {
   float x4_val;
 
 public:
-  CREConstant(float val) : x4_val(val) {}
+  explicit CREConstant(float val) : x4_val(val) {}
   bool GetValue(int frame, float& valOut) const override;
   bool IsConstant() const override { return true; }
 };
@@ -133,7 +133,7 @@ class CRETimeScale : public CRealElement {
   std::unique_ptr<CRealElement> x4_a;
 
 public:
-  CRETimeScale(std::unique_ptr<CRealElement>&& a) : x4_a(std::move(a)) {}
+  explicit CRETimeScale(std::unique_ptr<CRealElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, float& valOut) const override;
 };
 
@@ -141,7 +141,7 @@ class CRELifetimePercent : public CRealElement {
   std::unique_ptr<CRealElement> x4_percentVal;
 
 public:
-  CRELifetimePercent(std::unique_ptr<CRealElement>&& a) : x4_percentVal(std::move(a)) {}
+  explicit CRELifetimePercent(std::unique_ptr<CRealElement>&& a) : x4_percentVal(std::move(a)) {}
   bool GetValue(int frame, float& valOut) const override;
 };
 
@@ -256,7 +256,7 @@ class CREVectorMagnitude : public CRealElement {
   std::unique_ptr<CVectorElement> x4_a;
 
 public:
-  CREVectorMagnitude(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CREVectorMagnitude(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, float& valOut) const override;
 };
 
@@ -264,7 +264,7 @@ class CREVectorXToReal : public CRealElement {
   std::unique_ptr<CVectorElement> x4_a;
 
 public:
-  CREVectorXToReal(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CREVectorXToReal(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, float& valOut) const override;
 };
 
@@ -272,7 +272,7 @@ class CREVectorYToReal : public CRealElement {
   std::unique_ptr<CVectorElement> x4_a;
 
 public:
-  CREVectorYToReal(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CREVectorYToReal(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, float& valOut) const override;
 };
 
@@ -280,7 +280,7 @@ class CREVectorZToReal : public CRealElement {
   std::unique_ptr<CVectorElement> x4_a;
 
 public:
-  CREVectorZToReal(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CREVectorZToReal(std::unique_ptr<CVectorElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, float& valOut) const override;
 };
 
@@ -288,7 +288,7 @@ class CREExternalVar : public CRealElement {
   std::unique_ptr<CIntElement> x4_a;
 
 public:
-  CREExternalVar(std::unique_ptr<CIntElement>&& a) : x4_a(std::move(a)) {}
+  explicit CREExternalVar(std::unique_ptr<CIntElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, float& valOut) const override;
 };
 
@@ -326,7 +326,7 @@ class CREGetComponentRed : public CRealElement {
   std::unique_ptr<CColorElement> x4_a;
 
 public:
-  CREGetComponentRed(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CREGetComponentRed(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
   bool GetValue(int frame, float& valOut) const override;
 };
@@ -335,7 +335,7 @@ class CREGetComponentGreen : public CRealElement {
   std::unique_ptr<CColorElement> x4_a;
 
 public:
-  CREGetComponentGreen(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CREGetComponentGreen(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
   bool GetValue(int frame, float& valOut) const override;
 };
@@ -344,7 +344,7 @@ class CREGetComponentBlue : public CRealElement {
   std::unique_ptr<CColorElement> x4_a;
 
 public:
-  CREGetComponentBlue(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CREGetComponentBlue(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
   bool GetValue(int frame, float& valOut) const override;
 };
@@ -353,7 +353,7 @@ class CREGetComponentAlpha : public CRealElement {
   std::unique_ptr<CColorElement> x4_a;
 
 public:
-  CREGetComponentAlpha(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CREGetComponentAlpha(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
   bool GetValue(int frame, float& valOut) const override;
 };

--- a/Runtime/Particle/CSpawnSystemKeyframeData.hpp
+++ b/Runtime/Particle/CSpawnSystemKeyframeData.hpp
@@ -24,7 +24,7 @@ public:
     void LoadToken(CSimplePool* pool);
 
   public:
-    CSpawnSystemKeyframeInfo(CInputStream& in);
+    explicit CSpawnSystemKeyframeInfo(CInputStream& in);
     TLockedToken<CGenDescription>& GetToken() { return x10_token; }
   };
 
@@ -36,7 +36,7 @@ private:
   std::vector<std::pair<u32, std::vector<CSpawnSystemKeyframeInfo>>> x10_spawns;
 
 public:
-  CSpawnSystemKeyframeData(CInputStream& in);
+  explicit CSpawnSystemKeyframeData(CInputStream& in);
   void LoadAllSpawnedSystemTokens(CSimplePool* pool);
   std::vector<CSpawnSystemKeyframeInfo>& GetSpawnedSystemsAtFrame(u32 frame);
 };

--- a/Runtime/Particle/CUVElement.hpp
+++ b/Runtime/Particle/CUVElement.hpp
@@ -29,7 +29,7 @@ struct CUVEConstant : public CUVElement {
   TLockedToken<CTexture> x4_tex;
 
 public:
-  CUVEConstant(TToken<CTexture>&& tex) : x4_tex(std::move(tex)) {}
+  explicit CUVEConstant(TToken<CTexture>&& tex) : x4_tex(std::move(tex)) {}
   TLockedToken<CTexture> GetValueTexture(int frame) const override { return TLockedToken<CTexture>(x4_tex); }
   void GetValueUV(int frame, SUVElementSet& valOut) const override { valOut = {0.f, 0.f, 1.f, 1.f}; }
   bool HasConstantTexture() const override { return true; }

--- a/Runtime/Particle/CVectorElement.hpp
+++ b/Runtime/Particle/CVectorElement.hpp
@@ -22,7 +22,7 @@ class CVEKeyframeEmitter : public CVectorElement {
   std::vector<zeus::CVector3f> x18_keys;
 
 public:
-  CVEKeyframeEmitter(CInputStream& in);
+  explicit CVEKeyframeEmitter(CInputStream& in);
   bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
@@ -138,7 +138,7 @@ class CVERealToVector : public CVectorElement {
   std::unique_ptr<CRealElement> x4_a;
 
 public:
-  CVERealToVector(std::unique_ptr<CRealElement>&& a) : x4_a(std::move(a)) {}
+  explicit CVERealToVector(std::unique_ptr<CRealElement>&& a) : x4_a(std::move(a)) {}
   bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };
 
@@ -204,7 +204,7 @@ class CVEColorToVector : public CVectorElement {
   std::unique_ptr<CColorElement> x4_a;
 
 public:
-  CVEColorToVector(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
+  explicit CVEColorToVector(std::unique_ptr<CColorElement>&& a) : x4_a(std::move(a)) {}
 
   bool GetValue(int frame, zeus::CVector3f& valOut) const override;
 };

--- a/Runtime/Weapon/CBeamInfo.hpp
+++ b/Runtime/Weapon/CBeamInfo.hpp
@@ -31,7 +31,7 @@ class CBeamInfo {
   zeus::CColor x40_outerColor;
 
 public:
-  CBeamInfo(CInputStream& in)
+  explicit CBeamInfo(CInputStream& in)
   : x0_(in.readUint32Big())
   , x4_beamAttributes(in.readUint32Big())
   , x8_contactFxId(in.readUint32Big())

--- a/Runtime/Weapon/CGunController.hpp
+++ b/Runtime/Weapon/CGunController.hpp
@@ -19,7 +19,7 @@ class CGunController {
   bool x58_25_enteredComboFire : 1;
 
 public:
-  CGunController(CModelData& modelData) : x0_modelData(modelData) {
+  explicit CGunController(CModelData& modelData) : x0_modelData(modelData) {
     x58_24_animDone = true;
     x58_25_enteredComboFire = false;
   }

--- a/Runtime/Weapon/CPlayerGun.cpp
+++ b/Runtime/Weapon/CPlayerGun.cpp
@@ -2267,12 +2267,12 @@ void CPlayerGun::DropBomb(EBWeapon weapon, CStateManager& mgr) {
     if (x308_bombCount <= 0)
       return;
 
-    zeus::CVector3f plPos = mgr.GetPlayer().GetTranslation();
-    zeus::CTransform xf =
+    const zeus::CVector3f plPos = mgr.GetPlayer().GetTranslation();
+    const zeus::CTransform xf =
         zeus::CTransform::Translate({plPos.x(), plPos.y(), plPos.z() + g_tweakPlayer->GetPlayerBallHalfExtent()});
-    CBomb* bomb =
-        new CBomb(x784_bombEffects[u32(weapon)][0], x784_bombEffects[u32(weapon)][1], mgr.AllocateUniqueId(),
-                  mgr.GetPlayer().GetAreaId(), x538_playerId, x354_bombFuseTime, xf, g_tweakPlayerGun->GetBombInfo());
+    CBomb* bomb = new CBomb(x784_bombEffects[u32(weapon)][0], x784_bombEffects[u32(weapon)][1], mgr.AllocateUniqueId(),
+                            mgr.GetPlayer().GetAreaId(), x538_playerId, x354_bombFuseTime, xf,
+                            CDamageInfo{g_tweakPlayerGun->GetBombInfo()});
     mgr.AddObject(bomb);
 
     if (x308_bombCount == 3)
@@ -2288,8 +2288,8 @@ void CPlayerGun::DropBomb(EBWeapon weapon, CStateManager& mgr) {
 }
 
 TUniqueId CPlayerGun::DropPowerBomb(CStateManager& mgr) {
-  CDamageInfo dInfo = (mgr.GetPlayer().GetDeathTime() <= 0.f ? g_tweakPlayerGun->GetPowerBombInfo()
-                                                             : CDamageInfo(CWeaponMode::PowerBomb(), 0.f, 0.f, 0.f));
+  const auto dInfo = mgr.GetPlayer().GetDeathTime() <= 0.f ? CDamageInfo{g_tweakPlayerGun->GetPowerBombInfo()}
+                                                           : CDamageInfo{CWeaponMode::PowerBomb(), 0.f, 0.f, 0.f};
 
   TUniqueId uid = mgr.AllocateUniqueId();
   zeus::CVector3f plVec = mgr.GetPlayer().GetTranslation();

--- a/Runtime/Weapon/CProjectileInfo.hpp
+++ b/Runtime/Weapon/CProjectileInfo.hpp
@@ -13,7 +13,7 @@ class CProjectileInfo {
   CDamageInfo xc_damageInfo;
 
 public:
-  CProjectileInfo(CInputStream&);
+  explicit CProjectileInfo(CInputStream&);
   CProjectileInfo(CAssetId, const CDamageInfo&);
 
   float GetProjectileSpeed() const;

--- a/Runtime/World/CAnimationParameters.hpp
+++ b/Runtime/World/CAnimationParameters.hpp
@@ -13,7 +13,7 @@ public:
   CAnimationParameters() = default;
   CAnimationParameters(CAssetId ancs, u32 charIdx, u32 defaultAnim)
   : x0_ancs(ancs), x4_charIdx(charIdx), x8_defaultAnim(defaultAnim) {}
-  CAnimationParameters(CInputStream& in)
+  explicit CAnimationParameters(CInputStream& in)
   : x0_ancs(in.readUint32Big()), x4_charIdx(in.readUint32Big()), x8_defaultAnim(in.readUint32Big()) {}
 
   CAssetId GetACSFile() const { return x0_ancs; }

--- a/Runtime/World/CDamageInfo.hpp
+++ b/Runtime/World/CDamageInfo.hpp
@@ -20,7 +20,7 @@ class CDamageInfo {
 
 public:
   constexpr CDamageInfo() = default;
-  CDamageInfo(CInputStream& in) {
+  explicit CDamageInfo(CInputStream& in) {
     in.readUint32Big();
     x0_weaponMode = CWeaponMode(EWeaponType(in.readUint32Big()));
     x8_damage = in.readFloatBig();
@@ -38,7 +38,7 @@ public:
   constexpr CDamageInfo& operator=(CDamageInfo&&) = default;
 
   CDamageInfo(const CDamageInfo&, float);
-  CDamageInfo(const DataSpec::SShotParam& other);
+  explicit CDamageInfo(const DataSpec::SShotParam& other);
   CDamageInfo& operator=(const DataSpec::SShotParam& other);
 
   const CWeaponMode& GetWeaponMode() const { return x0_weaponMode; }

--- a/Runtime/World/CDamageVulnerability.hpp
+++ b/Runtime/World/CDamageVulnerability.hpp
@@ -47,7 +47,7 @@ class CDamageVulnerability {
   static const CDamageVulnerability sPassThroughVulnerability;
 
 public:
-  CDamageVulnerability(CInputStream& in);
+  explicit CDamageVulnerability(CInputStream& in);
   CDamageVulnerability(EVulnerability power, EVulnerability ice, EVulnerability wave, EVulnerability plasma,
                        EVulnerability bomb, EVulnerability powerBomb, EVulnerability missile, EVulnerability boostBall,
                        EVulnerability phazon, EVulnerability enemyWp1, EVulnerability wnemyWp2, EVulnerability enemyWp3,

--- a/Runtime/World/CGameArea.hpp
+++ b/Runtime/World/CGameArea.hpp
@@ -86,7 +86,7 @@ struct CAreaRenderOctTree {
   const u32* x34_indirectionTable;
   const u8* x38_entries;
 
-  CAreaRenderOctTree(const u8* buf);
+  explicit CAreaRenderOctTree(const u8* buf);
 
   void FindOverlappingModels(std::vector<u32>& out, const zeus::CAABox& testAABB) const;
   void FindOverlappingModels(u32* out, const zeus::CAABox& testAABB) const;
@@ -131,10 +131,11 @@ class CGameArea final : public IGameArea {
 
 public:
   class CChainIterator {
-    CGameArea* m_area;
+    CGameArea* m_area = nullptr;
 
   public:
-    CChainIterator(CGameArea* area) : m_area(area) {}
+    constexpr CChainIterator() = default;
+    explicit constexpr CChainIterator(CGameArea* area) : m_area(area) {}
     CGameArea& operator*() const { return *m_area; }
     CGameArea* operator->() const { return m_area; }
     CChainIterator& operator++() {
@@ -146,10 +147,11 @@ public:
   };
 
   class CConstChainIterator {
-    const CGameArea* m_area;
+    const CGameArea* m_area = nullptr;
 
   public:
-    CConstChainIterator(const CGameArea* area) : m_area(area) {}
+    constexpr CConstChainIterator() = default;
+    explicit constexpr CConstChainIterator(const CGameArea* area) : m_area(area) {}
     const CGameArea& operator*() const { return *m_area; }
     const CGameArea* operator->() const { return m_area; }
     CConstChainIterator& operator++() {
@@ -165,7 +167,7 @@ public:
     TAreaId x200c_areaIdx = 0;
 
   public:
-    CAreaObjectList(TAreaId areaIdx) : CObjectList(EGameObjectList::Invalid), x200c_areaIdx(areaIdx) {}
+    explicit CAreaObjectList(TAreaId areaIdx) : CObjectList(EGameObjectList::Invalid), x200c_areaIdx(areaIdx) {}
 
     bool IsQualified(const CEntity& ent) const override;
   };
@@ -267,8 +269,8 @@ private:
   void UpdateWeaponWorldLighting(float dt);
 
 public:
-  CGameArea(CInputStream& in, int idx, int mlvlVersion);
-  CGameArea(CAssetId mreaId); // Warmup constructor
+  explicit CGameArea(CInputStream& in, int idx, int mlvlVersion);
+  explicit CGameArea(CAssetId mreaId); // Warmup constructor
   ~CGameArea();
 
   bool IsFinishedOccluding() const;

--- a/Runtime/World/CHUDMemoParms.hpp
+++ b/Runtime/World/CHUDMemoParms.hpp
@@ -14,7 +14,7 @@ public:
   CHUDMemoParms() = default;
   CHUDMemoParms(float dispTime, bool clearMemoWindow, bool fadeOutOnly, bool hintMemo)
   : x0_dispTime(dispTime), x4_clearMemoWindow(clearMemoWindow), x5_fadeOutOnly(fadeOutOnly), x6_hintMemo(hintMemo) {}
-  CHUDMemoParms(CInputStream& in) {
+  explicit CHUDMemoParms(CInputStream& in) {
     x0_dispTime = in.readFloatBig();
     x4_clearMemoWindow = in.readBool();
   }

--- a/Runtime/World/CHealthInfo.hpp
+++ b/Runtime/World/CHealthInfo.hpp
@@ -9,11 +9,11 @@ class CHealthInfo {
   float x4_knockbackResistance;
 
 public:
-  CHealthInfo(float hp) : x0_health(hp), x4_knockbackResistance(0.f) {}
+  explicit CHealthInfo(float hp) : x0_health(hp), x4_knockbackResistance(0.f) {}
 
   CHealthInfo(float hp, float resist) : x0_health(hp), x4_knockbackResistance(resist) {}
 
-  CHealthInfo(CInputStream& in);
+  explicit CHealthInfo(CInputStream& in);
   void SetHP(float hp) { x0_health = hp; }
   float GetHP() const { return x0_health; }
   float GetKnockbackResistance() const { return x4_knockbackResistance; }

--- a/Runtime/World/CPathFindRegion.hpp
+++ b/Runtime/World/CPathFindRegion.hpp
@@ -17,7 +17,7 @@ class CPFNode {
   zeus::CVector3f xc_normal;
 
 public:
-  CPFNode(CMemoryInStream& in);
+  explicit CPFNode(CMemoryInStream& in);
   const zeus::CVector3f& GetPos() const { return x0_position; }
   const zeus::CVector3f& GetNormal() const { return xc_normal; }
 };
@@ -29,7 +29,7 @@ class CPFLink {
   float xc_oo2dWidth;
 
 public:
-  CPFLink(CMemoryInStream& in);
+  explicit CPFLink(CMemoryInStream& in);
   u32 GetNode() const { return x0_node; }
   u32 GetRegion() const { return x4_region; }
   float Get2dWidth() const { return x8_2dWidth; }
@@ -51,7 +51,7 @@ class CPFRegion {
 
 public:
   CPFRegion() = default;
-  CPFRegion(CMemoryInStream& in);
+  explicit CPFRegion(CMemoryInStream& in);
   void SetData(CPFRegionData* data) { x4c_regionData = data; }
   CPFRegionData* Data() const { return x4c_regionData; }
   u32 GetIndex() const { return x24_regionIdx; }

--- a/Runtime/World/CPhysicsActor.hpp
+++ b/Runtime/World/CPhysicsActor.hpp
@@ -21,7 +21,7 @@ struct SMoverData {
   zeus::CAxisAngle x24_;
   float x30_mass;
 
-  SMoverData(float mass) : x30_mass(mass) {}
+  explicit SMoverData(float mass) : x30_mass(mass) {}
 };
 
 struct CMotionState {

--- a/Runtime/World/CScriptSpindleCamera.hpp
+++ b/Runtime/World/CScriptSpindleCamera.hpp
@@ -29,7 +29,7 @@ struct SSpindleProperty {
   float x10_lowIn;
   float x14_highIn;
 
-  SSpindleProperty(CInputStream& in);
+  explicit SSpindleProperty(CInputStream& in);
   void FixupAngles() {
     x8_lowOut = zeus::degToRad(x8_lowOut);
     xc_highOut = zeus::degToRad(xc_highOut);

--- a/Runtime/World/CScriptTrigger.cpp
+++ b/Runtime/World/CScriptTrigger.cpp
@@ -61,11 +61,13 @@ void CScriptTrigger::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CS
 
 CScriptTrigger::CObjectTracker* CScriptTrigger::FindObject(TUniqueId id) {
   auto& inhabitants = GetInhabitants();
-  const auto& iter = std::find(inhabitants.begin(), inhabitants.end(), id);
+  const auto iter = std::find(inhabitants.begin(), inhabitants.end(), CObjectTracker{id});
 
-  if (iter != inhabitants.end())
-    return &(*iter);
-  return nullptr;
+  if (iter == inhabitants.end()) {
+    return nullptr;
+  }
+
+  return &*iter;
 }
 
 void CScriptTrigger::UpdateInhabitants(float dt, CStateManager& mgr) {

--- a/Runtime/World/CScriptTrigger.hpp
+++ b/Runtime/World/CScriptTrigger.hpp
@@ -41,7 +41,7 @@ public:
     TUniqueId x0_id;
 
   public:
-    CObjectTracker(TUniqueId id) : x0_id(id) {}
+    explicit CObjectTracker(TUniqueId id) : x0_id(id) {}
 
     TUniqueId GetObjectId() const { return x0_id; }
     bool operator==(const CObjectTracker& other) const { return x0_id == other.x0_id; }

--- a/Runtime/World/CStateMachine.hpp
+++ b/Runtime/World/CStateMachine.hpp
@@ -75,7 +75,7 @@ class CStateMachine {
   std::vector<CAiTrigger> x10_triggers;
 
 public:
-  CStateMachine(CInputStream& in);
+  explicit CStateMachine(CInputStream& in);
 
   s32 GetStateIndex(std::string_view state) const;
   const std::vector<CAiState>& GetStateVector() const { return x0_states; }

--- a/Runtime/World/CWorld.cpp
+++ b/Runtime/World/CWorld.cpp
@@ -567,7 +567,7 @@ void CWorld::Update(float dt) {
 
   u32 areaCount = 0;
 
-  for (CGameArea* head = x4c_chainHeads[3]; head != skGlobalNonConstEnd; head = head->x130_next, ++areaCount) {
+  for (auto head = GetChainHead(EChain::Alive); head != AliveAreasEnd(); ++head, ++areaCount) {
     head->AliveUpdate(dt);
 
     if (head->DoesAreaNeedSkyNow()) {
@@ -625,7 +625,7 @@ void CWorld::Update(float dt) {
 }
 
 void CWorld::PreRender() {
-  for (CGameArea* head = x4c_chainHeads[3]; head != skGlobalNonConstEnd; head = head->x130_next) {
+  for (auto head = GetChainHead(EChain::Alive); head != AliveAreasEnd(); ++head) {
     head->PreRender();
   }
 }

--- a/Runtime/World/CWorld.hpp
+++ b/Runtime/World/CWorld.hpp
@@ -83,7 +83,7 @@ public:
 
   public:
     CRelay() = default;
-    CRelay(CInputStream& in);
+    explicit CRelay(CInputStream& in);
 
     TEditorId GetRelayId() const { return x0_relay; }
     TEditorId GetTargetId() const { return x4_target; }
@@ -104,8 +104,6 @@ public:
   };
 
 private:
-  static constexpr CGameArea* skGlobalEnd = nullptr;
-  static constexpr CGameArea* skGlobalNonConstEnd = nullptr;
   enum class Phase {
     Loading,
     LoadingMap,
@@ -158,12 +156,16 @@ public:
   void MoveToChain(CGameArea* area, EChain chain);
   void MoveAreaToAliveChain(TAreaId aid);
   bool CheckWorldComplete(CStateManager* mgr, TAreaId id, CAssetId mreaId);
-  CGameArea::CChainIterator GetChainHead(EChain chain) { return {x4c_chainHeads[int(chain)]}; }
-  CGameArea::CConstChainIterator GetChainHead(EChain chain) const { return {x4c_chainHeads[int(chain)]}; }
-  CGameArea::CChainIterator begin() { return GetChainHead(EChain::Alive); }
-  CGameArea::CChainIterator end() { return AliveAreasEnd(); }
-  CGameArea::CConstChainIterator begin() const { return GetChainHead(EChain::Alive); }
-  CGameArea::CConstChainIterator end() const { return GetAliveAreasEnd(); }
+
+  [[nodiscard]] auto GetChainHead(EChain chain) { return CGameArea::CChainIterator{x4c_chainHeads[size_t(chain)]}; }
+  [[nodiscard]] auto GetChainHead(EChain chain) const {
+    return CGameArea::CConstChainIterator{x4c_chainHeads[size_t(chain)]};
+  }
+  [[nodiscard]] auto begin() { return GetChainHead(EChain::Alive); }
+  [[nodiscard]] auto end() { return AliveAreasEnd(); }
+  [[nodiscard]] auto begin() const { return GetChainHead(EChain::Alive); }
+  [[nodiscard]] auto end() const { return GetAliveAreasEnd(); }
+
   bool ScheduleAreaToLoad(CGameArea* area, CStateManager& mgr);
   void TravelToArea(TAreaId aid, CStateManager& mgr, bool skipLoadOther);
   void SetLoadPauseState(bool paused);
@@ -195,8 +197,8 @@ public:
   int IGetAreaCount() const override;
 
   static void PropogateAreaChain(CGameArea::EOcclusionState occlusionState, CGameArea* area, CWorld* world);
-  static CGameArea::CConstChainIterator GetAliveAreasEnd() { return {skGlobalEnd}; }
-  static CGameArea::CChainIterator AliveAreasEnd() { return {skGlobalNonConstEnd}; }
+  static constexpr CGameArea::CConstChainIterator GetAliveAreasEnd() { return CGameArea::CConstChainIterator{}; }
+  static constexpr CGameArea::CChainIterator AliveAreasEnd() { return CGameArea::CChainIterator{}; }
 
   void Update(float dt);
   void PreRender();

--- a/Runtime/World/CWorldLight.hpp
+++ b/Runtime/World/CWorldLight.hpp
@@ -30,7 +30,7 @@ private:
 
 public:
   CWorldLight(const CWorldLight&) = default;
-  CWorldLight(CInputStream& in);
+  explicit CWorldLight(CInputStream& in);
   EWorldLightType GetLightType() const { return x0_type; }
   const zeus::CVector3f& GetDirection() const { return x1c_direction; }
   const zeus::CVector3f& GetPosition() const { return x10_position; }

--- a/Runtime/World/CWorldTransManager.hpp
+++ b/Runtime/World/CWorldTransManager.hpp
@@ -48,7 +48,7 @@ public:
     float x1d8_transCompleteTime = 99999.f;
     bool x1dc_dissolveStarted = false;
 
-    SModelDatas(const CAnimRes& samusRes);
+    explicit SModelDatas(const CAnimRes& samusRes);
   };
 
 private:


### PR DESCRIPTION
Gets rid of potential error prone implicitly constructing constructors.

Made this separately so that others could give it a once-over, given the surface area touched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/278)
<!-- Reviewable:end -->
