### PR TITLE
CToken: Mark move assignment operator as noexcept

### DIFF
--- a/Runtime/CToken.cpp
+++ b/Runtime/CToken.cpp
@@ -112,7 +112,7 @@ CToken& CToken::operator=(const CToken& other) {
   }
   return *this;
 }
-CToken& CToken::operator=(CToken&& other) {
+CToken& CToken::operator=(CToken&& other) noexcept {
   Unlock();
   RemoveRef();
   x0_objRef = other.x0_objRef;

--- a/Runtime/CToken.hpp
+++ b/Runtime/CToken.hpp
@@ -153,7 +153,7 @@ public:
     m_obj = nullptr;
     return *this;
   }
-  TCachedToken& operator=(const CToken& other) {
+  TCachedToken& operator=(const CToken& other) override {
     TToken<T>::operator=(other);
     m_obj = nullptr;
     return *this;
@@ -172,7 +172,7 @@ public:
     return *this;
   }
   TLockedToken(const CToken& other) : TCachedToken<T>(other) { CToken::Lock(); }
-  TLockedToken& operator=(const CToken& other) {
+  TLockedToken& operator=(const CToken& other) override {
     CToken oldTok = std::move(*this);
     TCachedToken<T>::operator=(other);
     CToken::Lock();

--- a/Runtime/CToken.hpp
+++ b/Runtime/CToken.hpp
@@ -84,7 +84,7 @@ public:
   IObj* GetObj();
   const IObj* GetObj() const { return const_cast<CToken*>(this)->GetObj(); }
   CToken& operator=(const CToken& other);
-  CToken& operator=(CToken&& other);
+  CToken& operator=(CToken&& other) noexcept;
   CToken() = default;
   CToken(const CToken& other);
   CToken(CToken&& other) noexcept;


### PR DESCRIPTION
Allows containers and anything using std::move_if_noexcept to perform a move instead of a copy internally if reallocations are necessary.

`TToken` should likely also have a move assignment operator instead of only a copy assignment constructor, as this means all attempted `TToken`, `TCachedToken` and `TLockedToken` moves will fallback to the copy assignment operator in certain circumstances, which is a little suboptimal. However I think someone that has more intimate knowledge of the token classes should implement this.

`TLockedToken` similarly only has copy constructor/assignment defined for it, but not move construction/assignment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/urde/280)
<!-- Reviewable:end -->
