### PR TITLE
CTextRenderBuffer: Remove use of const_cast within Render()

### DIFF
--- a/Runtime/GuiSys/CGuiTextSupport.cpp
+++ b/Runtime/GuiSys/CGuiTextSupport.cpp
@@ -186,8 +186,8 @@ void CGuiTextSupport::AutoSetExtent() {
   x38_extentY = bounds.second.y;
 }
 
-void CGuiTextSupport::Render() const {
-  const_cast<CGuiTextSupport*>(this)->CheckAndRebuildRenderBuffer();
+void CGuiTextSupport::Render() {
+  CheckAndRebuildRenderBuffer();
   if (CTextRenderBuffer* buf = GetCurrentPageRenderBuffer()) {
     SCOPED_GRAPHICS_DEBUG_GROUP("CGuiTextSupport::Draw", zeus::skBlue);
     zeus::CTransform oldModel = CGraphics::g_GXModelMatrix;

--- a/Runtime/GuiSys/CGuiTextSupport.hpp
+++ b/Runtime/GuiSys/CGuiTextSupport.hpp
@@ -104,7 +104,7 @@ public:
   const std::pair<zeus::CVector2i, zeus::CVector2i>& GetBounds();
   void AutoSetExtent();
 
-  void Render() const;
+  void Render();
   void SetGeometryColor(const zeus::CColor& col);
   void SetOutlineColor(const zeus::CColor& col);
   void SetFontColor(const zeus::CColor& col);

--- a/Runtime/GuiSys/CTextRenderBuffer.cpp
+++ b/Runtime/GuiSys/CTextRenderBuffer.cpp
@@ -125,26 +125,26 @@ void CTextRenderBuffer::SetPrimitiveOpacity(int idx, float opacity) {
   m_primitiveMarks[idx].SetOpacity(*this, opacity);
 }
 
-void CTextRenderBuffer::Render(const zeus::CColor& col, float time) const {
-  const_cast<CTextRenderBuffer*>(this)->CommitResources();
+void CTextRenderBuffer::Render(const zeus::CColor& col, float time) {
+  CommitResources();
 
-  zeus::CMatrix4f mv = CGraphics::g_GXModelView.toMatrix4f();
-  zeus::CMatrix4f proj = CGraphics::GetPerspectiveProjectionMatrix(true);
-  zeus::CMatrix4f mat = proj * mv;
+  const zeus::CMatrix4f mv = CGraphics::g_GXModelView.toMatrix4f();
+  const zeus::CMatrix4f proj = CGraphics::GetPerspectiveProjectionMatrix(true);
+  const zeus::CMatrix4f mat = proj * mv;
 
-  const_cast<CTextRenderBuffer*>(this)->m_uniBuf.access() = CTextSupportShader::Uniform{mat, col};
+  m_uniBuf.access() = CTextSupportShader::Uniform{mat, col};
   if (m_drawFlags == CGuiWidget::EGuiModelDrawFlags::AlphaAdditiveOverdraw) {
     zeus::CColor colPremul = col * col.a();
     colPremul.a() = col.a();
-    const_cast<CTextRenderBuffer*>(this)->m_uniBuf2.access() = CTextSupportShader::Uniform{mat, colPremul};
+    m_uniBuf2.access() = CTextSupportShader::Uniform{mat, colPremul};
   }
 
-  for (const BooFontCharacters& chs : m_fontCharacters) {
+  for (BooFontCharacters& chs : m_fontCharacters) {
     if (chs.m_charData.size()) {
       if (chs.m_dirty) {
-        memmove(const_cast<BooFontCharacters&>(chs).m_instBuf.access(), chs.m_charData.data(),
-                sizeof(CTextSupportShader::CharacterInstance) * chs.m_charData.size());
-        const_cast<BooFontCharacters&>(chs).m_dirty = false;
+        std::memmove(chs.m_instBuf.access(), chs.m_charData.data(),
+                     sizeof(CTextSupportShader::CharacterInstance) * chs.m_charData.size());
+        chs.m_dirty = false;
       }
       CGraphics::SetShaderDataBinding(chs.m_dataBinding);
       CGraphics::DrawInstances(0, 4, chs.m_charData.size());
@@ -155,12 +155,12 @@ void CTextRenderBuffer::Render(const zeus::CColor& col, float time) const {
     }
   }
 
-  for (const BooImage& img : m_images) {
+  for (BooImage& img : m_images) {
     if (img.m_dirty) {
-      *const_cast<BooImage&>(img).m_instBuf.access() = img.m_imageData;
-      const_cast<BooImage&>(img).m_dirty = false;
+      *img.m_instBuf.access() = img.m_imageData;
+      img.m_dirty = false;
     }
-    int idx = int(img.m_imageDef.x0_fps * time) % img.m_dataBinding.size();
+    const int idx = int(img.m_imageDef.x0_fps * time) % img.m_dataBinding.size();
     CGraphics::SetShaderDataBinding(img.m_dataBinding[idx]);
     CGraphics::DrawInstances(0, 4, 1);
     if (m_drawFlags == CGuiWidget::EGuiModelDrawFlags::AlphaAdditiveOverdraw) {

--- a/Runtime/GuiSys/CTextRenderBuffer.hpp
+++ b/Runtime/GuiSys/CTextRenderBuffer.hpp
@@ -122,7 +122,7 @@ public:
   u32 GetPrimitiveCount() const { return m_primitiveMarks.size(); }
 #endif
   void SetMode(EMode mode);
-  void Render(const zeus::CColor& col, float) const;
+  void Render(const zeus::CColor& col, float time);
   void AddImage(const zeus::CVector2i& offset, const CFontImageDef& image);
   void AddCharacter(const zeus::CVector2i& offset, char16_t ch, const zeus::CColor& color);
   void AddPaletteChange(const zeus::CColor& main, const zeus::CColor& outline);


### PR DESCRIPTION
Same behavior but way less casting.