### PR TITLE
CIOWin: Make Draw() non-const

### DIFF
--- a/Runtime/CIOWin.hpp
+++ b/Runtime/CIOWin.hpp
@@ -21,8 +21,8 @@ public:
   virtual ~CIOWin() = default;
   virtual EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) = 0;
   virtual bool GetIsContinueDraw() const { return true; }
-  virtual void Draw() const {}
-  virtual void PreDraw() const {}
+  virtual void Draw() {}
+  virtual void PreDraw() {}
 
   std::string_view GetName() const { return x4_name; }
   size_t GetNameHash() const { return m_nameHash; }

--- a/Runtime/CPlayMovieBase.hpp
+++ b/Runtime/CPlayMovieBase.hpp
@@ -11,7 +11,7 @@ class CPlayMovieBase : public CIOWin {
 public:
   CPlayMovieBase(const char* iowName, const char* path) : CIOWin(iowName), x18_moviePlayer(path, 0.0, false, false) {}
   EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override { return EMessageReturn::Normal; }
-  void Draw() const override {}
+  void Draw() override {}
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CConsoleOutputWindow.cpp
+++ b/Runtime/GuiSys/CConsoleOutputWindow.cpp
@@ -9,7 +9,7 @@ CIOWin::EMessageReturn CConsoleOutputWindow::OnMessage(const CArchitectureMessag
   return EMessageReturn::Normal;
 }
 
-void CConsoleOutputWindow::Draw() const {
+void CConsoleOutputWindow::Draw() {
   //SCOPED_GRAPHICS_DEBUG_GROUP("CConsoleOutputWindow::Draw", zeus::skGreen);
 }
 

--- a/Runtime/GuiSys/CConsoleOutputWindow.hpp
+++ b/Runtime/GuiSys/CConsoleOutputWindow.hpp
@@ -8,7 +8,7 @@ class CConsoleOutputWindow : public CIOWin {
 public:
   CConsoleOutputWindow(int, float, float);
   EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
-  void Draw() const override;
+  void Draw() override;
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CErrorOutputWindow.cpp
+++ b/Runtime/GuiSys/CErrorOutputWindow.cpp
@@ -15,7 +15,7 @@ CIOWin::EMessageReturn CErrorOutputWindow::OnMessage(const CArchitectureMessage&
   return EMessageReturn::Normal;
 }
 
-void CErrorOutputWindow::Draw() const {
+void CErrorOutputWindow::Draw() {
   //SCOPED_GRAPHICS_DEBUG_GROUP("CErrorOutputWindow::Draw", zeus::skGreen);
 }
 

--- a/Runtime/GuiSys/CErrorOutputWindow.hpp
+++ b/Runtime/GuiSys/CErrorOutputWindow.hpp
@@ -27,7 +27,7 @@ public:
   explicit CErrorOutputWindow(bool);
   EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
   bool GetIsContinueDraw() const override { return int(x14_state) < 2; }
-  void Draw() const override;
+  void Draw() override;
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CSplashScreen.cpp
+++ b/Runtime/GuiSys/CSplashScreen.cpp
@@ -48,19 +48,22 @@ CIOWin::EMessageReturn CSplashScreen::OnMessage(const CArchitectureMessage& msg,
   return EMessageReturn::Exit;
 }
 
-void CSplashScreen::Draw() const {
-  if (!x25_textureLoaded)
+void CSplashScreen::Draw() {
+  if (!x25_textureLoaded) {
     return;
+  }
   SCOPED_GRAPHICS_DEBUG_GROUP("CSplashScreen::Draw", zeus::skGreen);
 
   zeus::CColor color;
-  if (x14_which == ESplashScreen::Nintendo)
+  if (x14_which == ESplashScreen::Nintendo) {
     color = zeus::CColor{0.86f, 0.f, 0.f, 1.f};
+  }
 
-  if (x18_splashTimeout > 1.5f)
+  if (x18_splashTimeout > 1.5f) {
     color.a() = 1.f - (x18_splashTimeout - 1.5f) * 2.f;
-  else if (x18_splashTimeout < 0.5f)
+  } else if (x18_splashTimeout < 0.5f) {
     color.a() = x18_splashTimeout * 2.f;
+  }
 
   zeus::CRectangle rect;
   rect.size.x() = m_quad.GetTex()->GetWidth() / (480.f * g_Viewport.aspect);
@@ -68,7 +71,7 @@ void CSplashScreen::Draw() const {
   rect.position.x() = 0.5f - rect.size.x() / 2.f;
   rect.position.y() = 0.5f - rect.size.y() / 2.f;
 
-  const_cast<CTexturedQuadFilterAlpha&>(m_quad).draw(color, 1.f, rect);
+  m_quad.draw(color, 1.f, rect);
 }
 
 } // namespace urde

--- a/Runtime/GuiSys/CSplashScreen.hpp
+++ b/Runtime/GuiSys/CSplashScreen.hpp
@@ -24,7 +24,7 @@ private:
 public:
   explicit CSplashScreen(ESplashScreen);
   EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
-  void Draw() const override;
+  void Draw() override;
 };
 
 } // namespace urde

--- a/Runtime/MP1/CCredits.cpp
+++ b/Runtime/MP1/CCredits.cpp
@@ -10,7 +10,7 @@ CIOWin::EMessageReturn CCredits::OnMessage(const CArchitectureMessage& msg, CArc
   return EMessageReturn::Normal;
 }
 
-void CCredits::Draw() const {
+void CCredits::Draw() {
   SCOPED_GRAPHICS_DEBUG_GROUP("CCredits::Draw", zeus::skGreen);
 }
 

--- a/Runtime/MP1/CCredits.hpp
+++ b/Runtime/MP1/CCredits.hpp
@@ -9,7 +9,7 @@ public:
   CCredits();
   EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
   bool GetIsContinueDraw() const override { return false; }
-  void Draw() const override;
+  void Draw() override;
 };
 
 } // namespace urde::MP1

--- a/Runtime/MP1/CFrontEndUI.cpp
+++ b/Runtime/MP1/CFrontEndUI.cpp
@@ -1906,9 +1906,10 @@ void CFrontEndUI::CompleteStateTransition() {
 
 void CFrontEndUI::HandleDebugMenuReturnValue(CGameDebug::EReturnValue val, CArchitectureQueue& queue) {}
 
-void CFrontEndUI::Draw() const {
-  if (x14_phase < EPhase::DisplayFrontEnd)
+void CFrontEndUI::Draw() {
+  if (x14_phase < EPhase::DisplayFrontEnd) {
     return;
+  }
   SCOPED_GRAPHICS_DEBUG_GROUP("CFrontEndUI::Draw", zeus::skGreen);
 
   if (xec_emuFrme) {

--- a/Runtime/MP1/CFrontEndUI.hpp
+++ b/Runtime/MP1/CFrontEndUI.hpp
@@ -385,7 +385,7 @@ public:
   void StartStateTransition(EScreen screen);
   void CompleteStateTransition();
   void HandleDebugMenuReturnValue(CGameDebug::EReturnValue val, CArchitectureQueue& queue);
-  void Draw() const override;
+  void Draw() override;
   void UpdateMovies(float dt);
   bool PumpMovieLoad();
   void ProcessUserInput(const CFinalInput& input, CArchitectureQueue& queue);

--- a/Runtime/MP1/CMFGame.cpp
+++ b/Runtime/MP1/CMFGame.cpp
@@ -193,9 +193,10 @@ void CMFGame::Touch() {
     player.GetMorphBall()->TouchModel(*x14_stateManager);
 }
 
-void CMFGame::Draw() const {
-  if (!x2a_24_initialized)
+void CMFGame::Draw() {
+  if (!x2a_24_initialized) {
     return;
+  }
   SCOPED_GRAPHICS_DEBUG_GROUP("CMFGame::Draw", zeus::skGreen);
 
   const_cast<CMFGame&>(*this).Touch();
@@ -210,8 +211,8 @@ void CMFGame::Draw() const {
   x18_guiManager->Draw(*x14_stateManager);
 
   if (x1c_flowState == EGameFlowState::CinematicSkip) {
-    float c = std::min(1.f, 1.f - x20_cineSkipTime);
-    const_cast<CColoredQuadFilter&>(m_fadeToBlack).draw(zeus::CColor{c, c, c, c});
+    const float c = std::min(1.f, 1.f - x20_cineSkipTime);
+    m_fadeToBlack.draw(zeus::CColor{c, c, c, c});
   }
 }
 
@@ -364,7 +365,7 @@ CIOWin::EMessageReturn CMFGameLoader::OnMessage(const CArchitectureMessage& msg,
   return EMessageReturn::Exit;
 }
 
-void CMFGameLoader::Draw() const {
+void CMFGameLoader::Draw() {
   SCOPED_GRAPHICS_DEBUG_GROUP("CMFGameLoader::Draw", zeus::skGreen);
   g_GameState->GetWorldTransitionManager()->Draw();
 }

--- a/Runtime/MP1/CMFGame.hpp
+++ b/Runtime/MP1/CMFGame.hpp
@@ -43,7 +43,7 @@ public:
   ~CMFGame() override;
   CIOWin::EMessageReturn OnMessage(const CArchitectureMessage& msg, CArchitectureQueue& queue) override;
   void Touch();
-  void Draw() const override;
+  void Draw() override;
   void PlayerDied();
   void UnpauseGame();
   void EnterMessageScreen(float time);
@@ -72,7 +72,7 @@ public:
   CMFGameLoader();
   ~CMFGameLoader() override;
   EMessageReturn OnMessage(const CArchitectureMessage& msg, CArchitectureQueue& queue) override;
-  void Draw() const override;
+  void Draw() override;
 };
 
 } // namespace MP1

--- a/Runtime/MP1/CMainFlow.hpp
+++ b/Runtime/MP1/CMainFlow.hpp
@@ -14,7 +14,7 @@ public:
   void AdvanceGameState(CArchitectureQueue& queue) override;
   void SetGameState(EClientFlowStates state, CArchitectureQueue& queue) override;
   bool GetIsContinueDraw() const override { return false; }
-  void Draw() const override {}
+  void Draw() override {}
 };
 
 } // namespace MP1

--- a/Runtime/MP1/CSlideShow.cpp
+++ b/Runtime/MP1/CSlideShow.cpp
@@ -124,18 +124,19 @@ CIOWin::EMessageReturn CSlideShow::OnMessage(const CArchitectureMessage& msg, CA
   return EMessageReturn::Exit;
 }
 
-void CSlideShow::SSlideData::Draw() const {
-  if (!IsLoaded())
+void CSlideShow::SSlideData::Draw() {
+  if (!IsLoaded()) {
     return;
+  }
 
-  zeus::CRectangle rect;
-  const_cast<CTexturedQuadFilterAlpha&>(*m_texQuad).draw(x30_mulColor, 1.f, rect);
+  const zeus::CRectangle rect;
+  m_texQuad->draw(x30_mulColor, 1.f, rect);
 
-  zeus::CVector2f centeredOffset((x28_canvasSize.x() - m_texQuad->GetTex()->GetWidth()) * 0.5f,
-                                 (x28_canvasSize.y() - m_texQuad->GetTex()->GetHeight()) * 0.5f);
+  const zeus::CVector2f centeredOffset((x28_canvasSize.x() - m_texQuad->GetTex()->GetWidth()) * 0.5f,
+                                       (x28_canvasSize.y() - m_texQuad->GetTex()->GetHeight()) * 0.5f);
 }
 
-void CSlideShow::Draw() const {
+void CSlideShow::Draw() {
   SCOPED_GRAPHICS_DEBUG_GROUP("CSlideShow::Draw", zeus::skGreen);
   if (x14_phase == Phase::Five) {
     x5c_slideA.Draw();

--- a/Runtime/MP1/CSlideShow.hpp
+++ b/Runtime/MP1/CSlideShow.hpp
@@ -37,7 +37,7 @@ public:
 
     void SetTexture(const TLockedToken<CTexture>& tex) { m_texQuad.emplace(EFilterType::Blend, tex); }
     bool IsLoaded() const { return m_texQuad && m_texQuad->GetTex().IsLoaded(); }
-    void Draw() const;
+    void Draw();
   };
 
 private:
@@ -110,7 +110,7 @@ public:
   CSlideShow();
   EMessageReturn OnMessage(const CArchitectureMessage&, CArchitectureQueue&) override;
   bool GetIsContinueDraw() const override { return false; }
-  void Draw() const override;
+  void Draw() override;
 
   static u32 SlideShowGalleryFlags();
 };


### PR DESCRIPTION
Allows removing several const_cast usages within the codebase.