### PR TITLE
Runtime: Add more usages of explicit

### DIFF
--- a/Runtime/Audio/CAudioGroupSet.hpp
+++ b/Runtime/Audio/CAudioGroupSet.hpp
@@ -21,7 +21,7 @@ class CAudioGroupSet {
   amuse::AudioGroupData LoadData();
 
 public:
-  CAudioGroupSet(std::unique_ptr<u8[]>&& in);
+  explicit CAudioGroupSet(std::unique_ptr<u8[]>&& in);
   const amuse::AudioGroupData& GetAudioGroupData() const { return m_data; }
   std::string_view GetName() const { return x20_name; }
 };

--- a/Runtime/Audio/CMidiManager.hpp
+++ b/Runtime/Audio/CMidiManager.hpp
@@ -19,7 +19,7 @@ public:
     u16 GetGroupId() const { return x2_groupId; }
     CAssetId GetAGSCAssetId() const { return x4_agscId; }
     const u8* GetArrData() const { return x8_arrData.get(); }
-    CMidiData(CInputStream& in);
+    explicit CMidiData(CInputStream& in);
   };
 
   class CMidiWrapper {

--- a/Runtime/Audio/CStaticAudioPlayer.hpp
+++ b/Runtime/Audio/CStaticAudioPlayer.hpp
@@ -53,7 +53,7 @@ class CStaticAudioPlayer {
         memset(data, 0, 4 * frames);
       return frames;
     }
-    AudioVoiceCallback(CStaticAudioPlayer& p) : m_parent(p) {}
+    explicit AudioVoiceCallback(CStaticAudioPlayer& p) : m_parent(p) {}
   } m_voiceCallback;
   boo::ObjToken<boo::IAudioVoice> m_voice;
 

--- a/Runtime/Audio/CStreamAudioManager.cpp
+++ b/Runtime/Audio/CStreamAudioManager.cpp
@@ -50,7 +50,7 @@ struct SDSPStreamInfo {
   s16 x1c_coef[8][2];
 
   SDSPStreamInfo() = default;
-  SDSPStreamInfo(const CDSPStreamManager& stream);
+  explicit SDSPStreamInfo(const CDSPStreamManager& stream);
 };
 
 struct SDSPStream : boo::IAudioVoiceCallback {

--- a/Runtime/AutoMapper/CAutoMapper.hpp
+++ b/Runtime/AutoMapper/CAutoMapper.hpp
@@ -224,7 +224,7 @@ private:
   CAssetId GetAreaHintDescriptionString(CAssetId mreaId);
 
 public:
-  CAutoMapper(CStateManager& stateMgr);
+  explicit CAutoMapper(CStateManager& stateMgr);
   bool CheckLoadComplete();
   bool CanLeaveMapScreen(const CStateManager& mgr) const;
   float GetMapRotationX() const { return xa8_renderStates[0].x1c_camAngle; }

--- a/Runtime/AutoMapper/CMapArea.hpp
+++ b/Runtime/AutoMapper/CMapArea.hpp
@@ -38,7 +38,7 @@ public:
     std::vector<Instance> m_instances;
 
   public:
-    CMapAreaSurface(const void* surfBuf);
+    explicit CMapAreaSurface(const void* surfBuf);
     CMapAreaSurface(CMapAreaSurface&&) = default;
     void PostConstruct(const u8* buf, std::vector<u32>& index);
     void Draw(const zeus::CVector3f* verts, const zeus::CColor& surfColor, const zeus::CColor& lineColor,
@@ -69,7 +69,7 @@ private:
   boo::ObjToken<boo::IGraphicsBufferS> m_ibo;
 
 public:
-  CMapArea(CInputStream& in, u32 size);
+  explicit CMapArea(CInputStream& in, u32 size);
   void PostConstruct();
   bool GetIsVisibleToAutoMapper(bool worldVis, bool areaVis) const;
   zeus::CVector3f GetAreaCenterPoint() const { return x10_box.center(); }

--- a/Runtime/AutoMapper/CMapUniverse.hpp
+++ b/Runtime/AutoMapper/CMapUniverse.hpp
@@ -84,7 +84,7 @@ public:
     zeus::CVector3f x64_centerPoint = zeus::skZero3f;
 
   public:
-    CMapWorldData(CInputStream& in, u32 version);
+    explicit CMapWorldData(CInputStream& in, u32 version);
     CAssetId GetWorldAssetId() const { return x10_worldAssetId; }
     const zeus::CVector3f& GetWorldCenterPoint() const { return x64_centerPoint; }
     std::string_view GetWorldLabel() const { return x0_label; }
@@ -105,7 +105,7 @@ private:
   float x2c_universeRadius = 1600.f;
 
 public:
-  CMapUniverse(CInputStream&, u32);
+  explicit CMapUniverse(CInputStream&, u32);
   const CMapWorldData& GetMapWorldData(s32 idx) const { return x10_worldDatas[idx]; }
   const CMapWorldData& GetMapWorldDataByWorldId(CAssetId id) const {
     for (const CMapWorldData& data : x10_worldDatas)

--- a/Runtime/AutoMapper/CMapWorldInfo.hpp
+++ b/Runtime/AutoMapper/CMapWorldInfo.hpp
@@ -18,7 +18,7 @@ class CMapWorldInfo {
 
 public:
   CMapWorldInfo() = default;
-  CMapWorldInfo(CBitStreamReader&, const CSaveWorld& saveWorld, CAssetId mlvlId);
+  explicit CMapWorldInfo(CBitStreamReader&, const CSaveWorld& saveWorld, CAssetId mlvlId);
   void PutTo(CBitStreamWriter& writer, const CSaveWorld& savw, CAssetId mlvlId) const;
   bool IsMapped(TAreaId) const;
   void SetIsMapped(TAreaId, bool);

--- a/Runtime/AutoMapper/CMappableObject.hpp
+++ b/Runtime/AutoMapper/CMappableObject.hpp
@@ -63,7 +63,7 @@ private:
   struct DoorSurface {
     CMapSurfaceShader m_surface;
     CLineRenderer m_outline;
-    DoorSurface(boo::IGraphicsDataFactory::Context& ctx)
+    explicit DoorSurface(boo::IGraphicsDataFactory::Context& ctx)
     : m_surface(ctx, g_doorVbo, g_doorIbo)
     , m_outline(ctx, CLineRenderer::EPrimitiveMode::LineLoop, 5, nullptr, false, false, true) {}
   };
@@ -74,7 +74,7 @@ private:
   std::pair<zeus::CColor, zeus::CColor> GetDoorColors(int idx, const CMapWorldInfo& mwInfo, float alpha) const;
 
 public:
-  CMappableObject(const void* buf);
+  explicit CMappableObject(const void* buf);
   CMappableObject(CMappableObject&&) = default;
   void PostConstruct(const void*);
   const zeus::CTransform& GetTransform() const { return x10_transform; }

--- a/Runtime/CStateManager.hpp
+++ b/Runtime/CStateManager.hpp
@@ -216,8 +216,8 @@ private:
     u32 xf94_ = 0;
   };
 
-  CColoredQuadFilter m_deathWhiteout = {EFilterType::Add};
-  CColoredQuadFilter m_escapeWhiteout = {EFilterType::Add};
+  CColoredQuadFilter m_deathWhiteout{EFilterType::Add};
+  CColoredQuadFilter m_escapeWhiteout{EFilterType::Add};
   bool m_warping = false;
 
   void UpdateThermalVisor();

--- a/Runtime/Camera/CCameraManager.hpp
+++ b/Runtime/Camera/CCameraManager.hpp
@@ -80,7 +80,7 @@ class CCameraManager {
   void EnterCinematic(CStateManager& mgr);
 
 public:
-  CCameraManager(TUniqueId curCameraId = kInvalidUniqueId);
+  explicit CCameraManager(TUniqueId curCameraId = kInvalidUniqueId);
 
   static float Aspect() { return 1.42f; }
   static float FarPlane() { return 750.0f; }

--- a/Runtime/Camera/CCameraShakeData.hpp
+++ b/Runtime/Camera/CCameraShakeData.hpp
@@ -61,7 +61,7 @@ public:
                    const CCameraShakerComponent& shaker1, const CCameraShakerComponent& shaker2,
                    const CCameraShakerComponent& shaker3);
   CCameraShakeData(float duration, float magnitude);
-  CCameraShakeData(CInputStream&);
+  explicit CCameraShakeData(CInputStream&);
   static CCameraShakeData BuildLandingCameraShakeData(float duration, float magnitude);
   static CCameraShakeData BuildProjectileCameraShake(float duration, float magnitude);
   static CCameraShakeData BuildMissileCameraShake(float duration, float magnitude, float sfxDistance,

--- a/Runtime/Camera/CInterpolationCamera.hpp
+++ b/Runtime/Camera/CInterpolationCamera.hpp
@@ -26,7 +26,7 @@ class CInterpolationCamera : public CGameCamera {
                                float maxTime, float curTime);
 
 public:
-  CInterpolationCamera(TUniqueId uid, const zeus::CTransform& xf);
+  explicit CInterpolationCamera(TUniqueId uid, const zeus::CTransform& xf);
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void ProcessInput(const CFinalInput&, CStateManager& mgr) override;

--- a/Runtime/Character/CAdditiveAnimPlayback.hpp
+++ b/Runtime/Character/CAdditiveAnimPlayback.hpp
@@ -20,7 +20,7 @@ public:
     x4_fadeOutDur = in.readFloatBig();
   }
   CAdditiveAnimationInfo() = default;
-  CAdditiveAnimationInfo(CInputStream& in) { read(in); }
+  explicit CAdditiveAnimationInfo(CInputStream& in) { read(in); }
   float GetFadeInDuration() const { return x0_fadeInDur; }
   float GetFadeOutDuration() const { return x4_fadeOutDur; }
 };

--- a/Runtime/Character/CAllFormatsAnimSource.hpp
+++ b/Runtime/Character/CAllFormatsAnimSource.hpp
@@ -26,7 +26,7 @@ class CAnimFormatUnion {
   static void SubConstruct(u8* storage, EAnimFormat fmt, CInputStream& in, IObjectStore& store);
 
 public:
-  CAnimFormatUnion(CInputStream& in, IObjectStore& store);
+  explicit CAnimFormatUnion(CInputStream& in, IObjectStore& store);
   ~CAnimFormatUnion();
   EAnimFormat GetFormat() const { return x0_format; }
   CAnimSource& GetAsCAnimSource() { return *reinterpret_cast<CAnimSource*>(x4_storage); }
@@ -40,7 +40,7 @@ class CAllFormatsAnimSource : public CAnimFormatUnion {
   SObjectTag x74_tag;
 
 public:
-  CAllFormatsAnimSource(CInputStream& in, IObjectStore& store, const SObjectTag& tag);
+  explicit CAllFormatsAnimSource(CInputStream& in, IObjectStore& store, const SObjectTag& tag);
   static std::shared_ptr<IAnimReader> GetNewReader(const TLockedToken<CAllFormatsAnimSource>& tok,
                                                    const CCharAnimTime& startTime);
 };

--- a/Runtime/Character/CAnimCharacterSet.hpp
+++ b/Runtime/Character/CAnimCharacterSet.hpp
@@ -12,7 +12,7 @@ class CAnimCharacterSet {
   CAnimationSet x1c_animationSet;
 
 public:
-  CAnimCharacterSet(CInputStream& in);
+  explicit CAnimCharacterSet(CInputStream& in);
   const CCharacterSet& GetCharacterSet() const { return x4_characterSet; }
   const CAnimationSet& GetAnimationSet() const { return x1c_animationSet; }
 };

--- a/Runtime/Character/CAnimData.cpp
+++ b/Runtime/Character/CAnimData.cpp
@@ -56,7 +56,7 @@ CAnimData::CAnimData(CAssetId id, const CCharacterInfo& character, int defaultAn
 , x204_charIdx(charIdx)
 , x208_defaultAnim(defaultAnim)
 , x224_pose(layout->GetSegIdList().GetList().size())
-, x2fc_poseBuilder(layout)
+, x2fc_poseBuilder(CLayoutDescription{layout})
 , m_drawInstCount(drawInstCount) {
   x220_25_loop = loop;
 
@@ -72,7 +72,7 @@ CAnimData::CAnimData(CAssetId id, const CCharacterInfo& character, int defaultAn
   x108_aabb = xd8_modelData->GetModel()->GetAABB();
   x120_particleDB.CacheParticleDesc(xc_charInfo.GetParticleResData());
 
-  CHierarchyPoseBuilder pb(xcc_layoutData);
+  CHierarchyPoseBuilder pb(CLayoutDescription{xcc_layoutData});
   pb.BuildNoScale(x224_pose);
   x220_30_poseBuilt = true;
 

--- a/Runtime/Character/CAnimPOIData.hpp
+++ b/Runtime/Character/CAnimPOIData.hpp
@@ -19,7 +19,7 @@ class CAnimPOIData {
   std::vector<CSoundPOINode> x34_soundNodes;
 
 public:
-  CAnimPOIData(CInputStream& in);
+  explicit CAnimPOIData(CInputStream& in);
 
   const std::vector<CBoolPOINode>& GetBoolPOIStream() const { return x4_boolNodes; }
   const std::vector<CInt32POINode>& GetInt32POIStream() const { return x14_int32Nodes; }

--- a/Runtime/Character/CAnimSource.hpp
+++ b/Runtime/Character/CAnimSource.hpp
@@ -39,7 +39,7 @@ public:
   struct CRotationAndOffsetVectors {
     std::vector<zeus::CQuaternion> x0_rotations;
     std::vector<zeus::CVector3f> x10_offsets;
-    CRotationAndOffsetVectors(CInputStream& in);
+    explicit CRotationAndOffsetVectors(CInputStream& in);
   };
   u32 GetFrameSizeInBytes() const;
   RotationAndOffsetStorage(const CRotationAndOffsetVectors& vectors, u32 frameCount);
@@ -61,7 +61,7 @@ class CAnimSource {
   void CalcAverageVelocity();
 
 public:
-  CAnimSource(CInputStream& in, IObjectStore& store);
+  explicit CAnimSource(CInputStream& in, IObjectStore& store);
 
   void GetSegStatementSet(const CSegIdList& list, CSegStatementSet& set, const CCharAnimTime& time) const;
 

--- a/Runtime/Character/CAnimTreeNode.hpp
+++ b/Runtime/Character/CAnimTreeNode.hpp
@@ -14,7 +14,7 @@ protected:
   std::string x4_name;
 
 public:
-  CAnimTreeNode(std::string_view name) : x4_name(name) {}
+  explicit CAnimTreeNode(std::string_view name) : x4_name(name) {}
   bool IsCAnimTreeNode() const override { return true; }
   static std::shared_ptr<CAnimTreeNode> Cast(std::unique_ptr<IAnimReader>&& ptr) {
     if (ptr->IsCAnimTreeNode())

--- a/Runtime/Character/CAnimation.hpp
+++ b/Runtime/Character/CAnimation.hpp
@@ -14,7 +14,7 @@ class CAnimation {
   std::shared_ptr<IMetaAnim> x10_anim;
 
 public:
-  CAnimation(CInputStream& in);
+  explicit CAnimation(CInputStream& in);
   const std::shared_ptr<IMetaAnim>& GetMetaAnim() const { return x10_anim; }
   std::string_view GetMetaAnimName() const { return x0_name; }
 };

--- a/Runtime/Character/CAnimationDatabaseGame.hpp
+++ b/Runtime/Character/CAnimationDatabaseGame.hpp
@@ -12,7 +12,7 @@ class CAnimationDatabaseGame final : public CAnimationDatabase {
   std::vector<std::shared_ptr<IMetaAnim>> x10_anims;
 
 public:
-  CAnimationDatabaseGame(const std::vector<CAnimation>& anims);
+  explicit CAnimationDatabaseGame(const std::vector<CAnimation>& anims);
   const std::shared_ptr<IMetaAnim>& GetMetaAnim(s32 idx) const override;
   u32 GetNumMetaAnims() const override;
   const char* GetMetaAnimName(s32 idx) const override;

--- a/Runtime/Character/CAnimationSet.hpp
+++ b/Runtime/Character/CAnimationSet.hpp
@@ -24,7 +24,7 @@ class CAnimationSet {
   std::vector<std::pair<CAssetId, CAssetId>> x50_animRes;
 
 public:
-  CAnimationSet(CInputStream& in);
+  explicit CAnimationSet(CInputStream& in);
 
   const std::vector<CAnimation>& GetAnimations() const { return x4_animations; }
   const std::vector<CTransition>& GetTransitions() const { return x14_transitions; }

--- a/Runtime/Character/CBodyState.hpp
+++ b/Runtime/Character/CBodyState.hpp
@@ -105,7 +105,7 @@ class CBSLieOnGround : public CBodyState {
   pas::EAnimationState GetBodyStateTransition(float dt, CBodyController& bc) const;
 
 public:
-  CBSLieOnGround(CActor& actor);
+  explicit CBSLieOnGround(CActor& actor);
   void Start(CBodyController& bc, CStateManager& mgr) override;
   pas::EAnimationState UpdateBody(float dt, CBodyController& bc, CStateManager& mgr) override;
   void Shutdown(CBodyController& bc) override;
@@ -371,7 +371,7 @@ protected:
   }
 
 public:
-  CBSBiPedLocomotion(CActor& actor);
+  explicit CBSBiPedLocomotion(CActor& actor);
   bool IsMoving() const override { return x3c4_anim != pas::ELocomotionAnim::Idle; }
   void Start(CBodyController& bc, CStateManager& mgr) override;
   pas::EAnimationState UpdateBody(float dt, CBodyController& bc, CStateManager& mgr) override;
@@ -384,7 +384,7 @@ class CBSFlyerLocomotion : public CBSBiPedLocomotion {
   bool x3cc_pitchable;
 
 public:
-  CBSFlyerLocomotion(CActor& actor, bool pitchable);
+  explicit CBSFlyerLocomotion(CActor& actor, bool pitchable);
   bool IsPitchable() const override { return x3cc_pitchable; }
   float ApplyLocomotionPhysics(float dt, CBodyController& bc) override;
   virtual bool IsBackPedal(CBodyController& bc) const { return false; }
@@ -392,13 +392,13 @@ public:
 
 class CBSWallWalkerLocomotion : public CBSBiPedLocomotion {
 public:
-  CBSWallWalkerLocomotion(CActor& actor);
+  explicit CBSWallWalkerLocomotion(CActor& actor);
   float ApplyLocomotionPhysics(float dt, CBodyController& bc) override;
 };
 
 class CBSNewFlyerLocomotion : public CBSBiPedLocomotion {
 public:
-  CBSNewFlyerLocomotion(CActor& actor);
+  explicit CBSNewFlyerLocomotion(CActor& actor);
   float ApplyLocomotionPhysics(float dt, CBodyController& bc) override;
   float UpdateLocomotionAnimation(float dt, float velMag, CBodyController& bc, bool init) override;
 };
@@ -408,7 +408,7 @@ class CBSRestrictedLocomotion : public CBSLocomotion {
   pas::ELocomotionAnim x44_anim = pas::ELocomotionAnim::Invalid;
 
 public:
-  CBSRestrictedLocomotion(CActor& actor);
+  explicit CBSRestrictedLocomotion(CActor& actor);
   bool IsMoving() const override { return false; }
   float GetLocomotionSpeed(pas::ELocomotionType type, pas::ELocomotionAnim anim) const override { return 0.f; }
   float UpdateLocomotionAnimation(float dt, float velMag, CBodyController& bc, bool init) override;
@@ -416,7 +416,7 @@ public:
 
 class CBSRestrictedFlyerLocomotion : public CBSRestrictedLocomotion {
 public:
-  CBSRestrictedFlyerLocomotion(CActor& actor);
+  explicit CBSRestrictedFlyerLocomotion(CActor& actor);
   float ApplyLocomotionPhysics(float dt, CBodyController& bc) override;
 };
 } // namespace urde

--- a/Runtime/Character/CBodyStateCmdMgr.hpp
+++ b/Runtime/Character/CBodyStateCmdMgr.hpp
@@ -13,7 +13,7 @@ class CBodyStateCmd {
 
 public:
   virtual ~CBodyStateCmd() = default;
-  CBodyStateCmd(EBodyStateCmd cmd) : x4_cmd(cmd) {}
+  explicit CBodyStateCmd(EBodyStateCmd cmd) : x4_cmd(cmd) {}
   EBodyStateCmd GetCommandId() const { return x4_cmd; }
 };
 
@@ -23,10 +23,11 @@ class CBCMeleeAttackCmd : public CBodyStateCmd {
   bool x18_hasTargetPos = false;
 
 public:
-  CBCMeleeAttackCmd() : CBodyStateCmd(EBodyStateCmd::MeleeAttack) {}
-  CBCMeleeAttackCmd(pas::ESeverity severity) : CBodyStateCmd(EBodyStateCmd::MeleeAttack), x8_severity(severity) {}
-  CBCMeleeAttackCmd(pas::ESeverity severity, const zeus::CVector3f& target) : CBodyStateCmd(EBodyStateCmd::MeleeAttack)
-  , x8_severity(severity), xc_targetPos(target), x18_hasTargetPos(true) {}
+  explicit CBCMeleeAttackCmd() : CBodyStateCmd(EBodyStateCmd::MeleeAttack) {}
+  explicit CBCMeleeAttackCmd(pas::ESeverity severity)
+  : CBodyStateCmd(EBodyStateCmd::MeleeAttack), x8_severity(severity) {}
+  explicit CBCMeleeAttackCmd(pas::ESeverity severity, const zeus::CVector3f& target)
+  : CBodyStateCmd(EBodyStateCmd::MeleeAttack), x8_severity(severity), xc_targetPos(target), x18_hasTargetPos(true) {}
   pas::ESeverity GetAttackSeverity() const { return x8_severity; }
   bool HasAttackTargetPos() const { return x18_hasTargetPos; }
   const zeus::CVector3f& GetAttackTargetPos() const { return xc_targetPos; }
@@ -38,8 +39,8 @@ class CBCProjectileAttackCmd : public CBodyStateCmd {
   bool x18_blendAnims = false;
 
 public:
-  CBCProjectileAttackCmd() : CBodyStateCmd(EBodyStateCmd::ProjectileAttack) {}
-  CBCProjectileAttackCmd(pas::ESeverity severity, const zeus::CVector3f& vec, bool b)
+  explicit CBCProjectileAttackCmd() : CBodyStateCmd(EBodyStateCmd::ProjectileAttack) {}
+  explicit CBCProjectileAttackCmd(pas::ESeverity severity, const zeus::CVector3f& vec, bool b)
   : CBodyStateCmd(EBodyStateCmd::ProjectileAttack), x8_severity(severity), xc_target(vec), x18_blendAnims(b) {}
   pas::ESeverity GetAttackSeverity() const { return x8_severity; }
   const zeus::CVector3f& GetTargetPosition() const { return xc_target; }
@@ -51,8 +52,8 @@ class CBCStepCmd : public CBodyStateCmd {
   pas::EStepType xc_type = pas::EStepType::Normal;
 
 public:
-  CBCStepCmd() : CBodyStateCmd(EBodyStateCmd::Step) {}
-  CBCStepCmd(pas::EStepDirection dir, pas::EStepType type)
+  explicit CBCStepCmd() : CBodyStateCmd(EBodyStateCmd::Step) {}
+  explicit CBCStepCmd(pas::EStepDirection dir, pas::EStepType type)
   : CBodyStateCmd(EBodyStateCmd::Step), x8_dir(dir), xc_type(type) {}
   pas::EStepDirection GetStepDirection() const { return x8_dir; }
   pas::EStepType GetStepType() const { return xc_type; }
@@ -66,16 +67,16 @@ class CBCJumpCmd : public CBodyStateCmd {
   bool x24_25_startInJumpLoop : 1;
 
 public:
-  CBCJumpCmd() : CBodyStateCmd(EBodyStateCmd::Jump) {
+  explicit CBCJumpCmd() : CBodyStateCmd(EBodyStateCmd::Jump) {
     x24_24_wallJump = false;
     x24_25_startInJumpLoop = false;
   }
-  CBCJumpCmd(const zeus::CVector3f& wp1, pas::EJumpType type, bool startInLoop = false)
+  explicit CBCJumpCmd(const zeus::CVector3f& wp1, pas::EJumpType type, bool startInLoop = false)
   : CBodyStateCmd(EBodyStateCmd::Jump), x8_type(type), xc_waypoint1(wp1) {
     x24_24_wallJump = false;
     x24_25_startInJumpLoop = startInLoop;
   }
-  CBCJumpCmd(const zeus::CVector3f& wp1, const zeus::CVector3f& wp2, pas::EJumpType type)
+  explicit CBCJumpCmd(const zeus::CVector3f& wp1, const zeus::CVector3f& wp2, pas::EJumpType type)
   : CBodyStateCmd(EBodyStateCmd::Jump), x8_type(type), xc_waypoint1(wp1), x18_waypoint2(wp2) {
     x24_24_wallJump = true;
     x24_25_startInJumpLoop = false;
@@ -95,22 +96,22 @@ class CBCGenerateCmd : public CBodyStateCmd {
   bool x1c_25_overrideAnim : 1;
 
 public:
-  CBCGenerateCmd() : CBodyStateCmd(EBodyStateCmd::Generate) {
+  explicit CBCGenerateCmd() : CBodyStateCmd(EBodyStateCmd::Generate) {
     x1c_24_targetTransform = false;
     x1c_25_overrideAnim = false;
   }
-  CBCGenerateCmd(pas::EGenerateType type)
+  explicit CBCGenerateCmd(pas::EGenerateType type)
   : CBodyStateCmd(EBodyStateCmd::Generate), x8_type(type) {
     x1c_24_targetTransform = false;
     x1c_25_overrideAnim = false;
   }
-  CBCGenerateCmd(pas::EGenerateType type, s32 animId)
+  explicit CBCGenerateCmd(pas::EGenerateType type, s32 animId)
   : CBodyStateCmd(EBodyStateCmd::Generate), x8_type(type), x18_animId(animId) {
     x1c_24_targetTransform = false;
     x1c_25_overrideAnim = animId != -1;
   }
-  CBCGenerateCmd(pas::EGenerateType type, const zeus::CVector3f& vec, bool targetTransform = false,
-                 bool overrideAnim = false)
+  explicit CBCGenerateCmd(pas::EGenerateType type, const zeus::CVector3f& vec, bool targetTransform = false,
+                          bool overrideAnim = false)
   : CBodyStateCmd(EBodyStateCmd::Generate), x8_type(type), xc_targetPos(vec) {
     x1c_24_targetTransform = targetTransform;
     x1c_25_overrideAnim = overrideAnim;
@@ -127,8 +128,8 @@ class CBCKnockBackCmd : public CBodyStateCmd {
   pas::ESeverity x14_severity = pas::ESeverity::Invalid;
 
 public:
-  CBCKnockBackCmd() : CBodyStateCmd(EBodyStateCmd::KnockBack) {}
-  CBCKnockBackCmd(const zeus::CVector3f& vec, pas::ESeverity severity)
+  explicit CBCKnockBackCmd() : CBodyStateCmd(EBodyStateCmd::KnockBack) {}
+  explicit CBCKnockBackCmd(const zeus::CVector3f& vec, pas::ESeverity severity)
   : CBodyStateCmd(EBodyStateCmd::KnockBack), x8_dir(vec), x14_severity(severity) {}
   const zeus::CVector3f& GetHitDirection() const { return x8_dir; }
   pas::ESeverity GetHitSeverity() const { return x14_severity; }
@@ -140,8 +141,8 @@ class CBCHurledCmd : public CBodyStateCmd {
   bool x20_startInKnockLoop = false;
 
 public:
-  CBCHurledCmd() : CBodyStateCmd(EBodyStateCmd::Hurled) {}
-  CBCHurledCmd(const zeus::CVector3f& dir, const zeus::CVector3f& launchVel, bool startInLoop = false)
+  explicit CBCHurledCmd() : CBodyStateCmd(EBodyStateCmd::Hurled) {}
+  explicit CBCHurledCmd(const zeus::CVector3f& dir, const zeus::CVector3f& launchVel, bool startInLoop = false)
   : CBodyStateCmd(EBodyStateCmd::Hurled)
   , x8_direction(dir)
   , x14_launchVel(launchVel)
@@ -156,8 +157,8 @@ class CBCGetupCmd : public CBodyStateCmd {
   pas::EGetupType x8_type = pas::EGetupType::Invalid;
 
 public:
-  CBCGetupCmd() : CBodyStateCmd(EBodyStateCmd::Getup) {}
-  CBCGetupCmd(pas::EGetupType type) : CBodyStateCmd(EBodyStateCmd::Getup), x8_type(type) {}
+  explicit CBCGetupCmd() : CBodyStateCmd(EBodyStateCmd::Getup) {}
+  explicit CBCGetupCmd(pas::EGetupType type) : CBodyStateCmd(EBodyStateCmd::Getup), x8_type(type) {}
   pas::EGetupType GetGetupType() const { return x8_type; }
 };
 
@@ -165,8 +166,8 @@ class CBCLoopReactionCmd : public CBodyStateCmd {
   pas::EReactionType x8_type = pas::EReactionType::Invalid;
 
 public:
-  CBCLoopReactionCmd() : CBodyStateCmd(EBodyStateCmd::LoopReaction) {}
-  CBCLoopReactionCmd(pas::EReactionType type) : CBodyStateCmd(EBodyStateCmd::LoopReaction), x8_type(type) {}
+  explicit CBCLoopReactionCmd() : CBodyStateCmd(EBodyStateCmd::LoopReaction) {}
+  explicit CBCLoopReactionCmd(pas::EReactionType type) : CBodyStateCmd(EBodyStateCmd::LoopReaction), x8_type(type) {}
   pas::EReactionType GetReactionType() const { return x8_type; }
 };
 
@@ -174,8 +175,8 @@ class CBCLoopHitReactionCmd : public CBodyStateCmd {
   pas::EReactionType x8_type = pas::EReactionType::Invalid;
 
 public:
-  CBCLoopHitReactionCmd() : CBodyStateCmd(EBodyStateCmd::LoopHitReaction) {}
-  CBCLoopHitReactionCmd(pas::EReactionType type) : CBodyStateCmd(EBodyStateCmd::LoopHitReaction), x8_type(type) {}
+  explicit CBCLoopHitReactionCmd() : CBodyStateCmd(EBodyStateCmd::LoopHitReaction) {}
+  explicit CBCLoopHitReactionCmd(pas::EReactionType type) : CBodyStateCmd(EBodyStateCmd::LoopHitReaction), x8_type(type) {}
   pas::EReactionType GetReactionType() const { return x8_type; }
 };
 
@@ -184,8 +185,8 @@ class CBCKnockDownCmd : public CBodyStateCmd {
   pas::ESeverity x14_severity = pas::ESeverity::Invalid;
 
 public:
-  CBCKnockDownCmd() : CBodyStateCmd(EBodyStateCmd::KnockDown) {}
-  CBCKnockDownCmd(const zeus::CVector3f& vec, pas::ESeverity severity)
+  explicit CBCKnockDownCmd() : CBodyStateCmd(EBodyStateCmd::KnockDown) {}
+  explicit CBCKnockDownCmd(const zeus::CVector3f& vec, pas::ESeverity severity)
   : CBodyStateCmd(EBodyStateCmd::KnockDown), x8_dir(vec), x14_severity(severity) {}
   const zeus::CVector3f& GetHitDirection() const { return x8_dir; }
   pas::ESeverity GetHitSeverity() const { return x14_severity; }
@@ -196,8 +197,8 @@ class CBCSlideCmd : public CBodyStateCmd {
   zeus::CVector3f xc_dir;
 
 public:
-  CBCSlideCmd() : CBodyStateCmd(EBodyStateCmd::Slide) {}
-  CBCSlideCmd(pas::ESlideType type, const zeus::CVector3f& dir)
+  explicit CBCSlideCmd() : CBodyStateCmd(EBodyStateCmd::Slide) {}
+  explicit CBCSlideCmd(pas::ESlideType type, const zeus::CVector3f& dir)
   : CBodyStateCmd(EBodyStateCmd::Slide), x8_type(type), xc_dir(dir) {}
   pas::ESlideType GetSlideType() const { return x8_type; }
   const zeus::CVector3f& GetSlideDirection() const { return xc_dir; }
@@ -210,11 +211,11 @@ class CBCScriptedCmd : public CBodyStateCmd {
   float x10_loopDur = 0.f;
 
 public:
-  CBCScriptedCmd() : CBodyStateCmd(EBodyStateCmd::Scripted) {
+  explicit CBCScriptedCmd() : CBodyStateCmd(EBodyStateCmd::Scripted) {
     xc_24_loopAnim = false;
     xc_25_timedLoop = false;
   }
-  CBCScriptedCmd(int i, bool b1, bool b2, float f)
+  explicit CBCScriptedCmd(int i, bool b1, bool b2, float f)
   : CBodyStateCmd(EBodyStateCmd::Scripted), x8_anim(i), x10_loopDur(f) {
     xc_24_loopAnim = b1;
     xc_25_timedLoop = b2;
@@ -231,8 +232,8 @@ class CBCCoverCmd : public CBodyStateCmd {
   zeus::CVector3f x18_alignDir;
 
 public:
-  CBCCoverCmd() : CBodyStateCmd(EBodyStateCmd::Cover) {}
-  CBCCoverCmd(pas::ECoverDirection dir, const zeus::CVector3f& v1, const zeus::CVector3f& v2)
+  explicit CBCCoverCmd() : CBodyStateCmd(EBodyStateCmd::Cover) {}
+  explicit CBCCoverCmd(pas::ECoverDirection dir, const zeus::CVector3f& v1, const zeus::CVector3f& v2)
   : CBodyStateCmd(EBodyStateCmd::Cover), x8_dir(dir), xc_targetPos(v1), x18_alignDir(v2) {}
   pas::ECoverDirection GetDirection() const { return x8_dir; }
   const zeus::CVector3f& GetTarget() const { return xc_targetPos; }
@@ -243,22 +244,22 @@ class CBCWallHangCmd : public CBodyStateCmd {
   TUniqueId x8_wpId = kInvalidUniqueId;
 
 public:
-  CBCWallHangCmd() : CBodyStateCmd(EBodyStateCmd::WallHang) {}
-  CBCWallHangCmd(TUniqueId uid) : CBodyStateCmd(EBodyStateCmd::WallHang), x8_wpId(uid) {}
+  explicit CBCWallHangCmd() : CBodyStateCmd(EBodyStateCmd::WallHang) {}
+  explicit CBCWallHangCmd(TUniqueId uid) : CBodyStateCmd(EBodyStateCmd::WallHang), x8_wpId(uid) {}
   TUniqueId GetTarget() const { return x8_wpId; }
 };
 
 class CBCAdditiveAimCmd : public CBodyStateCmd {
 public:
-  CBCAdditiveAimCmd() : CBodyStateCmd(EBodyStateCmd::AdditiveAim) {}
+  explicit CBCAdditiveAimCmd() : CBodyStateCmd(EBodyStateCmd::AdditiveAim) {}
 };
 
 class CBCAdditiveFlinchCmd : public CBodyStateCmd {
   float x8_weight = 1.f;
 
 public:
-  CBCAdditiveFlinchCmd() : CBodyStateCmd(EBodyStateCmd::AdditiveFlinch) {}
-  CBCAdditiveFlinchCmd(float f) : CBodyStateCmd(EBodyStateCmd::AdditiveFlinch), x8_weight(f) {}
+  explicit CBCAdditiveFlinchCmd() : CBodyStateCmd(EBodyStateCmd::AdditiveFlinch) {}
+  explicit CBCAdditiveFlinchCmd(float f) : CBodyStateCmd(EBodyStateCmd::AdditiveFlinch), x8_weight(f) {}
   float GetWeight() const { return x8_weight; }
 };
 
@@ -268,9 +269,9 @@ class CBCAdditiveReactionCmd : public CBodyStateCmd {
   bool x10_active = false;
 
 public:
-  CBCAdditiveReactionCmd() : CBodyStateCmd(EBodyStateCmd::AdditiveReaction) {}
-  CBCAdditiveReactionCmd(pas::EAdditiveReactionType type, float f, bool active)
-  : CBodyStateCmd(EBodyStateCmd::AdditiveReaction), x8_weight(f), xc_type(type), x10_active(active) {}
+  explicit CBCAdditiveReactionCmd() : CBodyStateCmd(EBodyStateCmd::AdditiveReaction) {}
+  explicit CBCAdditiveReactionCmd(pas::EAdditiveReactionType type, float weight, bool active)
+  : CBodyStateCmd(EBodyStateCmd::AdditiveReaction), x8_weight(weight), xc_type(type), x10_active(active) {}
   pas::EAdditiveReactionType GetType() const { return xc_type; }
   float GetWeight() const { return x8_weight; }
   bool GetIsActive() const { return x10_active; }
@@ -281,8 +282,8 @@ class CBCLoopAttackCmd : public CBodyStateCmd {
   u32 xc_waitForAnimOver = 0;
 
 public:
-  CBCLoopAttackCmd() : CBodyStateCmd(EBodyStateCmd::LoopAttack) {}
-  CBCLoopAttackCmd(pas::ELoopAttackType type) : CBodyStateCmd(EBodyStateCmd::LoopAttack), x8_type(type) {}
+  explicit CBCLoopAttackCmd() : CBodyStateCmd(EBodyStateCmd::LoopAttack) {}
+  explicit CBCLoopAttackCmd(pas::ELoopAttackType type) : CBodyStateCmd(EBodyStateCmd::LoopAttack), x8_type(type) {}
   pas::ELoopAttackType GetAttackType() const { return x8_type; }
   bool WaitForAnimOver() const { return xc_waitForAnimOver == 1; }
 };
@@ -291,8 +292,8 @@ class CBCTauntCmd : public CBodyStateCmd {
   pas::ETauntType x8_type = pas::ETauntType::Invalid;
 
 public:
-  CBCTauntCmd() : CBodyStateCmd(EBodyStateCmd::Taunt) {}
-  CBCTauntCmd(pas::ETauntType type) : CBodyStateCmd(EBodyStateCmd::Taunt), x8_type(type) {}
+  explicit CBCTauntCmd() : CBodyStateCmd(EBodyStateCmd::Taunt) {}
+  explicit CBCTauntCmd(pas::ETauntType type) : CBodyStateCmd(EBodyStateCmd::Taunt), x8_type(type) {}
   pas::ETauntType GetTauntType() const { return x8_type; }
 };
 
@@ -302,7 +303,7 @@ class CBCLocomotionCmd {
   float x18_weight;
 
 public:
-  CBCLocomotionCmd(const zeus::CVector3f& move, const zeus::CVector3f& face, float weight)
+  explicit CBCLocomotionCmd(const zeus::CVector3f& move, const zeus::CVector3f& face, float weight)
   : x0_move(move), xc_face(face), x18_weight(weight) {}
   const zeus::CVector3f& GetMoveVector() const { return x0_move; }
   const zeus::CVector3f& GetFaceVector() const { return xc_face; }
@@ -324,7 +325,7 @@ class CBodyStateCmdMgr {
   u32 xb4_deliveredCmdMask = 0;
   CBCGetupCmd xb8_getup;
   CBCStepCmd xc4_step;
-  CBodyStateCmd xd4_die = {EBodyStateCmd::Die};
+  CBodyStateCmd xd4_die{EBodyStateCmd::Die};
   CBCKnockDownCmd xdc_knockDown;
   CBCKnockBackCmd xf4_knockBack;
   CBCMeleeAttackCmd x10c_meleeAttack;
@@ -332,10 +333,10 @@ class CBodyStateCmdMgr {
   CBCLoopAttackCmd x144_loopAttack;
   CBCLoopReactionCmd x154_loopReaction;
   CBCLoopHitReactionCmd x160_loopHitReaction;
-  CBodyStateCmd x16c_exitState = {EBodyStateCmd::ExitState};
-  CBodyStateCmd x174_leanFromCover = {EBodyStateCmd::LeanFromCover};
-  CBodyStateCmd x17c_nextState = {EBodyStateCmd::NextState};
-  CBodyStateCmd x184_maintainVelocity = {EBodyStateCmd::MaintainVelocity};
+  CBodyStateCmd x16c_exitState{EBodyStateCmd::ExitState};
+  CBodyStateCmd x174_leanFromCover{EBodyStateCmd::LeanFromCover};
+  CBodyStateCmd x17c_nextState{EBodyStateCmd::NextState};
+  CBodyStateCmd x184_maintainVelocity{EBodyStateCmd::MaintainVelocity};
   CBCGenerateCmd x18c_generate;
   CBCHurledCmd x1ac_hurled;
   CBCJumpCmd x1d0_jump;
@@ -344,12 +345,12 @@ class CBodyStateCmdMgr {
   CBCScriptedCmd x21c_scripted;
   CBCCoverCmd x230_cover;
   CBCWallHangCmd x254_wallHang;
-  CBodyStateCmd x260_locomotion = {EBodyStateCmd::Locomotion};
-  CBodyStateCmd x268_additiveIdle = {EBodyStateCmd::AdditiveIdle};
+  CBodyStateCmd x260_locomotion{EBodyStateCmd::Locomotion};
+  CBodyStateCmd x268_additiveIdle{EBodyStateCmd::AdditiveIdle};
   CBCAdditiveAimCmd x270_additiveAim;
   CBCAdditiveFlinchCmd x278_additiveFlinch;
   CBCAdditiveReactionCmd x284_additiveReaction;
-  CBodyStateCmd x298_stopReaction = {EBodyStateCmd::StopReaction};
+  CBodyStateCmd x298_stopReaction{EBodyStateCmd::StopReaction};
   void DeliverCmd(EBodyStateCmd cmd) { xb4_deliveredCmdMask |= (1 << int(cmd)); }
 
 public:

--- a/Runtime/Character/CBoolPOINode.hpp
+++ b/Runtime/Character/CBoolPOINode.hpp
@@ -9,8 +9,8 @@ class CBoolPOINode : public CPOINode {
   bool x38_val = false;
 
 public:
-  CBoolPOINode();
-  CBoolPOINode(CInputStream& in);
+  explicit CBoolPOINode();
+  explicit CBoolPOINode(CInputStream& in);
   bool GetValue() const { return x38_val; }
   static CBoolPOINode CopyNodeMinusStartTime(const CBoolPOINode& node, const CCharAnimTime& startTime);
 };

--- a/Runtime/Character/CCharacterInfo.hpp
+++ b/Runtime/Character/CCharacterInfo.hpp
@@ -47,7 +47,7 @@ private:
   std::vector<s32> xb0_animIdxs;
 
 public:
-  CCharacterInfo(CInputStream& in);
+  explicit CCharacterInfo(CInputStream& in);
 
   std::string_view GetCharacterName() const { return x4_name; }
   CAssetId GetModelId() const { return x14_cmdl; }

--- a/Runtime/Character/CCharacterSet.hpp
+++ b/Runtime/Character/CCharacterSet.hpp
@@ -13,7 +13,7 @@ class CCharacterSet {
   std::map<u32, CCharacterInfo> x4_characters;
 
 public:
-  CCharacterSet(CInputStream& in);
+  explicit CCharacterSet(CInputStream& in);
   const std::map<u32, CCharacterInfo>& GetCharacterInfoMap() const { return x4_characters; }
 };
 

--- a/Runtime/Character/CEffectComponent.hpp
+++ b/Runtime/Character/CEffectComponent.hpp
@@ -18,7 +18,7 @@ class CEffectComponent {
   static SObjectTag GetSObjectTagFromStream(CInputStream& in);
 
 public:
-  CEffectComponent(CInputStream& in);
+  explicit CEffectComponent(CInputStream& in);
 
   std::string_view GetComponentName() const { return x0_name; }
   const SObjectTag& GetParticleTag() const { return x10_tag; }

--- a/Runtime/Character/CFBStreamedAnimReader.hpp
+++ b/Runtime/Character/CFBStreamedAnimReader.hpp
@@ -42,7 +42,7 @@ class CFBStreamedAnimReaderTotals {
   void Allocate(u32 chanCount);
 
 public:
-  CFBStreamedAnimReaderTotals(const CFBStreamedCompression& source);
+  explicit CFBStreamedAnimReaderTotals(const CFBStreamedCompression& source);
   void Initialize(const CFBStreamedCompression& source);
   void IncrementInto(CBitLevelLoader& loader, const CFBStreamedCompression& source, CFBStreamedAnimReaderTotals& dest);
   void CalculateDown();
@@ -61,7 +61,7 @@ class CFBStreamedPairOfTotals {
   float x78_t = 0.f;
 
 public:
-  CFBStreamedPairOfTotals(const TSubAnimTypeToken<CFBStreamedCompression>& source);
+  explicit CFBStreamedPairOfTotals(const TSubAnimTypeToken<CFBStreamedCompression>& source);
   void SetTime(CBitLevelLoader& loader, const CCharAnimTime& time);
   void DoIncrement(CBitLevelLoader& loader);
   float GetT() const { return x78_t; }
@@ -76,7 +76,7 @@ class CBitLevelLoader {
   size_t m_bitIdx = 0;
 
 public:
-  CBitLevelLoader(const void* data) : m_data(reinterpret_cast<const u8*>(data)) {}
+  explicit CBitLevelLoader(const void* data) : m_data(reinterpret_cast<const u8*>(data)) {}
   void Reset() { m_bitIdx = 0; }
   u32 LoadUnsigned(u8 q);
   s32 LoadSigned(u8 q);
@@ -88,7 +88,7 @@ class CSegIdToIndexConverter {
   std::array<s32,100> x0_indices;
 
 public:
-  CSegIdToIndexConverter(const CFBStreamedAnimReaderTotals& totals);
+  explicit CSegIdToIndexConverter(const CFBStreamedAnimReaderTotals& totals);
   s32 SegIdToIndex(const CSegId& id) const { return x0_indices[id]; }
 };
 
@@ -104,7 +104,7 @@ class CFBStreamedAnimReader : public CAnimSourceReaderBase {
   zeus::CQuaternion GetRotation(const CSegId& seg) const;
 
 public:
-  CFBStreamedAnimReader(const TSubAnimTypeToken<CFBStreamedCompression>& source, const CCharAnimTime& time);
+  explicit CFBStreamedAnimReader(const TSubAnimTypeToken<CFBStreamedCompression>& source, const CCharAnimTime& time);
 
   SAdvancementResults VGetAdvancementResults(const CCharAnimTime& a, const CCharAnimTime& b) const override;
   bool VSupportsReverseView() const override { return false; }

--- a/Runtime/Character/CFBStreamedCompression.hpp
+++ b/Runtime/Character/CFBStreamedCompression.hpp
@@ -66,7 +66,7 @@ private:
   float CalculateAverageVelocity(const u8* chans) const;
 
 public:
-  CFBStreamedCompression(CInputStream& in, IObjectStore& objStore, bool pc);
+  explicit CFBStreamedCompression(CInputStream& in, IObjectStore& objStore, bool pc);
   const Header& MainHeader() const { return *reinterpret_cast<const Header*>(xc_rotsAndOffs.get()); }
   const u32* GetTimes() const;
   const u8* GetPerChannelHeaders() const;

--- a/Runtime/Character/CHalfTransition.hpp
+++ b/Runtime/Character/CHalfTransition.hpp
@@ -13,7 +13,7 @@ class CHalfTransition {
   std::shared_ptr<IMetaTrans> x4_trans;
 
 public:
-  CHalfTransition(CInputStream& in);
+  explicit CHalfTransition(CInputStream& in);
   u32 GetId() const { return x0_id; }
   const std::shared_ptr<IMetaTrans>& GetMetaTrans() const { return x4_trans; }
 };

--- a/Runtime/Character/CHierarchyPoseBuilder.hpp
+++ b/Runtime/Character/CHierarchyPoseBuilder.hpp
@@ -36,7 +36,7 @@ private:
                         const zeus::CVector3f& offset) const;
 
 public:
-  CHierarchyPoseBuilder(const CLayoutDescription& layout);
+  explicit CHierarchyPoseBuilder(const CLayoutDescription& layout);
 
   const TLockedToken<CCharLayoutInfo>& CharLayoutInfo() const { return x0_layoutDesc.ScaledLayout(); }
   bool HasRoot() const { return x34_hasRoot; }

--- a/Runtime/Character/CInt32POINode.hpp
+++ b/Runtime/Character/CInt32POINode.hpp
@@ -15,7 +15,7 @@ class CInt32POINode : public CPOINode {
 public:
   CInt32POINode();
   CInt32POINode(std::string_view, EPOIType, const CCharAnimTime&, s32, bool, float, s32, s32, s32, std::string_view);
-  CInt32POINode(CInputStream& in);
+  explicit CInt32POINode(CInputStream& in);
   s32 GetValue() const { return x38_val; }
   std::string_view GetLocatorName() const { return x3c_locatorName; }
 

--- a/Runtime/Character/CLayoutDescription.hpp
+++ b/Runtime/Character/CLayoutDescription.hpp
@@ -27,7 +27,7 @@ private:
   std::optional<CScaledLayoutDescription> xc_scaled;
 
 public:
-  CLayoutDescription(const TLockedToken<CCharLayoutInfo>& token) : x0_layoutToken(token) {}
+  explicit CLayoutDescription(const TLockedToken<CCharLayoutInfo>& token) : x0_layoutToken(token) {}
 
   const std::optional<CScaledLayoutDescription>& GetScaledLayoutDescription() const { return xc_scaled; }
 

--- a/Runtime/Character/CMetaAnimBlend.hpp
+++ b/Runtime/Character/CMetaAnimBlend.hpp
@@ -14,7 +14,7 @@ class CMetaAnimBlend : public IMetaAnim {
   bool x10_;
 
 public:
-  CMetaAnimBlend(CInputStream& in);
+  explicit CMetaAnimBlend(CInputStream& in);
   EMetaAnimType GetType() const override { return EMetaAnimType::Blend; }
 
   void GetUniquePrimitives(std::set<CPrimitive>& primsOut) const override;

--- a/Runtime/Character/CMetaAnimPhaseBlend.hpp
+++ b/Runtime/Character/CMetaAnimPhaseBlend.hpp
@@ -14,7 +14,7 @@ class CMetaAnimPhaseBlend : public IMetaAnim {
   bool x10_;
 
 public:
-  CMetaAnimPhaseBlend(CInputStream& in);
+  explicit CMetaAnimPhaseBlend(CInputStream& in);
   EMetaAnimType GetType() const override { return EMetaAnimType::PhaseBlend; }
 
   void GetUniquePrimitives(std::set<CPrimitive>& primsOut) const override;

--- a/Runtime/Character/CMetaAnimPlay.hpp
+++ b/Runtime/Character/CMetaAnimPlay.hpp
@@ -11,7 +11,7 @@ class CMetaAnimPlay : public IMetaAnim {
   CCharAnimTime x1c_startTime;
 
 public:
-  CMetaAnimPlay(CInputStream& in);
+  explicit CMetaAnimPlay(CInputStream& in);
   EMetaAnimType GetType() const override { return EMetaAnimType::Play; }
 
   void GetUniquePrimitives(std::set<CPrimitive>& primsOut) const override;

--- a/Runtime/Character/CMetaAnimRandom.hpp
+++ b/Runtime/Character/CMetaAnimRandom.hpp
@@ -15,7 +15,7 @@ class CMetaAnimRandom : public IMetaAnim {
   static RandomData CreateRandomData(CInputStream& in);
 
 public:
-  CMetaAnimRandom(CInputStream& in);
+  explicit CMetaAnimRandom(CInputStream& in);
   EMetaAnimType GetType() const override { return EMetaAnimType::Random; }
 
   void GetUniquePrimitives(std::set<CPrimitive>& primsOut) const override;

--- a/Runtime/Character/CMetaAnimSequence.hpp
+++ b/Runtime/Character/CMetaAnimSequence.hpp
@@ -13,7 +13,7 @@ class CMetaAnimSequence : public IMetaAnim {
   std::vector<std::shared_ptr<IMetaAnim>> CreateSequence(CInputStream& in);
 
 public:
-  CMetaAnimSequence(CInputStream& in);
+  explicit CMetaAnimSequence(CInputStream& in);
   EMetaAnimType GetType() const override { return EMetaAnimType::Sequence; }
 
   void GetUniquePrimitives(std::set<CPrimitive>& primsOut) const override;

--- a/Runtime/Character/CMetaTransMetaAnim.hpp
+++ b/Runtime/Character/CMetaTransMetaAnim.hpp
@@ -12,7 +12,7 @@ class CMetaTransMetaAnim : public IMetaTrans {
   std::shared_ptr<IMetaAnim> x4_metaAnim;
 
 public:
-  CMetaTransMetaAnim(CInputStream& in);
+  explicit CMetaTransMetaAnim(CInputStream& in);
   EMetaTransType GetType() const override { return EMetaTransType::MetaAnim; }
 
   std::shared_ptr<CAnimTreeNode> VGetTransitionTree(const std::weak_ptr<CAnimTreeNode>& a,

--- a/Runtime/Character/CMetaTransPhaseTrans.hpp
+++ b/Runtime/Character/CMetaTransPhaseTrans.hpp
@@ -13,7 +13,7 @@ class CMetaTransPhaseTrans : public IMetaTrans {
   u32 x10_flags;
 
 public:
-  CMetaTransPhaseTrans(CInputStream& in);
+  explicit CMetaTransPhaseTrans(CInputStream& in);
   EMetaTransType GetType() const override { return EMetaTransType::PhaseTrans; }
 
   std::shared_ptr<CAnimTreeNode> VGetTransitionTree(const std::weak_ptr<CAnimTreeNode>& a,

--- a/Runtime/Character/CMetaTransTrans.hpp
+++ b/Runtime/Character/CMetaTransTrans.hpp
@@ -13,7 +13,7 @@ class CMetaTransTrans : public IMetaTrans {
   u32 x10_flags;
 
 public:
-  CMetaTransTrans(CInputStream& in);
+  explicit CMetaTransTrans(CInputStream& in);
   EMetaTransType GetType() const override { return EMetaTransType::Trans; }
 
   std::shared_ptr<CAnimTreeNode> VGetTransitionTree(const std::weak_ptr<CAnimTreeNode>& a,

--- a/Runtime/Character/CModelData.hpp
+++ b/Runtime/Character/CModelData.hpp
@@ -88,8 +88,8 @@ public:
   bool GetSortThermal() const { return x14_25_sortThermal; }
 
   ~CModelData();
-  CModelData(const CStaticRes& res, int instCount = 1);
-  CModelData(const CAnimRes& res, int instCount = 1);
+  explicit CModelData(const CStaticRes& res, int instCount = 1);
+  explicit CModelData(const CAnimRes& res, int instCount = 1);
   CModelData(CModelData&&) = default;
   CModelData& operator=(CModelData&&) = default;
   CModelData();

--- a/Runtime/Character/CPASAnimInfo.hpp
+++ b/Runtime/Character/CPASAnimInfo.hpp
@@ -11,8 +11,8 @@ class CPASAnimInfo {
   rstl::reserved_vector<CPASAnimParm::UParmValue, 8> x4_parms;
 
 public:
-  CPASAnimInfo(u32 id) : x0_id(id) {}
-  CPASAnimInfo(u32 id, rstl::reserved_vector<CPASAnimParm::UParmValue, 8>&& parms);
+  explicit CPASAnimInfo(u32 id) : x0_id(id) {}
+  explicit CPASAnimInfo(u32 id, rstl::reserved_vector<CPASAnimParm::UParmValue, 8>&& parms);
   u32 GetAnimId() const { return x0_id; }
   CPASAnimParm::UParmValue GetAnimParmValue(u32 idx) const;
   CPASAnimParm GetAnimParmData(u32, CPASAnimParm::EParmType) const;

--- a/Runtime/Character/CPASAnimParmData.hpp
+++ b/Runtime/Character/CPASAnimParmData.hpp
@@ -12,28 +12,18 @@ class CPASAnimParmData {
 public:
   CPASAnimParmData() = default;
 
-  CPASAnimParmData(s32 stateId, const CPASAnimParm& parm1 = CPASAnimParm::NoParameter(),
-                   const CPASAnimParm& parm2 = CPASAnimParm::NoParameter(),
-                   const CPASAnimParm& parm3 = CPASAnimParm::NoParameter(),
-                   const CPASAnimParm& parm4 = CPASAnimParm::NoParameter(),
-                   const CPASAnimParm& parm5 = CPASAnimParm::NoParameter(),
-                   const CPASAnimParm& parm6 = CPASAnimParm::NoParameter(),
-                   const CPASAnimParm& parm7 = CPASAnimParm::NoParameter(),
-                   const CPASAnimParm& parm8 = CPASAnimParm::NoParameter());
+  explicit CPASAnimParmData(s32 stateId, const CPASAnimParm& parm1 = CPASAnimParm::NoParameter(),
+                            const CPASAnimParm& parm2 = CPASAnimParm::NoParameter(),
+                            const CPASAnimParm& parm3 = CPASAnimParm::NoParameter(),
+                            const CPASAnimParm& parm4 = CPASAnimParm::NoParameter(),
+                            const CPASAnimParm& parm5 = CPASAnimParm::NoParameter(),
+                            const CPASAnimParm& parm6 = CPASAnimParm::NoParameter(),
+                            const CPASAnimParm& parm7 = CPASAnimParm::NoParameter(),
+                            const CPASAnimParm& parm8 = CPASAnimParm::NoParameter());
 
   s32 GetStateId() const { return x0_stateId; }
   const rstl::reserved_vector<CPASAnimParm, 8>& GetAnimParmData() const { return x4_parms; }
 
-  static CPASAnimParmData NoParameters(s32 stateId) {
-    return {stateId,
-            CPASAnimParm::NoParameter(),
-            CPASAnimParm::NoParameter(),
-            CPASAnimParm::NoParameter(),
-            CPASAnimParm::NoParameter(),
-            CPASAnimParm::NoParameter(),
-            CPASAnimParm::NoParameter(),
-            CPASAnimParm::NoParameter(),
-            CPASAnimParm::NoParameter()};
-  }
+  static auto NoParameters(s32 stateId) { return CPASAnimParmData(stateId); }
 };
 } // namespace urde

--- a/Runtime/Character/CPOINode.hpp
+++ b/Runtime/Character/CPOINode.hpp
@@ -33,9 +33,9 @@ protected:
   s32 x34_flags;
 
 public:
-  CPOINode(std::string_view name, EPOIType type, const CCharAnimTime& time, s32 index, bool unique, float weight,
-           s32 charIdx, s32 flags);
-  CPOINode(CInputStream& in);
+  explicit CPOINode(std::string_view name, EPOIType type, const CCharAnimTime& time, s32 index, bool unique,
+                    float weight, s32 charIdx, s32 flags);
+  explicit CPOINode(CInputStream& in);
   virtual ~CPOINode() = default;
 
   std::string_view GetString() const { return x8_name; }

--- a/Runtime/Character/CParticleData.hpp
+++ b/Runtime/Character/CParticleData.hpp
@@ -22,7 +22,7 @@ private:
 
 public:
   CParticleData() = default;
-  CParticleData(CInputStream& in);
+  explicit CParticleData(CInputStream& in);
   u32 GetDuration() const { return x0_duration; }
   const SObjectTag& GetTag() const { return x4_particle; }
   std::string_view GetSegmentName() const { return xc_boneName; }

--- a/Runtime/Character/CParticlePOINode.hpp
+++ b/Runtime/Character/CParticlePOINode.hpp
@@ -10,8 +10,8 @@ class CParticlePOINode : public CPOINode {
   CParticleData x38_data;
 
 public:
-  CParticlePOINode();
-  CParticlePOINode(CInputStream& in);
+  explicit CParticlePOINode();
+  explicit CParticlePOINode(CInputStream& in);
   const CParticleData& GetParticleData() const { return x38_data; }
 
   static CParticlePOINode CopyNodeMinusStartTime(const CParticlePOINode& node, const CCharAnimTime& startTime);

--- a/Runtime/Character/CPrimitive.hpp
+++ b/Runtime/Character/CPrimitive.hpp
@@ -13,7 +13,7 @@ class CPrimitive {
   std::string x8_animName;
 
 public:
-  CPrimitive(CInputStream& in);
+  explicit CPrimitive(CInputStream& in);
   CAssetId GetAnimResId() const { return x0_animId; }
   u32 GetAnimDbIdx() const { return x4_animIdx; }
   std::string_view GetName() const { return x8_animName; }

--- a/Runtime/Character/CSegIdList.hpp
+++ b/Runtime/Character/CSegIdList.hpp
@@ -11,7 +11,7 @@ class CSegIdList {
   std::vector<CSegId> x0_list;
 
 public:
-  CSegIdList(CInputStream& in);
+  explicit CSegIdList(CInputStream& in);
   const std::vector<CSegId>& GetList() const { return x0_list; }
 };
 

--- a/Runtime/Character/CSkinBank.hpp
+++ b/Runtime/Character/CSkinBank.hpp
@@ -12,7 +12,7 @@ class CSkinBank {
   std::vector<CSegId> x0_segments;
 
 public:
-  CSkinBank(CInputStream& in);
+  explicit CSkinBank(CInputStream& in);
   void GetBankTransforms(std::vector<const zeus::CTransform*>& out, const CPoseAsTransforms& pose) const;
 };
 

--- a/Runtime/Character/CSoundPOINode.hpp
+++ b/Runtime/Character/CSoundPOINode.hpp
@@ -12,10 +12,10 @@ class CSoundPOINode : public CPOINode {
   float x40_maxDist;
 
 public:
-  CSoundPOINode();
-  CSoundPOINode(CInputStream& in);
-  CSoundPOINode(std::string_view name, EPOIType type, const CCharAnimTime& time, u32 b, bool c, float d, u32 e, u32 f,
-                u32 sfxId, float falloff, float maxDist);
+  explicit CSoundPOINode();
+  explicit CSoundPOINode(CInputStream& in);
+  explicit CSoundPOINode(std::string_view name, EPOIType type, const CCharAnimTime& time, u32 b, bool c, float d, u32 e,
+                         u32 f, u32 sfxId, float falloff, float maxDist);
 
   static CSoundPOINode CopyNodeMinusStartTime(const CSoundPOINode& node, const CCharAnimTime& startTime);
   u32 GetSfxId() const { return x38_sfxId; }

--- a/Runtime/Character/CTimeScaleFunctions.hpp
+++ b/Runtime/Character/CTimeScaleFunctions.hpp
@@ -25,7 +25,7 @@ private:
   float x4_scale;
 
 public:
-  CConstantAnimationTimeScale(float scale) : x4_scale(scale) {}
+  explicit CConstantAnimationTimeScale(float scale) : x4_scale(scale) {}
 
   EVaryingAnimationTimeScaleType GetType() const override { return EVaryingAnimationTimeScaleType::Constant; }
   float VTimeScaleIntegral(float lowerLimit, float upperLimit) const override;
@@ -46,7 +46,7 @@ class CLinearAnimationTimeScale : public IVaryingAnimationTimeScale {
   static float TimeScaleIntegralWithSortedLimits(const CFunctionDescription& desc, float lowerLimit, float upperLimit);
 
 public:
-  CLinearAnimationTimeScale(const CCharAnimTime& t1, float y1, const CCharAnimTime& t2, float y2);
+  explicit CLinearAnimationTimeScale(const CCharAnimTime& t1, float y1, const CCharAnimTime& t2, float y2);
 
   EVaryingAnimationTimeScaleType GetType() const override { return EVaryingAnimationTimeScaleType::Linear; }
   float VTimeScaleIntegral(float lowerLimit, float upperLimit) const override;

--- a/Runtime/Character/CTransition.hpp
+++ b/Runtime/Character/CTransition.hpp
@@ -15,7 +15,7 @@ class CTransition {
   std::shared_ptr<IMetaTrans> xc_trans;
 
 public:
-  CTransition(CInputStream& in);
+  explicit CTransition(CInputStream& in);
   u32 GetAnimA() const { return x4_animA; }
   u32 GetAnimB() const { return x8_animB; }
   std::pair<u32, u32> GetAnimPair() const { return {x4_animA, x8_animB}; }

--- a/Runtime/Character/IAnimReader.hpp
+++ b/Runtime/Character/IAnimReader.hpp
@@ -73,7 +73,8 @@ class TSubAnimTypeToken : public TLockedToken<CAllFormatsAnimSource> {};
 template <>
 class TSubAnimTypeToken<CAnimSource> : public TLockedToken<CAnimSource> {
 public:
-  TSubAnimTypeToken<CAnimSource>(const TLockedToken<CAllFormatsAnimSource>& token) : TLockedToken<CAnimSource>(token) {}
+  // Converting constructor
+  TSubAnimTypeToken(const TLockedToken<CAllFormatsAnimSource>& token) : TLockedToken<CAnimSource>(token) {}
 
   CAnimSource* GetObj() {
     CAllFormatsAnimSource* source = reinterpret_cast<CAllFormatsAnimSource*>(TLockedToken<CAnimSource>::GetObj());
@@ -88,8 +89,8 @@ public:
 template <>
 class TSubAnimTypeToken<CFBStreamedCompression> : public TLockedToken<CFBStreamedCompression> {
 public:
-  TSubAnimTypeToken<CFBStreamedCompression>(const TLockedToken<CAllFormatsAnimSource>& token)
-  : TLockedToken<CFBStreamedCompression>(token) {}
+  // Converting constructor
+  TSubAnimTypeToken(const TLockedToken<CAllFormatsAnimSource>& token) : TLockedToken<CFBStreamedCompression>(token) {}
 
   CFBStreamedCompression* GetObj() {
     CAllFormatsAnimSource* source =

--- a/Runtime/Character/IMetaAnim.hpp
+++ b/Runtime/Character/IMetaAnim.hpp
@@ -35,8 +35,8 @@ class CPreAdvanceIndicator {
   u16 x3c_;
   */
 public:
-  CPreAdvanceIndicator(const CCharAnimTime& time) : x0_isTime(true), x4_time(time) {}
-  CPreAdvanceIndicator(const char* string) : x0_isTime(false), xc_string(string) {}
+  explicit CPreAdvanceIndicator(const CCharAnimTime& time) : x0_isTime(true), x4_time(time) {}
+  explicit CPreAdvanceIndicator(const char* string) : x0_isTime(false), xc_string(string) {}
   const char* GetString() const { return xc_string; }
   bool IsString() const { return !x0_isTime; }
   const CCharAnimTime& GetTime() const { return x4_time; }

--- a/Runtime/Character/TSegIdMap.hpp
+++ b/Runtime/Character/TSegIdMap.hpp
@@ -18,7 +18,7 @@ class TSegIdMap {
   CSegId xd4_curPrevBone = 0;
 
 public:
-  TSegIdMap(const CSegId& capacity) : x1_capacity(capacity), xd0_bones(new T[capacity]) {}
+  explicit TSegIdMap(const CSegId& capacity) : x1_capacity(capacity), xd0_bones(new T[capacity]) {}
 
   T& operator[](const CSegId& id) { return SetElement(id); }
   const T& operator[](const CSegId& id) const { return xd0_bones[x8_indirectionMap[id].second]; }

--- a/Runtime/Collision/CAABoxFilter.hpp
+++ b/Runtime/Collision/CAABoxFilter.hpp
@@ -7,7 +7,7 @@ class CCollisionInfoList;
 
 class CAABoxFilter : public ICollisionFilter {
 public:
-  CAABoxFilter(CActor& actor) : ICollisionFilter(actor) {}
+  explicit CAABoxFilter(CActor& actor) : ICollisionFilter(actor) {}
   void Filter(const CCollisionInfoList& in, CCollisionInfoList& out) const override;
   static void FilterBoxFloorCollisions(const CCollisionInfoList& in, CCollisionInfoList& out);
 };

--- a/Runtime/Collision/CAreaOctTree.hpp
+++ b/Runtime/Collision/CAreaOctTree.hpp
@@ -27,7 +27,7 @@ public:
     const u16* m_ptr;
 
   public:
-    TriListReference(const u16* ptr) : m_ptr(ptr) {}
+    explicit TriListReference(const u16* ptr) : m_ptr(ptr) {}
     u16 GetAt(int idx) const { return m_ptr[idx + 1]; }
     u16 GetSize() const { return m_ptr[0]; }
   };

--- a/Runtime/Collision/CBallFilter.hpp
+++ b/Runtime/Collision/CBallFilter.hpp
@@ -8,7 +8,7 @@ class CPhysicsActor;
 
 class CBallFilter : public ICollisionFilter {
 public:
-  CBallFilter(CActor& actor) : ICollisionFilter(actor) {}
+  explicit CBallFilter(CActor& actor) : ICollisionFilter(actor) {}
   void Filter(const CCollisionInfoList& in, CCollisionInfoList& out) const override;
 };
 

--- a/Runtime/Collision/CCollidableOBBTreeGroup.hpp
+++ b/Runtime/Collision/CCollidableOBBTreeGroup.hpp
@@ -19,7 +19,7 @@ class CCollidableOBBTreeGroupContainer {
   zeus::CAABox x20_aabox;
 
 public:
-  CCollidableOBBTreeGroupContainer(CInputStream& in);
+  explicit CCollidableOBBTreeGroupContainer(CInputStream& in);
   CCollidableOBBTreeGroupContainer(const zeus::CVector3f&, const zeus::CVector3f&);
 };
 

--- a/Runtime/Collision/CCollisionEdge.hpp
+++ b/Runtime/Collision/CCollisionEdge.hpp
@@ -9,7 +9,7 @@ class CCollisionEdge {
 
 public:
   CCollisionEdge() = default;
-  CCollisionEdge(CInputStream&);
+  explicit CCollisionEdge(CInputStream&);
   CCollisionEdge(u16 v0, u16 v1) : x0_index1(v0), x2_index2(v1) {}
 
   u16 GetVertIndex1() const { return x0_index1; }

--- a/Runtime/Collision/CCollisionPrimitive.hpp
+++ b/Runtime/Collision/CCollisionPrimitive.hpp
@@ -134,7 +134,7 @@ private:
 
 public:
   CCollisionPrimitive() = default;
-  CCollisionPrimitive(const CMaterialList& list);
+  explicit CCollisionPrimitive(const CMaterialList& list);
   virtual u32 GetTableIndex() const = 0;
   virtual void SetMaterial(const CMaterialList&);
   virtual const CMaterialList& GetMaterial() const;

--- a/Runtime/Collision/CCollisionResponseData.hpp
+++ b/Runtime/Collision/CCollisionResponseData.hpp
@@ -126,7 +126,7 @@ class CCollisionResponseData {
   bool CheckAndAddResourceToResponse(FourCC clsId, CInputStream& in, CSimplePool* resPool);
 
 public:
-  CCollisionResponseData(CInputStream& in, CSimplePool* resPool);
+  explicit CCollisionResponseData(CInputStream& in, CSimplePool* resPool);
   const std::optional<TLockedToken<CGenDescription>>& GetParticleDescription(EWeaponCollisionResponseTypes type) const;
   const std::optional<TLockedToken<CDecalDescription>>& GetDecalDescription(EWeaponCollisionResponseTypes type) const;
   s32 GetSoundEffectId(EWeaponCollisionResponseTypes type) const;

--- a/Runtime/Collision/CMetroidAreaCollider.hpp
+++ b/Runtime/Collision/CMetroidAreaCollider.hpp
@@ -121,7 +121,7 @@ public:
     bool x908_24_overflow : 1;
 
   public:
-    COctreeLeafCache(const CAreaOctTree& octTree);
+    explicit COctreeLeafCache(const CAreaOctTree& octTree);
     void AddLeaf(const CAreaOctTree::Node& node);
     u32 GetNumLeaves() const { return x4_nodeCache.size(); }
     bool HasCacheOverflowed() const { return x908_24_overflow; }
@@ -179,7 +179,7 @@ class CAreaCollisionCache {
   };
 
 public:
-  CAreaCollisionCache(const zeus::CAABox& aabb) : x0_aabb(aabb) {}
+  explicit CAreaCollisionCache(const zeus::CAABox& aabb) : x0_aabb(aabb) {}
   void ClearCache();
   const zeus::CAABox& GetCacheBounds() const { return x0_aabb; }
   void SetCacheBounds(const zeus::CAABox& aabb) { x0_aabb = aabb; }

--- a/Runtime/Collision/COBBTree.cpp
+++ b/Runtime/Collision/COBBTree.cpp
@@ -130,30 +130,37 @@ zeus::CAABox COBBTree::CalculateAABox(const zeus::CTransform& xf) const {
 COBBTree::SIndexData::SIndexData(CInputStream& in) {
   u32 count = in.readUint32Big();
   x0_materials.reserve(count);
-  for (u32 i = 0; i < count; i++)
-    x0_materials.push_back(in.readUint32Big());
+  for (u32 i = 0; i < count; i++) {
+    x0_materials.emplace_back(in.readUint32Big());
+  }
 
   count = in.readUint32Big();
-  for (u32 i = 0; i < count; i++)
-    x10_vertMaterials.push_back(in.readUByte());
+  for (u32 i = 0; i < count; i++) {
+    x10_vertMaterials.emplace_back(in.readUByte());
+  }
   count = in.readUint32Big();
-  for (u32 i = 0; i < count; i++)
-    x20_edgeMaterials.push_back(in.readUByte());
+  for (u32 i = 0; i < count; i++) {
+    x20_edgeMaterials.emplace_back(in.readUByte());
+  }
   count = in.readUint32Big();
-  for (u32 i = 0; i < count; i++)
-    x30_surfaceMaterials.push_back(in.readUByte());
+  for (u32 i = 0; i < count; i++) {
+    x30_surfaceMaterials.emplace_back(in.readUByte());
+  }
 
   count = in.readUint32Big();
-  for (u32 i = 0; i < count; i++)
-    x40_edges.push_back(in);
+  for (u32 i = 0; i < count; i++) {
+    x40_edges.emplace_back(in);
+  }
 
   count = in.readUint32Big();
-  for (u32 i = 0; i < count; i++)
-    x50_surfaceIndices.push_back(in.readUint16Big());
+  for (u32 i = 0; i < count; i++) {
+    x50_surfaceIndices.emplace_back(in.readUint16Big());
+  }
 
   count = in.readUint32Big();
-  for (u32 i = 0; i < count; i++)
-    x60_vertices.push_back(zeus::CVector3f::ReadBig(in));
+  for (u32 i = 0; i < count; i++) {
+    x60_vertices.emplace_back(zeus::CVector3f::ReadBig(in));
+  }
 }
 
 COBBTree::CNode::CNode(const zeus::CTransform& xf, const zeus::CVector3f& point,
@@ -195,14 +202,15 @@ COBBTree::CLeafData::CLeafData(std::vector<u16>&& surface) : x0_surface(std::mov
 const std::vector<u16>& COBBTree::CLeafData::GetSurfaceVector() const { return x0_surface; }
 
 size_t COBBTree::CLeafData::GetMemoryUsage() const {
-  size_t ret = (x0_surface.size() * 2) + /*sizeof(CLeafData)*/ 16;
+  const size_t ret = (x0_surface.size() * 2) + /*sizeof(CLeafData)*/ 16;
   return (ret + 3) & ~3;
 }
 
 COBBTree::CLeafData::CLeafData(CInputStream& in) {
-  u32 edgeCount = in.readUint32Big();
-  for (u32 i = 0; i < edgeCount; i++)
-    x0_surface.push_back(in.readUint16Big());
+  const u32 edgeCount = in.readUint32Big();
+  for (u32 i = 0; i < edgeCount; i++) {
+    x0_surface.emplace_back(in.readUint16Big());
+  }
 }
 
 } // namespace urde

--- a/Runtime/Collision/COBBTree.hpp
+++ b/Runtime/Collision/COBBTree.hpp
@@ -24,7 +24,7 @@ public:
     std::vector<u16> x50_surfaceIndices;
     std::vector<zeus::CVector3f> x60_vertices;
     SIndexData() = default;
-    SIndexData(CInputStream&);
+    explicit SIndexData(CInputStream&);
   };
 
   class CLeafData {
@@ -32,8 +32,8 @@ public:
 
   public:
     CLeafData() = default;
-    CLeafData(std::vector<u16>&& surface);
-    CLeafData(CInputStream&);
+    explicit CLeafData(std::vector<u16>&& surface);
+    explicit CLeafData(CInputStream&);
 
     const std::vector<u16>& GetSurfaceVector() const;
     size_t GetMemoryUsage() const;
@@ -51,7 +51,7 @@ public:
     CNode() = default;
     CNode(const zeus::CTransform&, const zeus::CVector3f&, std::unique_ptr<CNode>&&, std::unique_ptr<CNode>&&,
           std::unique_ptr<CLeafData>&&);
-    CNode(CInputStream&);
+    explicit CNode(CInputStream&);
 
     bool WasHit() const { return x4c_hit; }
     void SetHit(bool h) { x4c_hit = h; }
@@ -73,7 +73,7 @@ private:
 
 public:
   COBBTree() = default;
-  COBBTree(CInputStream&);
+  explicit COBBTree(CInputStream&);
 
   static std::unique_ptr<COBBTree> BuildOrientedBoundingBoxTree(const zeus::CVector3f&,
                                                                 const zeus::CVector3f&);

--- a/Runtime/Collision/ICollisionFilter.hpp
+++ b/Runtime/Collision/ICollisionFilter.hpp
@@ -8,7 +8,7 @@ class ICollisionFilter {
   CActor& x4_actor;
 
 protected:
-  ICollisionFilter(CActor& actor) : x4_actor(actor) {}
+  explicit ICollisionFilter(CActor& actor) : x4_actor(actor) {}
 
 public:
   virtual void Filter(const CCollisionInfoList& in, CCollisionInfoList& out) const = 0;

--- a/Runtime/Graphics/CGraphicsPalette.hpp
+++ b/Runtime/Graphics/CGraphicsPalette.hpp
@@ -21,8 +21,9 @@ class CGraphicsPalette {
   bool x1c_ = false;
 
 public:
-  CGraphicsPalette(EPaletteFormat fmt, int count) : x0_fmt(fmt), x8_entryCount(count), xc_entries(new u16[count]) {}
-  CGraphicsPalette(CInputStream& in) : x0_fmt(EPaletteFormat(in.readUint32Big())) {
+  explicit CGraphicsPalette(EPaletteFormat fmt, int count)
+  : x0_fmt(fmt), x8_entryCount(count), xc_entries(new u16[count]) {}
+  explicit CGraphicsPalette(CInputStream& in) : x0_fmt(EPaletteFormat(in.readUint32Big())) {
     u16 w = in.readUint16Big();
     u16 h = in.readUint16Big();
     x8_entryCount = w * h;

--- a/Runtime/Graphics/CModel.hpp
+++ b/Runtime/Graphics/CModel.hpp
@@ -106,7 +106,7 @@ struct SShader {
   MaterialSet m_matSet;
   std::optional<GeometryUniformLayout> m_geomLayout;
   int m_matSetIdx;
-  SShader(int idx) : m_matSetIdx(idx) {
+  explicit SShader(int idx) : m_matSetIdx(idx) {
     x0_textures.clear();
     m_shaders.clear();
   }

--- a/Runtime/Graphics/CPVSAreaSet.hpp
+++ b/Runtime/Graphics/CPVSAreaSet.hpp
@@ -25,7 +25,7 @@ class CPVSAreaSet {
   }
 
 public:
-  CPVSAreaSet(const u8* data, u32 len);
+  explicit CPVSAreaSet(const u8* data, u32 len);
   u32 GetNumFeatures() const { return x0_numFeatures; }
   u32 GetNumActors() const { return xc_numActors; }
   u32 Get1stLightIndex(u32 lightIdx) const { return x0_numFeatures + x8_num2ndLights + lightIdx; }

--- a/Runtime/Graphics/Shaders/CAABoxShader.hpp
+++ b/Runtime/Graphics/Shaders/CAABoxShader.hpp
@@ -24,7 +24,7 @@ class CAABoxShader {
 public:
   static void Initialize();
   static void Shutdown();
-  CAABoxShader(bool zOnly = false);
+  explicit CAABoxShader(bool zOnly = false);
   void setAABB(const zeus::CAABox& aabb);
   void draw(const zeus::CColor& color);
 };

--- a/Runtime/Graphics/Shaders/CColoredQuadFilter.hpp
+++ b/Runtime/Graphics/Shaders/CColoredQuadFilter.hpp
@@ -28,8 +28,8 @@ public:
   static void Initialize();
   static void Shutdown();
   static const zeus::CRectangle DefaultRect;
-  CColoredQuadFilter(EFilterType type);
-  CColoredQuadFilter(EFilterType type, const TLockedToken<CTexture>&) : CColoredQuadFilter(type) {}
+  explicit CColoredQuadFilter(EFilterType type);
+  explicit CColoredQuadFilter(EFilterType type, const TLockedToken<CTexture>&) : CColoredQuadFilter(type) {}
   void draw(const zeus::CColor& color, const zeus::CRectangle& rect = DefaultRect);
   void DrawFilter(EFilterShape shape, const zeus::CColor& color, float t) { draw(color); }
 };
@@ -39,8 +39,8 @@ class CWideScreenFilter {
   CColoredQuadFilter m_bottom;
 
 public:
-  CWideScreenFilter(EFilterType type) : m_top(type), m_bottom(type) {}
-  CWideScreenFilter(EFilterType type, const TLockedToken<CTexture>&) : CWideScreenFilter(type) {}
+  explicit CWideScreenFilter(EFilterType type) : m_top(type), m_bottom(type) {}
+  explicit CWideScreenFilter(EFilterType type, const TLockedToken<CTexture>&) : CWideScreenFilter(type) {}
   void draw(const zeus::CColor& color, float t);
   void DrawFilter(EFilterShape shape, const zeus::CColor& color, float t);
 

--- a/Runtime/Graphics/Shaders/CRandomStaticFilter.hpp
+++ b/Runtime/Graphics/Shaders/CRandomStaticFilter.hpp
@@ -26,16 +26,16 @@ class CRandomStaticFilter {
 public:
   static void Initialize();
   static void Shutdown();
-  CRandomStaticFilter(EFilterType type, bool cookieCutter = false);
-  CRandomStaticFilter(EFilterType type, const TLockedToken<CTexture>&) : CRandomStaticFilter(type) {}
+  explicit CRandomStaticFilter(EFilterType type, bool cookieCutter = false);
+  explicit CRandomStaticFilter(EFilterType type, const TLockedToken<CTexture>&) : CRandomStaticFilter(type) {}
   void draw(const zeus::CColor& color, float t);
   void DrawFilter(EFilterShape, const zeus::CColor& color, float t) { draw(color, t); }
 };
 
 class CCookieCutterDepthRandomStaticFilter : public CRandomStaticFilter {
 public:
-  CCookieCutterDepthRandomStaticFilter(EFilterType type) : CRandomStaticFilter(type, true) {}
-  CCookieCutterDepthRandomStaticFilter(EFilterType type, const TLockedToken<CTexture>&)
+  explicit CCookieCutterDepthRandomStaticFilter(EFilterType type) : CRandomStaticFilter(type, true) {}
+  explicit CCookieCutterDepthRandomStaticFilter(EFilterType type, const TLockedToken<CTexture>&)
   : CCookieCutterDepthRandomStaticFilter(type) {}
 };
 

--- a/Runtime/Graphics/Shaders/CScanLinesFilter.hpp
+++ b/Runtime/Graphics/Shaders/CScanLinesFilter.hpp
@@ -23,21 +23,21 @@ class CScanLinesFilter {
 public:
   static void Initialize();
   static void Shutdown();
-  CScanLinesFilter(EFilterType type, bool even);
+  explicit CScanLinesFilter(EFilterType type, bool even);
   void draw(const zeus::CColor& color);
   void DrawFilter(EFilterShape, const zeus::CColor& color, float) { draw(color); }
 };
 
 class CScanLinesFilterEven : public CScanLinesFilter {
 public:
-  CScanLinesFilterEven(EFilterType type) : CScanLinesFilter(type, true) {}
-  CScanLinesFilterEven(EFilterType type, const TLockedToken<CTexture>&) : CScanLinesFilterEven(type) {}
+  explicit CScanLinesFilterEven(EFilterType type) : CScanLinesFilter(type, true) {}
+  explicit CScanLinesFilterEven(EFilterType type, const TLockedToken<CTexture>&) : CScanLinesFilterEven(type) {}
 };
 
 class CScanLinesFilterOdd : public CScanLinesFilter {
 public:
-  CScanLinesFilterOdd(EFilterType type) : CScanLinesFilter(type, false) {}
-  CScanLinesFilterOdd(EFilterType type, const TLockedToken<CTexture>&) : CScanLinesFilterOdd(type) {}
+  explicit CScanLinesFilterOdd(EFilterType type) : CScanLinesFilter(type, false) {}
+  explicit CScanLinesFilterOdd(EFilterType type, const TLockedToken<CTexture>&) : CScanLinesFilterOdd(type) {}
 };
 
 } // namespace urde

--- a/Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp
+++ b/Runtime/Graphics/Shaders/CTexturedQuadFilter.hpp
@@ -35,7 +35,7 @@ protected:
   ZTest m_zTest;
   bool m_flipRect = false;
 
-  CTexturedQuadFilter(const boo::ObjToken<boo::ITexture>& tex);
+  explicit CTexturedQuadFilter(const boo::ObjToken<boo::ITexture>& tex);
 
 public:
   struct Vert {
@@ -45,8 +45,8 @@ public:
   static void Initialize();
   static void Shutdown();
   static const zeus::CRectangle DefaultRect;
-  CTexturedQuadFilter(EFilterType type, TLockedToken<CTexture> tex, ZTest zTest = ZTest::None);
-  CTexturedQuadFilter(EFilterType type, const boo::ObjToken<boo::ITexture>& tex, ZTest zTest = ZTest::None);
+  explicit CTexturedQuadFilter(EFilterType type, TLockedToken<CTexture> tex, ZTest zTest = ZTest::None);
+  explicit CTexturedQuadFilter(EFilterType type, const boo::ObjToken<boo::ITexture>& tex, ZTest zTest = ZTest::None);
   CTexturedQuadFilter(const CTexturedQuadFilter&) = delete;
   CTexturedQuadFilter& operator=(const CTexturedQuadFilter&) = delete;
   CTexturedQuadFilter(CTexturedQuadFilter&&) = default;
@@ -63,8 +63,8 @@ class CTexturedQuadFilterAlpha : public CTexturedQuadFilter {
 public:
   static void Initialize();
   static void Shutdown();
-  CTexturedQuadFilterAlpha(EFilterType type, TLockedToken<CTexture> tex);
-  CTexturedQuadFilterAlpha(EFilterType type, const boo::ObjToken<boo::ITexture>& tex);
+  explicit CTexturedQuadFilterAlpha(EFilterType type, TLockedToken<CTexture> tex);
+  explicit CTexturedQuadFilterAlpha(EFilterType type, const boo::ObjToken<boo::ITexture>& tex);
 };
 
 } // namespace urde

--- a/Runtime/Graphics/Shaders/CWorldShadowShader.hpp
+++ b/Runtime/Graphics/Shaders/CWorldShadowShader.hpp
@@ -30,7 +30,7 @@ class CWorldShadowShader {
 public:
   static void Initialize();
   static void Shutdown();
-  CWorldShadowShader(u32 w, u32 h);
+  explicit CWorldShadowShader(u32 w, u32 h);
   void bindRenderTarget();
   void drawBase(float extent);
   void lightenShadow();

--- a/Runtime/Graphics/Shaders/CXRayBlurFilter.hpp
+++ b/Runtime/Graphics/Shaders/CXRayBlurFilter.hpp
@@ -24,7 +24,7 @@ class CXRayBlurFilter {
 public:
   static void Initialize();
   static void Shutdown();
-  CXRayBlurFilter(TLockedToken<CTexture>& tex);
+  explicit CXRayBlurFilter(TLockedToken<CTexture>& tex);
   void draw(float amount);
 };
 

--- a/Runtime/GuiSys/CAuiImagePane.cpp
+++ b/Runtime/GuiSys/CAuiImagePane.cpp
@@ -54,9 +54,9 @@ void CAuiImagePane::Update(float dt) {
 CAuiImagePane::Filters::Filters(TLockedToken<CTexture>& tex)
 : m_texId(tex.GetObjectTag()->id)
 , m_darkenerQuad(EFilterType::Blend, tex)
-, m_flashQuad{{{EFilterType::Add, tex}, {EFilterType::Add, tex}}}
-, m_alphaQuad{{{EFilterType::Blend, tex}, {EFilterType::Blend, tex}}}
-, m_addQuad{{{EFilterType::Add, tex}, {EFilterType::Add, tex}}} {}
+, m_flashQuad{{CTexturedQuadFilterAlpha{EFilterType::Add, tex}, CTexturedQuadFilterAlpha{EFilterType::Add, tex}}}
+, m_alphaQuad{{CTexturedQuadFilterAlpha{EFilterType::Blend, tex}, CTexturedQuadFilterAlpha{EFilterType::Blend, tex}}}
+, m_addQuad{{CTexturedQuadFilterAlpha{EFilterType::Add, tex}, CTexturedQuadFilterAlpha{EFilterType::Add, tex}}} {}
 
 void CAuiImagePane::DoDrawImagePane(const zeus::CColor& color, const CTexture& tex, int frame, float alpha, bool noBlur,
                                     CTexturedQuadFilterAlpha& quad) const {

--- a/Runtime/MP1/CFaceplateDecoration.hpp
+++ b/Runtime/MP1/CFaceplateDecoration.hpp
@@ -18,7 +18,7 @@ class CFaceplateDecoration {
   std::optional<CTexturedQuadFilter> m_texFilter;
 
 public:
-  CFaceplateDecoration(CStateManager& stateMgr);
+  explicit CFaceplateDecoration(CStateManager& stateMgr);
   void Update(float dt, CStateManager& stateMgr);
   void Draw(CStateManager& stateMgr);
 };

--- a/Runtime/MP1/CFrontEndUI.hpp
+++ b/Runtime/MP1/CFrontEndUI.hpp
@@ -203,7 +203,7 @@ public:
 
     bool m_gbaOverride = false;
 
-    SFusionBonusFrame(CFrontEndUITouchBar& touchBar);
+    explicit SFusionBonusFrame(CFrontEndUITouchBar& touchBar);
     void FinishedLoading();
     bool PumpLoad();
     void SetTableColors(CGuiTableGroup* tbgp) const;
@@ -354,7 +354,7 @@ private:
   std::unique_ptr<SOptionsFrontEndFrame> xf0_optionsFrme;
   CStaticAudioPlayer* xf4_curAudio = nullptr;
 
-  CColoredQuadFilter m_fadeToBlack = {EFilterType::Blend};
+  CColoredQuadFilter m_fadeToBlack{EFilterType::Blend};
   std::optional<CTexturedQuadFilterAlpha> m_pressStartQuad;
 
   std::unique_ptr<CFrontEndUITouchBar> m_touchBar;

--- a/Runtime/MP1/CInGameGuiManager.hpp
+++ b/Runtime/MP1/CInGameGuiManager.hpp
@@ -98,9 +98,9 @@ private:
 
   std::optional<CTexturedQuadFilter> m_deathRenderTexQuad;
   std::optional<CTexturedQuadFilter> m_deathDotQuad;
-  CRandomStaticFilter m_randomStatic = {EFilterType::Blend};
-  CColoredQuadFilter m_deathWhiteout = {EFilterType::Blend};
-  CColoredQuadFilter m_deathBlackout = {EFilterType::Blend};
+  CRandomStaticFilter m_randomStatic{EFilterType::Blend};
+  CColoredQuadFilter m_deathWhiteout{EFilterType::Blend};
+  CColoredQuadFilter m_deathBlackout{EFilterType::Blend};
 
   union {
     struct {
@@ -126,7 +126,7 @@ private:
   void RefreshHudOptions();
 
 public:
-  CInGameGuiManager(CStateManager& stateMgr, CArchitectureQueue& archQueue);
+  explicit CInGameGuiManager(CStateManager& stateMgr, CArchitectureQueue& archQueue);
   bool CheckLoadComplete(CStateManager& stateMgr);
   void Update(CStateManager& stateMgr, float dt, CArchitectureQueue& archQueue, bool useHud);
   void ProcessControllerInput(CStateManager& stateMgr, const CFinalInput& input, CArchitectureQueue& archQueue);

--- a/Runtime/MP1/CMFGame.hpp
+++ b/Runtime/MP1/CMFGame.hpp
@@ -31,7 +31,7 @@ class CMFGame : public CMFGameBase {
     u8 _dummy = 0;
   };
 
-  CColoredQuadFilter m_fadeToBlack = {EFilterType::Multiply};
+  CColoredQuadFilter m_fadeToBlack{EFilterType::Multiply};
 
   bool IsCameraActiveFlow() const {
     return (x1c_flowState == EGameFlowState::InGame || x1c_flowState == EGameFlowState::SamusDied);

--- a/Runtime/MP1/CMemoryCardDriver.hpp
+++ b/Runtime/MP1/CMemoryCardDriver.hpp
@@ -99,7 +99,7 @@ private:
     u8 x0_saveBuffer[940] = {};
     CGameState::GameFileStateInfo x944_fileInfo;
     SGameFileSlot();
-    SGameFileSlot(CMemoryInStream& in);
+    explicit SGameFileSlot(CMemoryInStream& in);
     void InitializeFromGameState();
     void LoadGameState(u32 idx);
     void DoPut(CMemoryOutStream& w) const { w.writeBytes(x0_saveBuffer, 940); }

--- a/Runtime/MP1/CMessageScreen.hpp
+++ b/Runtime/MP1/CMessageScreen.hpp
@@ -39,7 +39,7 @@ class CMessageScreen {
   bool x78_24_exit : 1;
 
 public:
-  CMessageScreen(CAssetId msg, float time);
+  explicit CMessageScreen(CAssetId msg, float time);
   void ProcessControllerInput(const CFinalInput& input);
   bool Update(float dt, float blurAmt);
   void Draw() const;

--- a/Runtime/MP1/CPauseScreenBlur.hpp
+++ b/Runtime/MP1/CPauseScreenBlur.hpp
@@ -20,8 +20,8 @@ class CPauseScreenBlur {
   EState x14_nextState = EState::InGame;
   float x18_blurAmt = 0.f;
   CCameraBlurPass x1c_camBlur;
-  CTexturedQuadFilter m_quarterFilter = {EFilterType::Multiply, x4_mapLightQuarter};
-  CScanLinesFilterEven m_linesFilter = {EFilterType::Multiply};
+  CTexturedQuadFilter m_quarterFilter{EFilterType::Multiply, x4_mapLightQuarter};
+  CScanLinesFilterEven m_linesFilter{EFilterType::Multiply};
 
   union {
     struct {

--- a/Runtime/MP1/CPlayMovie.hpp
+++ b/Runtime/MP1/CPlayMovie.hpp
@@ -32,7 +32,7 @@ private:
   static bool IsResultsScreen(EWhichMovie which);
 
 public:
-  CPlayMovie(EWhichMovie which);
+  explicit CPlayMovie(EWhichMovie which);
 };
 
 } // namespace urde::MP1

--- a/Runtime/MP1/CPlayerVisor.hpp
+++ b/Runtime/MP1/CPlayerVisor.hpp
@@ -82,7 +82,7 @@ class CPlayerVisor {
   void BeginTransitionOut();
 
 public:
-  CPlayerVisor(CStateManager& stateMgr);
+  explicit CPlayerVisor(CStateManager& stateMgr);
   ~CPlayerVisor();
   void Update(float dt, const CStateManager& stateMgr);
   void Draw(const CStateManager& stateMgr, const CTargetingManager* tgtManager) const;

--- a/Runtime/MP1/CQuitGameScreen.hpp
+++ b/Runtime/MP1/CQuitGameScreen.hpp
@@ -36,7 +36,7 @@ public:
   EQuitAction Update(float dt);
   void Draw();
   void ProcessUserInput(const CFinalInput& input);
-  CQuitGameScreen(EQuitType type);
+  explicit CQuitGameScreen(EQuitType type);
 };
 
 } // namespace MP1

--- a/Runtime/MP1/CSamusFaceReflection.hpp
+++ b/Runtime/MP1/CSamusFaceReflection.hpp
@@ -19,7 +19,7 @@ class CSamusFaceReflection {
   bool x70_hidden = true;
 
 public:
-  CSamusFaceReflection(CStateManager& stateMgr);
+  explicit CSamusFaceReflection(CStateManager& stateMgr);
   void PreDraw(const CStateManager& stateMgr);
   void Draw(const CStateManager& stateMgr) const;
   void Update(float dt, const CStateManager& stateMgr, CRandom16& rand);

--- a/Runtime/MP1/CSamusHud.hpp
+++ b/Runtime/MP1/CSamusHud.hpp
@@ -173,7 +173,7 @@ class CSamusHud {
   rstl::reserved_vector<SProfileInfo, 15> x7ac_;
 
   CColoredQuadFilter m_energyDrainFilter;
-  CCookieCutterDepthRandomStaticFilter m_cookieCutterStatic = {EFilterType::NoColor};
+  CCookieCutterDepthRandomStaticFilter m_cookieCutterStatic{EFilterType::NoColor};
 
   static CSamusHud* g_SamusHud;
   static rstl::reserved_vector<bool, 4> BuildPlayerHasVisors(const CStateManager& mgr);
@@ -211,7 +211,7 @@ class CSamusHud {
   static EHudState GetDesiredHudState(const CStateManager& mgr);
 
 public:
-  CSamusHud(CStateManager& stateMgr);
+  explicit CSamusHud(CStateManager& stateMgr);
   ~CSamusHud();
   void Update(float dt, const CStateManager& mgr, CInGameGuiManager::EHelmetVisMode helmetVis, bool hudVis,
               bool targetingManager);

--- a/Runtime/MP1/CSaveGameScreen.hpp
+++ b/Runtime/MP1/CSaveGameScreen.hpp
@@ -108,7 +108,7 @@ public:
   const CGameState::GameFileStateInfo* GetGameData(int idx) const;
   EUIType GetUIType() const { return x10_uiType; }
   bool IsSavingDisabled() const { return x92_savingDisabled; }
-  CSaveGameScreen(ESaveContext saveCtx, u64 serial);
+  explicit CSaveGameScreen(ESaveContext saveCtx, u64 serial);
 };
 
 } // namespace MP1

--- a/Runtime/MP1/CSlideShow.hpp
+++ b/Runtime/MP1/CSlideShow.hpp
@@ -33,7 +33,7 @@ public:
     zeus::CVector2f x28_canvasSize;
     zeus::CColor x30_mulColor = zeus::skWhite;
 
-    SSlideData(CSlideShow& parent) : x0_parent(parent) { x30_mulColor.a() = 0.f; }
+    explicit SSlideData(CSlideShow& parent) : x0_parent(parent) { x30_mulColor.a() = 0.f; }
 
     void SetTexture(const TLockedToken<CTexture>& tex) { m_texQuad.emplace(EFilterType::Blend, tex); }
     bool IsLoaded() const { return m_texQuad && m_texQuad->GetTex().IsLoaded(); }

--- a/Runtime/MP1/World/CBabygoth.hpp
+++ b/Runtime/MP1/World/CBabygoth.hpp
@@ -45,7 +45,7 @@ struct CBabygothData {
   CAssetId x174_flamePlayerIceTxtr;
 
 public:
-  CBabygothData(CInputStream&);
+  explicit CBabygothData(CInputStream&);
   const CDamageInfo& GetFireballDamage() const { return xc_fireballDamage; }
   CAssetId GetFireballResID() const { return x8_fireballWeapon; }
   float GetFireballAttackVariance() const { return x4_fireballAttackTimeVariance; }

--- a/Runtime/MP1/World/CChozoGhost.hpp
+++ b/Runtime/MP1/World/CChozoGhost.hpp
@@ -25,7 +25,7 @@ public:
     u32 x1c_numBolts;
 
   public:
-    CBehaveChance(CInputStream&);
+    explicit CBehaveChance(CInputStream&);
 
     EBehaveType GetBehave(EBehaveType type, CStateManager& mgr) const;
     float GetLurk() const { return x4_lurk; }

--- a/Runtime/MP1/World/CFlaahgra.hpp
+++ b/Runtime/MP1/World/CFlaahgra.hpp
@@ -48,7 +48,7 @@ class CFlaahgraData {
 
 public:
   static constexpr u32 GetNumProperties() { return 23; }
-  CFlaahgraData(CInputStream&);
+  explicit CFlaahgraData(CInputStream&);
 
   const CAnimationParameters& GetAnimationParameters() const { return x14c_animationParameters; }
 };

--- a/Runtime/MP1/World/CFlyingPirate.cpp
+++ b/Runtime/MP1/World/CFlyingPirate.cpp
@@ -337,8 +337,8 @@ CFlyingPirate::CFlyingPirate(TUniqueId uid, std::string_view name, const CEntity
   x7e0_gunSegId = animData->GetLocatorSegId("L_gun_LCTR"sv);
   x864_missileSegments.push_back(animData->GetLocatorSegId("L_Missile_LCTR"sv));
   x864_missileSegments.push_back(animData->GetLocatorSegId("R_Missile_LCTR"sv));
-  x850_height =
-      modelData->GetScale().x() * GetAnimationDistance({3, CPASAnimParm::FromEnum(3), CPASAnimParm::FromEnum(1)});
+  x850_height = modelData->GetScale().x() *
+                GetAnimationDistance(CPASAnimParmData{3, CPASAnimParm::FromEnum(3), CPASAnimParm::FromEnum(1)});
   if (x568_data.xd8_particleGen1.IsValid() && x568_data.xdc_particleGen2.IsValid() &&
       x568_data.xe0_particleGen3.IsValid()) {
     x65c_particleGenDescs.push_back(g_SimplePool->GetObj({SBIG('PART'), x568_data.xd8_particleGen1}));
@@ -763,7 +763,7 @@ void CFlyingPirate::FireProjectile(CStateManager& mgr, float dt) {
   }
   if (projectileFired) {
     const std::pair<float, s32>& anim = x450_bodyController->GetPASDatabase().FindBestAnimation(
-        {24, CPASAnimParm::FromEnum(2)}, *mgr.GetActiveRandom(), -1);
+        CPASAnimParmData{24, CPASAnimParm::FromEnum(2)}, *mgr.GetActiveRandom(), -1);
     if (anim.first > 0.f) {
       GetModelData()->GetAnimationData()->AddAdditiveAnimation(anim.second, 1.f, false, true);
     }

--- a/Runtime/MP1/World/CMagdolite.hpp
+++ b/Runtime/MP1/World/CMagdolite.hpp
@@ -16,7 +16,7 @@ public:
     float x1c_;
 
   public:
-    CMagdoliteData(CInputStream&);
+    explicit CMagdoliteData(CInputStream&);
   };
 
 private:

--- a/Runtime/MP1/World/CMetroid.hpp
+++ b/Runtime/MP1/World/CMetroid.hpp
@@ -25,7 +25,7 @@ class CMetroidData {
   bool x128_24_ : 1;
 
 public:
-  CMetroidData(CInputStream& in);
+  explicit CMetroidData(CInputStream& in);
   static u32 GetNumProperties() { return skNumProperties; }
 };
 

--- a/Runtime/MP1/World/CMetroidBeta.hpp
+++ b/Runtime/MP1/World/CMetroidBeta.hpp
@@ -38,7 +38,7 @@ class CMetroidBetaData {
   bool x108_24_ : 1;
 
 public:
-  CMetroidBetaData(CInputStream&);
+  explicit CMetroidBetaData(CInputStream&);
 };
 class CMetroidBeta : public CPatterned {
   s32 x568_progState = -1;

--- a/Runtime/MP1/World/CSpacePirate.cpp
+++ b/Runtime/MP1/World/CSpacePirate.cpp
@@ -618,10 +618,11 @@ bool CSpacePirate::FireProjectile(float dt, CStateManager& mgr) {
     }
   }
   if (ret) {
-    auto bestAnim = x450_bodyController->GetPASDatabase().FindBestAnimation({24, CPASAnimParm::FromEnum(2)},
-                                                                            *mgr.GetActiveRandom(), -1);
-    if (bestAnim.first > 0.f)
+    const auto bestAnim = x450_bodyController->GetPASDatabase().FindBestAnimation(
+        CPASAnimParmData{24, CPASAnimParm::FromEnum(2)}, *mgr.GetActiveRandom(), -1);
+    if (bestAnim.first > 0.f) {
       x64_modelData->GetAnimationData()->AddAdditiveAnimation(bestAnim.second, 1.f, false, true);
+    }
     CSfxManager::AddEmitter(x568_pirateData.x48_Sound_Projectile, GetTranslation(), zeus::skZero3f, true, false, 0x7f,
                             kInvalidAreaId);
   }
@@ -1876,8 +1877,8 @@ void CSpacePirate::Taunt(CStateManager& mgr, EStateMsg msg, float dt) {
       if (!x635_27_shadowPirate) {
         bool withOtherPirate = true;
         if (x634_27_melee) {
-          auto bestAnim = x450_bodyController->GetPASDatabase().FindBestAnimation({16, CPASAnimParm::FromEnum(2)},
-                                                                                  *mgr.GetActiveRandom(), -1);
+          const auto bestAnim = x450_bodyController->GetPASDatabase().FindBestAnimation(
+              CPASAnimParmData{16, CPASAnimParm::FromEnum(2)}, *mgr.GetActiveRandom(), -1);
           if (bestAnim.first > 0.f) {
             withOtherPirate = false;
             x760_taunt = pas::ETauntType::Two;

--- a/Runtime/RetroTypes.hpp
+++ b/Runtime/RetroTypes.hpp
@@ -55,7 +55,7 @@ struct SObjectTag {
   [[nodiscard]] constexpr bool operator<(const SObjectTag& other) const noexcept { return id < other.id; }
   constexpr SObjectTag() noexcept = default;
   constexpr SObjectTag(FourCC tp, CAssetId rid) noexcept : type(tp), id(rid) {}
-  SObjectTag(CInputStream& in) {
+  explicit SObjectTag(CInputStream& in) {
     in.readBytesToBuf(&type, 4);
     id = CAssetId(in);
   }

--- a/Runtime/Weapon/CPhazonBeam.hpp
+++ b/Runtime/Weapon/CPhazonBeam.hpp
@@ -22,8 +22,8 @@ class CPhazonBeam final : public CGunWeapon {
   bool x274_26_veinsAlphaActive : 1;
   bool x274_27_phazonVeinsIdx : 1;
   float x278_fireTime = 1.f / 3.f;
-  mutable CAABoxShader m_aaboxShaderScale = {true};
-  mutable CAABoxShader m_aaboxShaderTranslate = {true};
+  mutable CAABoxShader m_aaboxShaderScale{true};
+  mutable CAABoxShader m_aaboxShaderTranslate{true};
   void ReInitVariables();
   void DrawClipScaleCube() const;
   void DrawClipTranslateCube() const;

--- a/Runtime/Weapon/CPlayerGun.hpp
+++ b/Runtime/Weapon/CPlayerGun.hpp
@@ -198,7 +198,7 @@ private:
   float x664_ = 0.f;
   float x668_aimVerticalSpeed;
   float x66c_aimHorizontalSpeed;
-  std::pair<u16, CSfxHandle> x670_animSfx = {0xffff, {}};
+  std::pair<u16, CSfxHandle> x670_animSfx{0xffff, {}};
   CGunMorph x678_morph;
   CMotionState x6a0_motionState;
   zeus::CAABox x6c8_hologramClipCube;
@@ -266,9 +266,9 @@ private:
     u32 _dummy = 0;
   };
 
-  mutable CTexturedQuadFilter m_screenQuad = {EFilterType::Blend, CGraphics::g_SpareTexture.get(),
-                                              CTexturedQuadFilter::ZTest::GEqualZWrite};
-  mutable CAABoxShader m_aaboxShader = {true};
+  mutable CTexturedQuadFilter m_screenQuad{EFilterType::Blend, CGraphics::g_SpareTexture.get(),
+                                           CTexturedQuadFilter::ZTest::GEqualZWrite};
+  mutable CAABoxShader m_aaboxShader{true};
 
   void InitBeamData();
   void InitBombData();

--- a/Runtime/World/CGameArea.hpp
+++ b/Runtime/World/CGameArea.hpp
@@ -199,7 +199,7 @@ public:
     u32 x8_collisionSize = 0;
     std::optional<CAreaRenderOctTree> xc_octTree;
     std::vector<CMetroidModelInstance> x4c_insts;
-    SShader m_materialSet = {0};
+    SShader m_materialSet{0};
     // std::unique_ptr<from unknown, pointless MREA section> x5c_;
     std::vector<CWorldLight> x60_lightsA;
     std::vector<CLight> x70_gfxLightsA;

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -185,7 +185,7 @@ constexpr std::array<std::pair<CPlayerState::EItemType, ControlMapper::ECommands
 }};
 
 CModelData MakePlayerAnimRes(CAssetId resId, const zeus::CVector3f& scale) {
-  return {CAnimRes(resId, 0, scale, 0, true), 1};
+  return CModelData{CAnimRes(resId, 0, scale, 0, true), 1};
 }
 
 uint32_t GetOrbitScreenBoxHalfExtentXScaled(int zone) {

--- a/Runtime/World/CWorldTransManager.cpp
+++ b/Runtime/World/CWorldTransManager.cpp
@@ -349,7 +349,7 @@ void CWorldTransManager::TouchModels() {
 
   if (x4_modelData->x68_beamModelData.IsNull() && x4_modelData->x14c_beamModel.IsLoaded() &&
       x4_modelData->x14c_beamModel.GetObj()) {
-    x4_modelData->x68_beamModelData = {
+    x4_modelData->x68_beamModelData = CModelData{
         CStaticRes(x4_modelData->x14c_beamModel.GetObjectTag()->id, x4_modelData->x0_samusRes.GetScale()), 2};
   }
 
@@ -358,7 +358,7 @@ void CWorldTransManager::TouchModels() {
       x4_modelData->x164_suitSkin.GetObj()) {
     CAnimRes animRes(x4_modelData->x0_samusRes.GetId(), GetSuitCharIdx(), x4_modelData->x0_samusRes.GetScale(),
                      x4_modelData->x0_samusRes.GetDefaultAnim(), true);
-    x4_modelData->x1c_samusModelData = {animRes, 2};
+    x4_modelData->x1c_samusModelData = CModelData{animRes, 2};
 
     CAnimPlaybackParms aData(animRes.GetDefaultAnim(), -1, 1.f, true);
     x4_modelData->x1c_samusModelData.GetAnimationData()->SetAnimation(aData, false);
@@ -408,22 +408,23 @@ void CWorldTransManager::EnableTransition(const CAnimRes& samusRes, CAssetId pla
   x4_modelData->x164_suitSkin = g_SimplePool->GetObj(SObjectTag{FOURCC('CSKR'), info.GetSkinRulesId()});
 
   if (platRes.IsValid()) {
-    x4_modelData->xb4_platformModelData = {CStaticRes(platRes, platScale), 2};
+    x4_modelData->xb4_platformModelData = CModelData{CStaticRes(platRes, platScale), 2};
     x4_modelData->xb4_platformModelData.Touch(CModelData::EWhichModel::Normal, 0);
   }
 
   if (bgRes.IsValid()) {
-    CStaticRes bg(bgRes, bgScale);
-    x4_modelData->x100_bgModelData[0] = bg;
+    const CStaticRes bg(bgRes, bgScale);
+    x4_modelData->x100_bgModelData[0] = CModelData{bg};
     x4_modelData->x100_bgModelData[0].Touch(CModelData::EWhichModel::Normal, 0);
-    x4_modelData->x100_bgModelData[1] = bg;
+    x4_modelData->x100_bgModelData[1] = CModelData{bg};
     x4_modelData->x100_bgModelData[1].Touch(CModelData::EWhichModel::Normal, 0);
-    x4_modelData->x100_bgModelData[2] = bg;
+    x4_modelData->x100_bgModelData[2] = CModelData{bg};
     x4_modelData->x100_bgModelData[2].Touch(CModelData::EWhichModel::Normal, 0);
-    zeus::CAABox bounds = x4_modelData->x100_bgModelData[0].GetBounds();
+    const zeus::CAABox bounds = x4_modelData->x100_bgModelData[0].GetBounds();
     x1c_bgHeight = (bounds.max.z() - bounds.min.z()) * bgScale.z();
-  } else
+  } else {
     x1c_bgHeight = 0.f;
+  }
 
   StartTransition();
   TouchModels();

--- a/Runtime/World/CWorldTransManager.hpp
+++ b/Runtime/World/CWorldTransManager.hpp
@@ -80,9 +80,9 @@ private:
     u8 dummy = 0;
   };
 
-  CColoredQuadFilter m_fadeToBlack = {EFilterType::Blend};
-  CTexturedQuadFilter m_dissolve = {EFilterType::Blend, CGraphics::g_SpareTexture.get()};
-  CWideScreenFilter m_widescreen = {EFilterType::Blend};
+  CColoredQuadFilter m_fadeToBlack{EFilterType::Blend};
+  CTexturedQuadFilter m_dissolve{EFilterType::Blend, CGraphics::g_SpareTexture.get()};
+  CWideScreenFilter m_widescreen{EFilterType::Blend};
   CCameraBlurFilter m_camblur;
 
   boo::ObjToken<boo::ITextureCubeR> m_reflectionCube[2];

--- a/Runtime/World/ScriptLoader.cpp
+++ b/Runtime/World/ScriptLoader.cpp
@@ -434,10 +434,12 @@ CEntity* ScriptLoader::LoadActor(CStateManager& mgr, CInputStream& in, int propC
     list.Add(EMaterialTypes::CameraPassthrough);
 
   CModelData data;
-  if (animType == SBIG('ANCS'))
-    data = CAnimRes(aParms.GetACSFile(), aParms.GetCharacter(), head.x40_scale, aParms.GetInitialAnimation(), false);
-  else
-    data = CStaticRes(staticId, head.x40_scale);
+  if (animType == SBIG('ANCS')) {
+    data = CModelData{
+        CAnimRes(aParms.GetACSFile(), aParms.GetCharacter(), head.x40_scale, aParms.GetInitialAnimation(), false)};
+  } else {
+    data = CModelData{CStaticRes(staticId, head.x40_scale)};
+  }
 
   if ((collisionExtent.x() < 0.f || collisionExtent.y() < 0.f || collisionExtent.z() < 0.f) || collisionExtent.isZero())
     aabb = data.GetBounds(head.x10_transform.getRotation());
@@ -494,7 +496,7 @@ CEntity* ScriptLoader::LoadDoor(CStateManager& mgr, CInputStream& in, int propCo
   if (!g_ResFactory->GetResourceTypeById(aParms.GetACSFile()).IsValid())
     return nullptr;
 
-  CModelData mData = CAnimRes(aParms.GetACSFile(), aParms.GetCharacter(), head.x40_scale, 0, false);
+  CModelData mData{CAnimRes(aParms.GetACSFile(), aParms.GetCharacter(), head.x40_scale, 0, false)};
   if (collisionExtent.isZero())
     aabb = mData.GetBounds(head.x10_transform.getRotation());
 
@@ -654,10 +656,12 @@ CEntity* ScriptLoader::LoadPlatform(CStateManager& mgr, CInputStream& in, int pr
   }
 
   CModelData data;
-  if (animType == SBIG('ANCS'))
-    data = CAnimRes(aParms.GetACSFile(), aParms.GetCharacter(), head.x40_scale, aParms.GetInitialAnimation(), true);
-  else
-    data = CStaticRes(staticId, head.x40_scale);
+  if (animType == SBIG('ANCS')) {
+    data = CModelData{
+        CAnimRes(aParms.GetACSFile(), aParms.GetCharacter(), head.x40_scale, aParms.GetInitialAnimation(), true)};
+  } else {
+    data = CModelData{CStaticRes(staticId, head.x40_scale)};
+  }
 
   if (extent.isZero())
     aabb = data.GetBounds(head.x10_transform.getRotation());
@@ -813,9 +817,9 @@ CEntity* ScriptLoader::LoadNewIntroBoss(CStateManager& mgr, CInputStream& in, in
 
   CAnimRes res(aParms.GetACSFile(), aParms.GetCharacter(), head.x40_scale, aParms.GetInitialAnimation(), true);
 
-  return new MP1::CNewIntroBoss(mgr.AllocateUniqueId(), head.x0_name, info, head.x10_transform, res, pInfo, actParms,
-                                minTurnAngle, projectile, dInfo, beamContactFxId, beamPulseFxId, beamTextureId,
-                                beamGlowTextureId);
+  return new MP1::CNewIntroBoss(mgr.AllocateUniqueId(), head.x0_name, info, head.x10_transform, CModelData{res}, pInfo,
+                                actParms, minTurnAngle, projectile, dInfo, beamContactFxId, beamPulseFxId,
+                                beamTextureId, beamGlowTextureId);
 }
 
 CEntity* ScriptLoader::LoadSpawnPoint(CStateManager& mgr, CInputStream& in, int propCount, const CEntityInfo& info) {
@@ -921,14 +925,16 @@ CEntity* ScriptLoader::LoadPickup(CStateManager& mgr, CInputStream& in, int prop
 
   CModelData data;
 
-  if (acsType == SBIG('ANCS'))
-    data = CAnimRes(animParms.GetACSFile(), animParms.GetCharacter(), head.x40_scale, animParms.GetInitialAnimation(),
-                    true);
-  else
-    data = CStaticRes(staticModel, head.x40_scale);
+  if (acsType == SBIG('ANCS')) {
+    data = CModelData{CAnimRes(animParms.GetACSFile(), animParms.GetCharacter(), head.x40_scale,
+                               animParms.GetInitialAnimation(), true)};
+  } else {
+    data = CModelData{CStaticRes(staticModel, head.x40_scale)};
+  }
 
-  if (extent.isZero())
+  if (extent.isZero()) {
     aabb = data.GetBounds(head.x10_transform.getRotation());
+  }
 
   return new CScriptPickup(mgr.AllocateUniqueId(), head.x0_name, info, head.x10_transform, std::move(data), actorParms,
                            aabb, itemType, amount, capacity, pickupEffect, possibility, lifeTime, fadeInTime,
@@ -1007,9 +1013,9 @@ CEntity* ScriptLoader::LoadBeetle(CStateManager& mgr, CInputStream& in, int prop
   const CAnimationParameters& animParams = pInfo.GetAnimationParameters();
   CAnimRes animRes(animParams.GetACSFile(), animParams.GetCharacter(), scale, animParams.GetInitialAnimation(), true);
 
-  return new MP1::CBeetle(mgr.AllocateUniqueId(), name, info, xfrm, animRes, pInfo, flavor, entranceType, touchDamage,
-                          platingVuln, tailAimReference, initialAttackDelay, retreatTime, unused, tailVuln, aParams,
-                          tailRes);
+  return new MP1::CBeetle(mgr.AllocateUniqueId(), name, info, xfrm, CModelData{animRes}, pInfo, flavor, entranceType,
+                          touchDamage, platingVuln, tailAimReference, initialAttackDelay, retreatTime, unused, tailVuln,
+                          aParams, tailRes);
 }
 
 CEntity* ScriptLoader::LoadHUDMemo(CStateManager& mgr, CInputStream& in, int propCount, const CEntityInfo& info) {
@@ -1128,28 +1134,30 @@ CEntity* ScriptLoader::LoadDebris(CStateManager& mgr, CInputStream& in, int prop
   if (!EnsurePropertyCount(propCount, 18, "Debris"))
     return nullptr;
 
-  SScaledActorHead head = LoadScaledActorHead(in, mgr);
-  float zImpulse = in.readFloatBig();
-  zeus::CVector3f velocity = zeus::CVector3f::ReadBig(in);
+  const SScaledActorHead head = LoadScaledActorHead(in, mgr);
+  const float zImpulse = in.readFloatBig();
+  const zeus::CVector3f velocity = zeus::CVector3f::ReadBig(in);
   zeus::CColor endsColor;
   endsColor.readRGBABig(in);
-  float mass = in.readFloatBig();
-  float restitution = in.readFloatBig();
-  float duration = in.readFloatBig();
-  CScriptDebris::EScaleType scaleType = CScriptDebris::EScaleType(in.readUint32Big());
-  bool randomAngImpulse = in.readBool();
-  CAssetId model = in.readUint32Big();
-  CActorParameters aParams = LoadActorParameters(in);
-  CAssetId particleId = in.readUint32Big();
-  zeus::CVector3f particleScale = zeus::CVector3f::ReadBig(in);
-  bool b1 = in.readBool();
-  bool active = in.readBool();
+  const float mass = in.readFloatBig();
+  const float restitution = in.readFloatBig();
+  const float duration = in.readFloatBig();
+  const auto scaleType = CScriptDebris::EScaleType(in.readUint32Big());
+  const bool randomAngImpulse = in.readBool();
+  const CAssetId model = in.readUint32Big();
+  const CActorParameters aParams = LoadActorParameters(in);
+  const CAssetId particleId = in.readUint32Big();
+  const zeus::CVector3f particleScale = zeus::CVector3f::ReadBig(in);
+  const bool b1 = in.readBool();
+  const bool active = in.readBool();
 
-  if (!g_ResFactory->GetResourceTypeById(model).IsValid())
+  if (!g_ResFactory->GetResourceTypeById(model).IsValid()) {
     return nullptr;
+  }
+
   return new CScriptDebris(mgr.AllocateUniqueId(), head.x0_name, info, head.x10_transform,
-                           CStaticRes(model, head.x40_scale), aParams, particleId, particleScale, zImpulse, velocity,
-                           endsColor, mass, restitution, duration, scaleType, b1, randomAngImpulse, active);
+                           CModelData{CStaticRes(model, head.x40_scale)}, aParams, particleId, particleScale, zImpulse,
+                           velocity, endsColor, mass, restitution, duration, scaleType, b1, randomAngImpulse, active);
 }
 
 CEntity* ScriptLoader::LoadCameraShaker(CStateManager& mgr, CInputStream& in, int propCount, const CEntityInfo& info) {


### PR DESCRIPTION
Prevents error-prone implicit conversions where applicable.

This targets the regular RuntimeCommon target this time around.

Opening this to get CI run on it.