### PR TITLE
CAutoMapper: Eliminate usages of const_cast

### DIFF
--- a/Runtime/AutoMapper/CAutoMapper.cpp
+++ b/Runtime/AutoMapper/CAutoMapper.cpp
@@ -158,7 +158,7 @@ bool CAutoMapper::CanLeaveMapScreenInternal(const CStateManager& mgr) const {
   return false;
 }
 
-void CAutoMapper::LeaveMapScreen(const CStateManager& mgr) {
+void CAutoMapper::LeaveMapScreen(CStateManager& mgr) {
   if (x1c0_nextState == EAutoMapperState::MapScreenUniverse) {
     xa8_renderStates[1].x2c_drawDepth1 = GetMapAreaMiniMapDrawDepth();
     xa8_renderStates[1].x30_drawDepth2 = GetMapAreaMiniMapDrawDepth();
@@ -180,9 +180,9 @@ void CAutoMapper::LeaveMapScreen(const CStateManager& mgr) {
   }
 }
 
-void CAutoMapper::SetupMiniMapWorld(const CStateManager& mgr) {
-  const CWorld& wld = *mgr.GetWorld();
-  const_cast<CMapWorld*>(wld.GetMapWorld())->SetWhichMapAreasLoaded(wld, wld.GetCurrentAreaId(), 3);
+void CAutoMapper::SetupMiniMapWorld(CStateManager& mgr) {
+  CWorld& wld = *mgr.GetWorld();
+  wld.GetMapWorld()->SetWhichMapAreasLoaded(wld, wld.GetCurrentAreaId(), 3);
   x328_ = 3;
 }
 
@@ -372,7 +372,7 @@ void CAutoMapper::BeginMapperStateTransition(EAutoMapperState state, CStateManag
   }
 }
 
-void CAutoMapper::CompleteMapperStateTransition(const CStateManager& mgr) {
+void CAutoMapper::CompleteMapperStateTransition(CStateManager& mgr) {
   if (x1bc_state == EAutoMapperState::MapScreenUniverse)
     TransformRenderStatesUniverseToWorld();
 
@@ -1093,7 +1093,7 @@ void CAutoMapper::ProcessControllerInput(const CFinalInput& input, CStateManager
   }
 }
 
-void CAutoMapper::Update(float dt, const CStateManager& mgr) {
+void CAutoMapper::Update(float dt, CStateManager& mgr) {
   if (x1bc_state != EAutoMapperState::MiniMap && x1c0_nextState != EAutoMapperState::MiniMap) {
     x1d8_flashTimer = std::fmod(x1d8_flashTimer + dt, 0.75f);
     x1dc_playerFlashPulse = x1d8_flashTimer < 0.375f ? x1d8_flashTimer / 0.375f : (0.75f - x1d8_flashTimer) / 0.375f;
@@ -1289,7 +1289,7 @@ void CAutoMapper::Update(float dt, const CStateManager& mgr) {
       wld->ICheckWorldComplete();
 }
 
-void CAutoMapper::Draw(const CStateManager& mgr, const zeus::CTransform& xf, float alpha) const {
+void CAutoMapper::Draw(const CStateManager& mgr, const zeus::CTransform& xf, float alpha) {
   SCOPED_GRAPHICS_DEBUG_GROUP("CAutoMapper::Draw", zeus::skPurple);
   alpha *= g_GameState->GameOptions().GetHUDAlpha() / 255.f;
   // Blend mode alpha
@@ -1447,7 +1447,7 @@ void CAutoMapper::Draw(const CStateManager& mgr, const zeus::CTransform& xf, flo
     if (IsInMapperState(EAutoMapperState::MapScreen)) {
       CAssetId wldMlvl = x24_world->IGetWorldAssetId();
       const CMapWorld* mw = x24_world->IGetMapWorld();
-      std::vector<CTexturedQuadFilter>& hintBeaconFilters = const_cast<CAutoMapper&>(*this).m_hintBeaconFilters;
+      std::vector<CTexturedQuadFilter>& hintBeaconFilters = m_hintBeaconFilters;
       if (hintBeaconFilters.size() < x1f8_hintLocations.size()) {
         hintBeaconFilters.reserve(x1f8_hintLocations.size());
         for (u32 i = hintBeaconFilters.size(); i < x1f8_hintLocations.size(); ++i)
@@ -1607,8 +1607,8 @@ CAssetId CAutoMapper::GetAreaHintDescriptionString(CAssetId mreaId) {
 void CAutoMapper::OnNewInGameGuiState(EInGameGuiState state, CStateManager& mgr) {
   if (state == EInGameGuiState::MapScreen) {
     MP1::CMain::EnsureWorldPaksReady();
-    const CWorld& wld = *mgr.GetWorld();
-    const_cast<CMapWorld*>(wld.GetMapWorld())->SetWhichMapAreasLoaded(wld, 0, 9999);
+    CWorld& wld = *mgr.GetWorld();
+    wld.GetMapWorld()->SetWhichMapAreasLoaded(wld, 0, 9999);
     SetupHintNavigation();
     BeginMapperStateTransition(EAutoMapperState::MapScreen, mgr);
     x28_frmeMapScreen = g_SimplePool->GetObj("FRME_MapScreen");

--- a/Runtime/AutoMapper/CAutoMapper.hpp
+++ b/Runtime/AutoMapper/CAutoMapper.hpp
@@ -194,8 +194,8 @@ private:
   }
   bool NotHintNavigating() const;
   bool CanLeaveMapScreenInternal(const CStateManager& mgr) const;
-  void LeaveMapScreen(const CStateManager& mgr);
-  void SetupMiniMapWorld(const CStateManager& mgr);
+  void LeaveMapScreen(CStateManager& mgr);
+  void SetupMiniMapWorld(CStateManager& mgr);
   bool HasCurrentMapUniverseWorld() const;
   bool CheckDummyWorldLoad(CStateManager& mgr);
   void UpdateHintNavigation(float dt, CStateManager& mgr);
@@ -238,11 +238,11 @@ public:
   bool IsInPlayerControlState() const {
     return IsInMapperState(EAutoMapperState::MapScreen) || IsInMapperState(EAutoMapperState::MapScreenUniverse);
   }
-  void Update(float dt, const CStateManager& mgr);
-  void Draw(const CStateManager& mgr, const zeus::CTransform& xf, float alpha) const;
+  void Update(float dt, CStateManager& mgr);
+  void Draw(const CStateManager& mgr, const zeus::CTransform& xf, float alpha);
   float GetTimeIntoInterpolation() const { return x1c8_interpTime; }
   void BeginMapperStateTransition(EAutoMapperState state, CStateManager& mgr);
-  void CompleteMapperStateTransition(const CStateManager& mgr);
+  void CompleteMapperStateTransition(CStateManager& mgr);
   void ResetInterpolationTimer(float duration);
   SAutoMapperRenderState BuildMiniMapWorldRenderState(const CStateManager& stateMgr, const zeus::CQuaternion& rot,
                                                       TAreaId area) const;

--- a/Runtime/AutoMapper/CMapArea.cpp
+++ b/Runtime/AutoMapper/CMapArea.cpp
@@ -257,15 +257,16 @@ void CMapArea::CMapAreaSurface::PostConstruct(const u8* buf, std::vector<u32>& i
 }
 
 void CMapArea::CMapAreaSurface::Draw(const zeus::CVector3f* verts, const zeus::CColor& surfColor,
-                                     const zeus::CColor& lineColor, float lineWidth, size_t instIdx) const {
+                                     const zeus::CColor& lineColor, float lineWidth, size_t instIdx) {
   if (instIdx >= m_instances.size()) {
     return;
   }
 
-  Instance& instance = const_cast<Instance&>(m_instances[instIdx]);
+  Instance& instance = m_instances[instIdx];
 
-  if (surfColor.a())
+  if (surfColor.a()) {
     instance.m_surfacePrims.draw(surfColor, m_primStart, m_primCount);
+  }
 
   if (lineColor.a()) {
     bool draw2 = lineWidth > 1.f;

--- a/Runtime/AutoMapper/CMapArea.hpp
+++ b/Runtime/AutoMapper/CMapArea.hpp
@@ -42,7 +42,7 @@ public:
     CMapAreaSurface(CMapAreaSurface&&) = default;
     void PostConstruct(const u8* buf, std::vector<u32>& index);
     void Draw(const zeus::CVector3f* verts, const zeus::CColor& surfColor, const zeus::CColor& lineColor,
-              float lineWidth, size_t instIdx = 0) const;
+              float lineWidth, size_t instIdx = 0);
     const zeus::CVector3f& GetNormal() const { return x0_normal; }
     const zeus::CVector3f& GetCenterPosition() const { return xc_centroid; }
   };
@@ -74,7 +74,9 @@ public:
   bool GetIsVisibleToAutoMapper(bool worldVis, bool areaVis) const;
   zeus::CVector3f GetAreaCenterPoint() const { return x10_box.center(); }
   const zeus::CAABox& GetBoundingBox() const { return x10_box; }
+  CMappableObject& GetMappableObject(int idx) { return m_mappableObjects[idx]; }
   const CMappableObject& GetMappableObject(int idx) const { return m_mappableObjects[idx]; }
+  CMapAreaSurface& GetSurface(int idx) { return m_surfaces[idx]; }
   const CMapAreaSurface& GetSurface(int idx) const { return m_surfaces[idx]; }
   u32 GetNumMappableObjects() const { return m_mappableObjects.size(); }
   u32 GetNumSurfaces() const { return m_surfaces.size(); }

--- a/Runtime/AutoMapper/CMapUniverse.cpp
+++ b/Runtime/AutoMapper/CMapUniverse.cpp
@@ -38,9 +38,10 @@ CMapUniverse::CMapWorldData::CMapWorldData(CInputStream& in, u32 version)
   x64_centerPoint *= zeus::CVector3f(1.0f / float(x44_hexagonXfs.size()));
 }
 
-void CMapUniverse::Draw(const CMapUniverseDrawParms& parms, const zeus::CVector3f&, float, float) const {
-  if (!x4_hexagonToken.IsLoaded())
+void CMapUniverse::Draw(const CMapUniverseDrawParms& parms, const zeus::CVector3f&, float, float) {
+  if (!x4_hexagonToken.IsLoaded()) {
     return;
+  }
   SCOPED_GRAPHICS_DEBUG_GROUP("CMapUniverse::Draw", zeus::skBlue);
 
   u32 totalSurfaceCount = 0;
@@ -100,7 +101,7 @@ void CMapUniverse::Draw(const CMapUniverseDrawParms& parms, const zeus::CVector3
 
     zeus::CTransform hexXf = mwData.GetMapAreaData(info.GetAreaIndex());
     hexXf.orthonormalize();
-    const CMapArea::CMapAreaSurface& surf = x4_hexagonToken->GetSurface(info.GetObjectIndex());
+    CMapArea::CMapAreaSurface& surf = x4_hexagonToken->GetSurface(info.GetObjectIndex());
     zeus::CColor color(std::max(0.f, (-parms.GetCameraTransform().basis[1]).dot(hexXf.rotate(surf.GetNormal()))) *
                            g_tweakAutoMapper->GetMapSurfaceNormColorLinear() +
                        g_tweakAutoMapper->GetMapSurfaceNormColorConstant());

--- a/Runtime/AutoMapper/CMapUniverse.hpp
+++ b/Runtime/AutoMapper/CMapUniverse.hpp
@@ -116,7 +116,7 @@ public:
   u32 GetNumMapWorldDatas() const { return x10_worldDatas.size(); }
   float GetMapUniverseRadius() const { return x2c_universeRadius; }
   const zeus::CVector3f& GetMapUniverseCenterPoint() const { return x20_universeCenter; }
-  void Draw(const CMapUniverseDrawParms&, const zeus::CVector3f&, float, float) const;
+  void Draw(const CMapUniverseDrawParms&, const zeus::CVector3f&, float, float);
   std::vector<CMapWorldData>::const_iterator begin() const { return x10_worldDatas.cbegin(); }
   std::vector<CMapWorldData>::const_iterator end() const { return x10_worldDatas.cend(); }
 };

--- a/Runtime/AutoMapper/CMapWorld.hpp
+++ b/Runtime/AutoMapper/CMapWorld.hpp
@@ -71,6 +71,7 @@ public:
     void Lock() { x0_area.Lock(); }
     void Unlock() { x0_area.Unlock(); }
     bool IsLoaded() const { return x0_area.IsLoaded(); }
+    CMapArea* GetMapArea() { return x0_area.GetObj(); }
     const CMapArea* GetMapArea() const { return x0_area.GetObj(); }
     CMapAreaData* GetNextMapAreaData() { return x14_next; }
     const CMapAreaData* GetNextMapAreaData() const { return x14_next; }
@@ -144,10 +145,11 @@ private:
 public:
   explicit CMapWorld(CInputStream& in);
   u32 GetNumAreas() const { return x0_areas.size(); }
+  CMapArea* GetMapArea(int aid) { return x0_areas[aid].GetMapArea(); }
   const CMapArea* GetMapArea(int aid) const { return x0_areas[aid].GetMapArea(); }
   bool IsMapAreaInBFSInfoVector(const CMapAreaData* area, const std::vector<CMapAreaBFSInfo>& vec) const;
   void SetWhichMapAreasLoaded(const IWorld& wld, int start, int count);
-  bool IsMapAreasStreaming() const;
+  bool IsMapAreasStreaming();
   void MoveMapAreaToList(CMapAreaData* data, EMapAreaList list);
   s32 GetCurrentMapAreaDepth(const IWorld& wld, TAreaId aid);
   std::vector<int> GetVisibleAreas(const IWorld& wld, const CMapWorldInfo& mwInfo) const;
@@ -156,7 +158,7 @@ public:
              std::vector<CMapAreaBFSInfo>& bfsInfos);
   bool IsMapAreaValid(const IWorld& wld, int areaIdx, bool checkLoad) const;
   void DrawAreas(const CMapWorldDrawParms& parms, int selArea, const std::vector<CMapAreaBFSInfo>& bfsInfos,
-                 bool inMapScreen) const;
+                 bool inMapScreen);
   void RecalculateWorldSphere(const CMapWorldInfo& mwInfo, const IWorld& wld);
   zeus::CVector3f ConstrainToWorldVolume(const zeus::CVector3f& point, const zeus::CVector3f& lookVec) const;
   void ClearTraversedFlags();

--- a/Runtime/AutoMapper/CMappableObject.hpp
+++ b/Runtime/AutoMapper/CMappableObject.hpp
@@ -79,8 +79,8 @@ public:
   void PostConstruct(const void*);
   const zeus::CTransform& GetTransform() const { return x10_transform; }
   EMappableObjectType GetType() const { return x0_type; }
-  void Draw(int, const CMapWorldInfo&, float, bool) const;
-  void DrawDoorSurface(int curArea, const CMapWorldInfo& mwInfo, float alpha, int surfIdx, bool needsVtxLoad) const;
+  void Draw(int, const CMapWorldInfo&, float, bool);
+  void DrawDoorSurface(int curArea, const CMapWorldInfo& mwInfo, float alpha, int surfIdx, bool needsVtxLoad);
   zeus::CVector3f BuildSurfaceCenterPoint(int surfIdx) const;
   bool IsDoorConnectedToArea(int idx, const CStateManager&) const;
   bool IsDoorConnectedToVisitedArea(const CStateManager&) const;

--- a/Runtime/MP1/CInGameGuiManager.cpp
+++ b/Runtime/MP1/CInGameGuiManager.cpp
@@ -279,7 +279,7 @@ void CInGameGuiManager::OnNewPauseScreenState(CArchitectureQueue& archQueue) {
   x1bc_prevState = x1c0_nextState;
 }
 
-void CInGameGuiManager::UpdateAutoMapper(float dt, const CStateManager& stateMgr) {
+void CInGameGuiManager::UpdateAutoMapper(float dt, CStateManager& stateMgr) {
   x38_autoMapper->Update(dt, stateMgr);
   zeus::CTransform xf =
       x148_model_automapper->GetParent()->GetWorldTransform() * x144_basewidget_automapper->GetTransform();

--- a/Runtime/MP1/CInGameGuiManager.hpp
+++ b/Runtime/MP1/CInGameGuiManager.hpp
@@ -121,7 +121,7 @@ private:
   void TryReloadAreaTextures();
   bool IsInGameStateNotTransitioning() const;
   bool IsInPausedStateNotTransitioning() const;
-  void UpdateAutoMapper(float dt, const CStateManager& stateMgr);
+  void UpdateAutoMapper(float dt, CStateManager& stateMgr);
   void OnNewPauseScreenState(CArchitectureQueue& archQueue);
   void RefreshHudOptions();
 

--- a/Runtime/World/CScriptDoor.cpp
+++ b/Runtime/World/CScriptDoor.cpp
@@ -314,7 +314,7 @@ CScriptDoor::EDoorOpenCondition CScriptDoor::GetDoorOpenCondition(CStateManager&
   if (connArea == kInvalidAreaId)
     return EDoorOpenCondition::NotReady;
 
-  const CWorld* world = mgr.GetWorld();
+  CWorld* world = mgr.GetWorld();
   const CGameArea* area = world->GetAreaAlways(connArea);
 
   if (!area->IsPostConstructed()) {

--- a/Runtime/World/CWorld.hpp
+++ b/Runtime/World/CWorld.hpp
@@ -177,7 +177,9 @@ public:
   bool DoesAreaExist(TAreaId area) const;
   const std::vector<std::unique_ptr<CGameArea>>& GetGameAreas() const { return x18_areas; }
 
+  CMapWorld* GetMapWorld() { return x28_mapWorld.GetObj(); }
   const CMapWorld* GetMapWorld() const { return x28_mapWorld.GetObj(); }
+
   u32 GetRelayCount() const { return x2c_relays.size(); }
   CRelay GetRelay(u32 idx) const { return x2c_relays[idx]; }
 


### PR DESCRIPTION
Same behavior, but makes it explicit from the interface that modifications are clearly going on from within the class.