### PR TITLE
CSegStatementSet: Minor changes

### DIFF
--- a/Runtime/Character/CAdditiveAnimPlayback.cpp
+++ b/Runtime/Character/CAdditiveAnimPlayback.cpp
@@ -18,7 +18,7 @@ void CAdditiveAnimPlayback::AddToSegStatementSet(const CSegIdList& list, const C
   CSegStatementSet stackSet;
   x8_anim->VGetSegStatementSet(list, stackSet);
   for (const CSegId& id : list.GetList()) {
-    CAnimPerSegmentData& data = stackSet.x4_segData[id];
+    CAnimPerSegmentData& data = stackSet[id];
     data.x10_offset = layout.GetFromParentUnrotated(id);
     data.x1c_hasOffset = true;
   }

--- a/Runtime/Character/CAnimSource.cpp
+++ b/Runtime/Character/CAnimSource.cpp
@@ -133,7 +133,7 @@ void CAnimSource::GetSegStatementSet(const CSegIdList& list, CSegStatementSet& s
 
       zeus::CQuaternion quatA(frameDataA[0], frameDataA[1], frameDataA[2], frameDataA[3]);
       zeus::CQuaternion quatB(frameDataB[0], frameDataB[1], frameDataB[2], frameDataB[3]);
-      set.x4_segData[id].x0_rotation = zeus::CQuaternion::slerp(quatA, quatB, t);
+      set[id].x0_rotation = zeus::CQuaternion::slerp(quatA, quatB, t);
 
       u8 transIdx = x30_translationChannels[rotIdx];
       if (transIdx != 0xff) {
@@ -142,8 +142,8 @@ void CAnimSource::GetSegStatementSet(const CSegIdList& list, CSegStatementSet& s
             &x40_data.x0_storage[(frameIdx - 1) * floatsPerFrame + rotFloatsPerFrame + transIdx * 3];
         zeus::CVector3f vecA(frameDataA[0], frameDataA[1], frameDataA[2]);
         zeus::CVector3f vecB(frameDataB[0], frameDataB[1], frameDataB[2]);
-        set.x4_segData[id].x10_offset = zeus::CVector3f::lerp(vecA, vecB, t);
-        set.x4_segData[id].x1c_hasOffset = true;
+        set[id].x10_offset = zeus::CVector3f::lerp(vecA, vecB, t);
+        set[id].x1c_hasOffset = true;
       }
     }
   }

--- a/Runtime/Character/CSegStatementSet.hpp
+++ b/Runtime/Character/CSegStatementSet.hpp
@@ -8,10 +8,12 @@ class CCharLayoutInfo;
 class CSegIdList;
 
 class CSegStatementSet {
-public:
+private:
   /* Used to be a pointer to arbitrary subclass-provided storage,
    * now it's a self-stored array */
   CAnimPerSegmentData x4_segData[100];
+
+public:
   void Add(const CSegIdList& list, const CCharLayoutInfo& layout, const CSegStatementSet& other, float weight);
 
   CAnimPerSegmentData& operator[](const CSegId& idx) { return x4_segData[idx]; }

--- a/Runtime/Character/CSegStatementSet.hpp
+++ b/Runtime/Character/CSegStatementSet.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <array>
+
 #include "Runtime/Character/CAnimPerSegmentData.hpp"
 #include "Runtime/Character/CSegId.hpp"
 
@@ -11,7 +13,7 @@ class CSegStatementSet {
 private:
   /* Used to be a pointer to arbitrary subclass-provided storage,
    * now it's a self-stored array */
-  CAnimPerSegmentData x4_segData[100];
+  std::array<CAnimPerSegmentData, 100> x4_segData;
 
 public:
   void Add(const CSegIdList& list, const CCharLayoutInfo& layout, const CSegStatementSet& other, float weight);


### PR DESCRIPTION
- Make x4_segData private. We already have accessors for retrieving the data, so we can use those instead.
- Make use of std::array. Same behavior, but without any implicit array to pointer decay.