### PR TITLE
CCameraShakeData: Make classes and structs constexpr where applicable

### DIFF
--- a/Runtime/Camera/CCameraShakeData.cpp
+++ b/Runtime/Camera/CCameraShakeData.cpp
@@ -27,22 +27,6 @@ CCameraShakerComponent CCameraShakerComponent::LoadNewCameraShakerComponent(CInp
   return {useModulation != 0, am, fm};
 }
 
-CCameraShakeData::CCameraShakeData(float duration, float sfxDist, u32 flags, const zeus::CVector3f& sfxPos,
-                                   const CCameraShakerComponent& shaker1, const CCameraShakerComponent& shaker2,
-                                   const CCameraShakerComponent& shaker3)
-: x0_duration(duration)
-, x8_shakerX(shaker1)
-, x44_shakerY(shaker2)
-, x80_shakerZ(shaker3)
-, xc0_flags(flags)
-, xc4_sfxPos(sfxPos)
-, xd0_sfxDist(sfxDist) {}
-
-CCameraShakeData::CCameraShakeData(float duration, float magnitude)
-: CCameraShakeData(duration, 100.f, 0, zeus::skZero3f, CCameraShakerComponent{}, CCameraShakerComponent{},
-                   CCameraShakerComponent{1, SCameraShakePoint{0, 0.25f * duration, 0.f, 0.75f * duration, magnitude},
-                                          SCameraShakePoint{1, 0.f, 0.f, 0.5f * duration, 2.f}}) {}
-
 CCameraShakeData::CCameraShakeData(CInputStream& in) {
   in.readUint32Big();
   in.readFloatBig();
@@ -54,66 +38,6 @@ CCameraShakeData::CCameraShakeData(CInputStream& in) {
   in.readFloatBig();
   in.readBool();
   BuildProjectileCameraShake(0.5f, 0.75f);
-}
-
-CCameraShakeData CCameraShakeData::BuildLandingCameraShakeData(float duration, float magnitude) {
-  return {duration,
-          100.f,
-          0,
-          zeus::skZero3f,
-          CCameraShakerComponent(1, SCameraShakePoint(0, 0.15f * duration, 0.f, 0.85f * duration, magnitude),
-                                 SCameraShakePoint(1, 0.f, 0.f, 0.4f * duration, 1.5f)),
-          CCameraShakerComponent(),
-          CCameraShakerComponent(1, SCameraShakePoint(0, 0.25f * duration, 0.f, 0.75f * duration, magnitude),
-                                 SCameraShakePoint(1, 0.f, 0.f, 0.5f * duration, 2.f))};
-}
-
-CCameraShakeData CCameraShakeData::BuildProjectileCameraShake(float duration, float magnitude) {
-  return {duration,
-          100.f,
-          0,
-          zeus::skZero3f,
-          CCameraShakerComponent(1, SCameraShakePoint(0, 0.f, 0.f, duration, magnitude),
-                                 SCameraShakePoint(1, 0.f, 0.f, 0.5f * duration, 3.f)),
-          CCameraShakerComponent(),
-          CCameraShakerComponent()};
-}
-
-CCameraShakeData CCameraShakeData::BuildMissileCameraShake(float duration, float magnitude, float sfxDistance,
-                                                           const zeus::CVector3f& sfxPos) {
-  CCameraShakeData ret(duration, magnitude);
-  ret.SetSfxPositionAndDistance(sfxPos, sfxDistance);
-  return ret;
-}
-
-CCameraShakeData CCameraShakeData::BuildPhazonCameraShakeData(float duration, float magnitude) {
-  return {duration,
-          100.f,
-          0,
-          zeus::skZero3f,
-          CCameraShakerComponent(1, SCameraShakePoint(0, 0.15f * duration, 0.f, 0.25f * duration, magnitude),
-                                 SCameraShakePoint(1, 0.f, 0.f, 0.4f * duration, 0.3f)),
-          CCameraShakerComponent(),
-          CCameraShakerComponent(1, SCameraShakePoint(0, 0.25f * duration, 0.f, 0.25f * duration, magnitude),
-                                 SCameraShakePoint(1, 0.f, 0.f, 0.5f * duration, 0.5f))};
-}
-
-CCameraShakeData CCameraShakeData::BuildPatternedExplodeShakeData(float duration, float magnitude) {
-  return {duration,
-          100.f,
-          0,
-          zeus::skZero3f,
-          CCameraShakerComponent(1, SCameraShakePoint(0, 0.25f * duration, 0.f, 0.75f * duration, magnitude),
-                                 SCameraShakePoint(1, 0.f, 0.f, 0.5f * duration, 2.0f)),
-          CCameraShakerComponent(),
-          CCameraShakerComponent()};
-}
-
-CCameraShakeData CCameraShakeData::BuildPatternedExplodeShakeData(const zeus::CVector3f& pos, float duration,
-                                                                  float magnitude, float distance) {
-  CCameraShakeData shakeData = CCameraShakeData::BuildPatternedExplodeShakeData(duration, magnitude);
-  shakeData.SetSfxPositionAndDistance(pos, distance);
-  return shakeData;
 }
 
 void SCameraShakePoint::Update(float curTime) {
@@ -198,13 +122,18 @@ CCameraShakeData CCameraShakeData::LoadCameraShakeData(CInputStream& in) {
   return {duration, 100.f, 0, zeus::skZero3f, shakerX, shakerY, shakerZ};
 }
 
-const CCameraShakeData CCameraShakeData::skChargedShotCameraShakeData = {
+const CCameraShakeData CCameraShakeData::skChargedShotCameraShakeData{
     0.3f,
     100.f,
     0,
     zeus::skZero3f,
-    CCameraShakerComponent(),
-    CCameraShakerComponent(1, {0, 0.f, 0.f, 0.3f, -1.f}, {1, 0.f, 0.f, 0.05f, 0.3f}),
-    CCameraShakerComponent()};
+    CCameraShakerComponent{},
+    CCameraShakerComponent{
+        true,
+        {false, 0.f, 0.f, 0.3f, -1.f},
+        {true, 0.f, 0.f, 0.05f, 0.3f},
+    },
+    CCameraShakerComponent{},
+};
 
 } // namespace urde

--- a/Runtime/Camera/CCameraShakeData.hpp
+++ b/Runtime/Camera/CCameraShakeData.hpp
@@ -16,14 +16,15 @@ struct SCameraShakePoint {
   float xc_attackTime = 0.f;
   float x10_sustainTime = 0.f;
   float x14_duration = 0.f;
-  SCameraShakePoint() = default;
-  SCameraShakePoint(bool useEnvelope, float attackTime, float sustainTime, float duration, float magnitude)
+  constexpr SCameraShakePoint() noexcept = default;
+  constexpr SCameraShakePoint(bool useEnvelope, float attackTime, float sustainTime, float duration,
+                              float magnitude) noexcept
   : x0_useEnvelope(useEnvelope)
   , x8_magnitude(magnitude)
   , xc_attackTime(attackTime)
   , x10_sustainTime(sustainTime)
   , x14_duration(duration) {}
-  float GetValue() const { return x0_useEnvelope ? x8_magnitude : x4_value; }
+  [[nodiscard]] constexpr float GetValue() const noexcept { return x0_useEnvelope ? x8_magnitude : x4_value; }
   static SCameraShakePoint LoadCameraShakePoint(CInputStream& in);
   void Update(float curTime);
 };
@@ -35,12 +36,13 @@ class CCameraShakerComponent {
   float x38_value = 0.f;
 
 public:
-  CCameraShakerComponent() = default;
-  CCameraShakerComponent(bool useModulation, const SCameraShakePoint& am, const SCameraShakePoint& fm)
+  constexpr CCameraShakerComponent() noexcept = default;
+  constexpr CCameraShakerComponent(bool useModulation, const SCameraShakePoint& am,
+                                   const SCameraShakePoint& fm) noexcept
   : x4_useModulation(useModulation), x8_am(am), x20_fm(fm) {}
   static CCameraShakerComponent LoadNewCameraShakerComponent(CInputStream& in);
   void Update(float curTime, float duration, float distAtt);
-  float GetValue() const { return x38_value; }
+  [[nodiscard]] constexpr float GetValue() const noexcept { return x38_value; }
 };
 
 class CCameraShakeData {
@@ -57,19 +59,112 @@ class CCameraShakeData {
 
 public:
   static const CCameraShakeData skChargedShotCameraShakeData;
-  CCameraShakeData(float duration, float sfxDist, u32 flags, const zeus::CVector3f& sfxPos,
-                   const CCameraShakerComponent& shaker1, const CCameraShakerComponent& shaker2,
-                   const CCameraShakerComponent& shaker3);
-  CCameraShakeData(float duration, float magnitude);
+
+  constexpr CCameraShakeData(float duration, float sfxDist, u32 flags, const zeus::CVector3f& sfxPos,
+                             const CCameraShakerComponent& shaker1, const CCameraShakerComponent& shaker2,
+                             const CCameraShakerComponent& shaker3) noexcept
+  : x0_duration(duration)
+  , x8_shakerX(shaker1)
+  , x44_shakerY(shaker2)
+  , x80_shakerZ(shaker3)
+  , xc0_flags(flags)
+  , xc4_sfxPos(sfxPos)
+  , xd0_sfxDist(sfxDist) {}
+
+  constexpr CCameraShakeData(float duration, float magnitude) noexcept
+  : CCameraShakeData(
+        duration, 100.f, 0, zeus::skZero3f, CCameraShakerComponent{}, CCameraShakerComponent{},
+        CCameraShakerComponent{true, SCameraShakePoint{false, 0.25f * duration, 0.f, 0.75f * duration, magnitude},
+                               SCameraShakePoint{true, 0.f, 0.f, 0.5f * duration, 2.f}}) {}
+
   explicit CCameraShakeData(CInputStream&);
-  static CCameraShakeData BuildLandingCameraShakeData(float duration, float magnitude);
-  static CCameraShakeData BuildProjectileCameraShake(float duration, float magnitude);
-  static CCameraShakeData BuildMissileCameraShake(float duration, float magnitude, float sfxDistance,
-                                                  const zeus::CVector3f& sfxPos);
-  static CCameraShakeData BuildPhazonCameraShakeData(float duration, float magnitude);
-  static CCameraShakeData BuildPatternedExplodeShakeData(float duration, float magnitude);
-  static CCameraShakeData BuildPatternedExplodeShakeData(const zeus::CVector3f& pos, float duration, float magnitude,
-                                                         float distance);
+
+  static constexpr CCameraShakeData BuildLandingCameraShakeData(float duration, float magnitude) noexcept {
+    return {
+        duration,
+        100.f,
+        0,
+        zeus::skZero3f,
+        CCameraShakerComponent{
+            true,
+            SCameraShakePoint(false, 0.15f * duration, 0.f, 0.85f * duration, magnitude),
+            SCameraShakePoint(true, 0.f, 0.f, 0.4f * duration, 1.5f),
+        },
+        CCameraShakerComponent{},
+        CCameraShakerComponent{
+            true,
+            SCameraShakePoint(false, 0.25f * duration, 0.f, 0.75f * duration, magnitude),
+            SCameraShakePoint(true, 0.f, 0.f, 0.5f * duration, 2.f),
+        },
+    };
+  }
+
+  static constexpr CCameraShakeData BuildProjectileCameraShake(float duration, float magnitude) noexcept {
+    return {
+        duration,
+        100.f,
+        0,
+        zeus::skZero3f,
+        CCameraShakerComponent{
+            true,
+            SCameraShakePoint(false, 0.f, 0.f, duration, magnitude),
+            SCameraShakePoint(true, 0.f, 0.f, 0.5f * duration, 3.f),
+        },
+        CCameraShakerComponent{},
+        CCameraShakerComponent{},
+    };
+  }
+
+  static constexpr CCameraShakeData BuildMissileCameraShake(float duration, float magnitude, float sfxDistance,
+                                                            const zeus::CVector3f& sfxPos) noexcept {
+    CCameraShakeData ret(duration, magnitude);
+    ret.SetSfxPositionAndDistance(sfxPos, sfxDistance);
+    return ret;
+  }
+
+  static constexpr CCameraShakeData BuildPhazonCameraShakeData(float duration, float magnitude) noexcept {
+    return {
+        duration,
+        100.f,
+        0,
+        zeus::skZero3f,
+        CCameraShakerComponent{
+            true,
+            SCameraShakePoint(false, 0.15f * duration, 0.f, 0.25f * duration, magnitude),
+            SCameraShakePoint(true, 0.f, 0.f, 0.4f * duration, 0.3f),
+        },
+        CCameraShakerComponent{},
+        CCameraShakerComponent{
+            true,
+            SCameraShakePoint(false, 0.25f * duration, 0.f, 0.25f * duration, magnitude),
+            SCameraShakePoint(true, 0.f, 0.f, 0.5f * duration, 0.5f),
+        },
+    };
+  }
+
+  static constexpr CCameraShakeData BuildPatternedExplodeShakeData(float duration, float magnitude) noexcept {
+    return {
+        duration,
+        100.f,
+        0,
+        zeus::skZero3f,
+        CCameraShakerComponent{
+            true,
+            SCameraShakePoint(false, 0.25f * duration, 0.f, 0.75f * duration, magnitude),
+            SCameraShakePoint(true, 0.f, 0.f, 0.5f * duration, 2.0f),
+        },
+        CCameraShakerComponent{},
+        CCameraShakerComponent{},
+    };
+  }
+
+  static constexpr CCameraShakeData BuildPatternedExplodeShakeData(const zeus::CVector3f& pos, float duration,
+                                                                   float magnitude, float distance) noexcept {
+    CCameraShakeData shakeData = BuildPatternedExplodeShakeData(duration, magnitude);
+    shakeData.SetSfxPositionAndDistance(pos, distance);
+    return shakeData;
+  }
+
   void Update(float dt, CStateManager& mgr);
   zeus::CVector3f GetPoint() const;
   float GetMaxAMComponent() const;
@@ -77,10 +172,10 @@ public:
   void SetShakerId(u32 id) { xbc_shakerId = id; }
   u32 GetShakerId() const { return xbc_shakerId; }
   static CCameraShakeData LoadCameraShakeData(CInputStream& in);
-  void SetSfxPositionAndDistance(const zeus::CVector3f& pos, float f2) {
+  constexpr void SetSfxPositionAndDistance(const zeus::CVector3f& pos, float sfxDistance) noexcept {
     xc0_flags |= 0x1;
     xc4_sfxPos = pos;
-    xd0_sfxDist = f2;
+    xd0_sfxDist = sfxDistance;
   }
 };
 

--- a/Runtime/Weapon/CAuxWeapon.cpp
+++ b/Runtime/Weapon/CAuxWeapon.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/Weapon/CAuxWeapon.hpp"
 
+#include <array>
+
 #include "Runtime/CSimplePool.hpp"
 #include "Runtime/GameGlobalObjects.hpp"
 #include "Runtime/Weapon/CEnergyProjectile.hpp"
@@ -7,9 +9,27 @@
 #include "Runtime/Weapon/CWaveBuster.hpp"
 
 namespace urde {
+constexpr CCameraShakeData skHardShake{
+    0.3f,
+    100.f,
+    0,
+    zeus::skZero3f,
+    {},
+    {
+        true,
+        {false, 0.f, 0.f, 0.3f, -2.f},
+        {true, 0.f, 0.f, 0.05f, 0.5f},
+    },
+    {},
+};
 
-static const CCameraShakeData skHardShake = {
-    0.3f, 100.f, 0, zeus::skZero3f, {}, {1, {0, 0.f, 0.f, 0.3f, -2.f}, {1, 0.f, 0.f, 0.05f, 0.5f}}, {}};
+constexpr std::array skComboNames{
+    "SuperMissile", "IceCombo", "WaveBuster", "FlameThrower", "SuperMissile",
+};
+
+constexpr std::array<u16, 5> skSoundId{
+    1810, 1837, 1847, 1842, 1810,
+};
 
 CAuxWeapon::CAuxWeapon(TUniqueId playerId)
 : x0_missile(g_SimplePool->GetObj("Missile"))
@@ -23,11 +43,10 @@ CAuxWeapon::CAuxWeapon(TUniqueId playerId)
   InitComboData();
 }
 
-static const char* skComboNames[] = {"SuperMissile", "IceCombo", "WaveBuster", "FlameThrower", "SuperMissile"};
-
 void CAuxWeapon::InitComboData() {
-  for (int i = 0; i < 5; ++i)
-    x28_combos.push_back(g_SimplePool->GetObj(skComboNames[i]));
+  for (const auto comboName : skComboNames) {
+    x28_combos.push_back(g_SimplePool->GetObj(comboName));
+  }
 }
 
 void CAuxWeapon::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) {
@@ -241,8 +260,6 @@ void CAuxWeapon::CreateWaveBusterBeam(EProjectileAttrib attribs, TUniqueId homin
   mgr.GetPlayerState()->SetFiringComboBeam(true);
   x74_firingBeamId = CPlayerState::EBeamId::Wave;
 }
-
-static const u16 skSoundId[] = {1810, 1837, 1847, 1842, 1810};
 
 void CAuxWeapon::LaunchMissile(float dt, bool underwater, bool charged, CPlayerState::EBeamId currentBeam,
                                EProjectileAttrib attrib, const zeus::CTransform& xf, TUniqueId homingId,

--- a/Runtime/Weapon/CPlasmaBeam.cpp
+++ b/Runtime/Weapon/CPlasmaBeam.cpp
@@ -9,7 +9,7 @@
 
 namespace urde {
 namespace {
-const CCameraShakeData CameraShaker{0.125f, 0.25f};
+constexpr CCameraShakeData CameraShaker{0.125f, 0.25f};
 constexpr std::array<u16, 2> kSoundId{SFXwpn_fire_plasma_normal, SFXwpn_fire_plasma_charged};
 } // Anonymous namespace
 


### PR DESCRIPTION
Same behavior, but allows eliminating file-scope initializers needing to be run on program start.

Opening this as a PR to run CI over it.