### PR TITLE
CRasterFont: Collapse loop into a std::find_if in InternalGetGlyph()

### DIFF
--- a/Runtime/GuiSys/CRasterFont.cpp
+++ b/Runtime/GuiSys/CRasterFont.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/GuiSys/CRasterFont.hpp"
 
+#include <algorithm>
+
 #include "Runtime/CSimplePool.hpp"
 #include "Runtime/Graphics/CTexture.hpp"
 #include "Runtime/GuiSys/CDrawStringOptions.hpp"
@@ -82,6 +84,17 @@ CRasterFont::CRasterFont(urde::CInputStream& in, urde::IObjectStore& store) {
 
   if (magic == SBIG('FONT') && version <= 4)
     x0_initialized = true;
+}
+
+const CGlyph* CRasterFont::InternalGetGlyph(char16_t chr) const {
+  const auto iter =
+      std::find_if(xc_glyphs.cbegin(), xc_glyphs.cend(), [chr](const auto& entry) { return entry.first == chr; });
+
+  if (iter == xc_glyphs.cend()) {
+    return nullptr;
+  }
+
+  return &iter->second;
 }
 
 void CRasterFont::SinglePassDrawString(const CDrawStringOptions& opts, int x, int y, int& xout, int& yout,

--- a/Runtime/GuiSys/CRasterFont.hpp
+++ b/Runtime/GuiSys/CRasterFont.hpp
@@ -109,16 +109,7 @@ class CRasterFont {
   s32 x8c_baseline;
   s32 x90_lineMargin = 0;
 
-  const CGlyph* InternalGetGlyph(char16_t chr) const {
-    u32 i = 0;
-    for (; i < xc_glyphs.size(); ++i)
-      if (chr == xc_glyphs[i].first)
-        break;
-
-    if (i == xc_glyphs.size())
-      return nullptr;
-    return &xc_glyphs[i].second;
-  }
+  const CGlyph* InternalGetGlyph(char16_t chr) const;
 
 public:
   CRasterFont(CInputStream& in, IObjectStore& store);


### PR DESCRIPTION
Same behavior, less code.