### PR TITLE
CActor: Make AddToRenderer() non-const

### DIFF
--- a/Runtime/MP1/World/CAtomicAlpha.cpp
+++ b/Runtime/MP1/World/CAtomicAlpha.cpp
@@ -66,9 +66,10 @@ void CAtomicAlpha::Render(const CStateManager& mgr) const {
     x690_bombModel.Render(mgr, locatorXf, x90_actorLights.get(), flags);
   }
 }
-void CAtomicAlpha::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
-  if (mgr.GetPlayerState()->GetActiveVisor(mgr) != CPlayerState::EPlayerVisor::XRay && x568_25_invisible)
+void CAtomicAlpha::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
+  if (mgr.GetPlayerState()->GetActiveVisor(mgr) != CPlayerState::EPlayerVisor::XRay && x568_25_invisible) {
     return;
+  }
   CPatterned::AddToRenderer(frustum, mgr);
 }
 

--- a/Runtime/MP1/World/CAtomicAlpha.hpp
+++ b/Runtime/MP1/World/CAtomicAlpha.hpp
@@ -40,7 +40,7 @@ public:
 
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Render(const CStateManager&) const override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void Think(float, CStateManager&) override;
   void DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node, EUserEventType type, float dt) override;
 

--- a/Runtime/MP1/World/CBouncyGrenade.cpp
+++ b/Runtime/MP1/World/CBouncyGrenade.cpp
@@ -36,7 +36,7 @@ CBouncyGrenade::CBouncyGrenade(TUniqueId uid, std::string_view name, const CEnti
   SetMaterialFilter(CMaterialFilter::MakeIncludeExclude(filter.IncludeList(), filter.ExcludeList()));
 }
 
-void CBouncyGrenade::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CBouncyGrenade::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   CActor::AddToRenderer(frustum, mgr);
   if (!x2b4_24_exploded) {
     g_Renderer->AddParticleGen(*x2ac_elementGen4);

--- a/Runtime/MP1/World/CBouncyGrenade.hpp
+++ b/Runtime/MP1/World/CBouncyGrenade.hpp
@@ -77,7 +77,7 @@ public:
                  const SBouncyGrenadeData& data, float velocity, float explodePlayerDistance);
 
   void Accept(IVisitor& visitor) override { visitor.Visit(this); }
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void CollidedWith(TUniqueId id, const CCollisionInfoList& list, CStateManager& mgr) override;
   [[nodiscard]] std::optional<zeus::CAABox> GetTouchBounds() const override;
   void Render(const CStateManager& mgr) const override;

--- a/Runtime/MP1/World/CFlaahgra.cpp
+++ b/Runtime/MP1/World/CFlaahgra.cpp
@@ -56,11 +56,11 @@ CFlaahgraRenderer::CFlaahgraRenderer(TUniqueId uid, TUniqueId owner, std::string
          CActorParameters::None(), kInvalidUniqueId)
 , xe8_owner(owner) {}
 
-void CFlaahgraRenderer::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
-
+void CFlaahgraRenderer::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   if (const CActor* act = static_cast<const CActor*>(mgr.GetObjectById(xe8_owner))) {
-    if (act->HasModelData() && (act->GetModelData()->HasAnimData() || act->GetModelData()->HasNormalModel()))
+    if (act->HasModelData() && (act->GetModelData()->HasAnimData() || act->GetModelData()->HasNormalModel())) {
       act->GetModelData()->RenderParticles(frustum);
+    }
   }
 }
 void CFlaahgraRenderer::Accept(IVisitor& visitor) { visitor.Visit(this); }
@@ -254,14 +254,16 @@ void CFlaahgra::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateM
   CPatterned::AcceptScriptMsg(msg, uid, mgr);
 }
 
-void CFlaahgra::AddToRenderer(const zeus::CFrustum& frustum, const urde::CStateManager& mgr) const {
-  if ((!GetModelData()->HasAnimData() && !GetModelData()->HasNormalModel()) || xe4_30_outOfFrustum)
+void CFlaahgra::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
+  if ((!GetModelData()->HasAnimData() && !GetModelData()->HasNormalModel()) || xe4_30_outOfFrustum) {
     return;
+  }
 
-  if (CanRenderUnsorted(mgr))
+  if (CanRenderUnsorted(mgr)) {
     Render(mgr);
-  else
+  } else {
     EnsureRendered(mgr);
+  }
 }
 
 void CFlaahgra::Death(CStateManager& mgr, const zeus::CVector3f& dir, EScriptObjectState state) {
@@ -1270,7 +1272,7 @@ void CFlaahgraPlants::Think(float dt, CStateManager& mgr) {
     mgr.FreeScriptObject(GetUniqueId());
 }
 
-void CFlaahgraPlants::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CFlaahgraPlants::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   g_Renderer->AddParticleGen(*xe8_elementGen.get());
   CActor::AddToRenderer(frustum, mgr);
 }

--- a/Runtime/MP1/World/CFlaahgra.hpp
+++ b/Runtime/MP1/World/CFlaahgra.hpp
@@ -59,7 +59,7 @@ class CFlaahgraRenderer : public CActor {
 public:
   CFlaahgraRenderer(TUniqueId, TUniqueId, std::string_view, const CEntityInfo&, const zeus::CTransform&);
 
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Accept(IVisitor&) override;
   std::optional<zeus::CAABox> GetTouchBounds() const override { return {}; }
 };
@@ -80,7 +80,7 @@ public:
   void Accept(IVisitor&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   std::optional<zeus::CAABox> GetTouchBounds() const override { return x110_aabox; }
   void Touch(CActor&, CStateManager&) override;
 };
@@ -200,7 +200,7 @@ public:
   void Think(float, CStateManager&) override;
   void PreThink(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   bool CanRenderUnsorted(const CStateManager&) const override { return true; }
   zeus::CVector3f GetAimPosition(const CStateManager&, float) const override { return x820_; }
   void Death(CStateManager&, const zeus::CVector3f&, EScriptObjectState) override;

--- a/Runtime/MP1/World/CFlyingPirate.cpp
+++ b/Runtime/MP1/World/CFlyingPirate.cpp
@@ -463,7 +463,7 @@ void CFlyingPirate::RemoveFromTeam(CStateManager& mgr) {
   }
 }
 
-void CFlyingPirate::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CFlyingPirate::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   for (const auto& gen : x684_particleGens) {
     if (frustum.aabbFrustumTest(GetBoundingBox())) {
       g_Renderer->AddParticleGen(*gen);

--- a/Runtime/MP1/World/CFlyingPirate.hpp
+++ b/Runtime/MP1/World/CFlyingPirate.hpp
@@ -84,7 +84,7 @@ public:
 
   void Accept(IVisitor& visitor) override { visitor.Visit(this); }
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   bool AnimOver(CStateManager& mgr, float arg) override;
   void CalculateRenderBounds() override;
   void DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node, EUserEventType type, float dt) override;

--- a/Runtime/MP1/World/CGrenadeLauncher.cpp
+++ b/Runtime/MP1/World/CGrenadeLauncher.cpp
@@ -117,7 +117,7 @@ void CGrenadeLauncher::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, 
   }
 }
 
-void CGrenadeLauncher::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CGrenadeLauncher::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   CActor::AddToRenderer(frustum, mgr);
 }
 

--- a/Runtime/MP1/World/CGrenadeLauncher.hpp
+++ b/Runtime/MP1/World/CGrenadeLauncher.hpp
@@ -98,7 +98,7 @@ public:
 
   void Accept(IVisitor& visitor) override { visitor.Visit(this); }
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   [[nodiscard]] const CCollisionPrimitive* GetCollisionPrimitive() const override { return &x328_cSphere; }
   [[nodiscard]] const CDamageVulnerability* GetDamageVulnerability() const override { return &x264_vulnerability; }
   [[nodiscard]] std::optional<zeus::CAABox> GetTouchBounds() const override;

--- a/Runtime/MP1/World/CMetroidBeta.cpp
+++ b/Runtime/MP1/World/CMetroidBeta.cpp
@@ -170,7 +170,7 @@ void CMetroidBeta::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CSta
     break;
   }
 }
-void CMetroidBeta::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CMetroidBeta::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   CPatterned::AddToRenderer(frustum, mgr);
 }
 void CMetroidBeta::Render(const CStateManager& mgr) const { CPatterned::Render(mgr); }

--- a/Runtime/MP1/World/CMetroidBeta.hpp
+++ b/Runtime/MP1/World/CMetroidBeta.hpp
@@ -102,7 +102,7 @@ public:
 
   void Think(float dt, CStateManager& mgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void Render(const CStateManager& mgr) const override;
   const CDamageVulnerability* GetDamageVulnerability() const override;
   const CDamageVulnerability* GetDamageVulnerability(const zeus::CVector3f& vec1, const zeus::CVector3f& vec2,

--- a/Runtime/MP1/World/CNewIntroBoss.cpp
+++ b/Runtime/MP1/World/CNewIntroBoss.cpp
@@ -303,7 +303,7 @@ void CNewIntroBoss::DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& nod
   }
 }
 
-void CNewIntroBoss::AddToRenderer(const zeus::CFrustum&, const CStateManager& mgr) const { EnsureRendered(mgr); }
+void CNewIntroBoss::AddToRenderer(const zeus::CFrustum&, CStateManager& mgr) { EnsureRendered(mgr); }
 
 float CNewIntroBoss::GetNextAttackTime(CStateManager& mgr) const {
   float attackTime = 2.f * mgr.GetActiveRandom()->Float() + 6.f;

--- a/Runtime/MP1/World/CNewIntroBoss.hpp
+++ b/Runtime/MP1/World/CNewIntroBoss.hpp
@@ -61,7 +61,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager&) override;
   void Think(float dt, CStateManager& mgr) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void OnScanStateChanged(EScanState, CStateManager&) override;
   CProjectileInfo* GetProjectileInfo() override { return &x5ac_projectileInfo; }
   zeus::CAABox GetSortingBounds(const CStateManager&) const override {

--- a/Runtime/MP1/World/CRidley.cpp
+++ b/Runtime/MP1/World/CRidley.cpp
@@ -697,7 +697,7 @@ void CRidley::Render(const CStateManager& mgr) const {
   CPatterned::Render(mgr);
 }
 
-void CRidley::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CRidley::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   CPatterned::AddToRenderer(frustum, mgr);
   if (xce0_ && frustum.aabbFrustumTest(*xce0_->GetBounds())) {
     g_Renderer->AddParticleGen(*xce0_);

--- a/Runtime/MP1/World/CRidley.hpp
+++ b/Runtime/MP1/World/CRidley.hpp
@@ -207,7 +207,7 @@ public:
   void Think(float dt, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
   void Render(const CStateManager& mgr) const override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   zeus::CAABox GetSortingBounds(const CStateManager&) const override { return GetBoundingBox(); }
   const CDamageVulnerability* GetDamageVulnerability() const override {
     return &CDamageVulnerability::ImmuneVulnerabilty();

--- a/Runtime/MP1/World/CShockWave.cpp
+++ b/Runtime/MP1/World/CShockWave.cpp
@@ -53,7 +53,7 @@ void CShockWave::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CState
   mgr.SendScriptMsgAlways(x980_id2, uid, msg);
 }
 
-void CShockWave::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CShockWave::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   CActor::AddToRenderer(frustum, mgr);
   g_Renderer->AddParticleGen(*x110_elementGen);
 }

--- a/Runtime/MP1/World/CShockWave.hpp
+++ b/Runtime/MP1/World/CShockWave.hpp
@@ -57,7 +57,7 @@ public:
 
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   [[nodiscard]] std::optional<zeus::CAABox> GetTouchBounds() const override;
   void Render(const CStateManager& mgr) const override;
   void Think(float dt, CStateManager& mgr) override;

--- a/Runtime/Weapon/CBomb.cpp
+++ b/Runtime/Weapon/CBomb.cpp
@@ -114,7 +114,7 @@ void CBomb::Think(float dt, urde::CStateManager& mgr) {
   x184_particle2->SetGlobalTranslation(GetTranslation());
 }
 
-void CBomb::AddToRenderer(const zeus::CFrustum& frustum, const urde::CStateManager& mgr) const {
+void CBomb::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   zeus::CVector3f origin = GetTranslation();
   float ballRadius = mgr.GetPlayer().GetMorphBall()->GetBallRadius();
 

--- a/Runtime/Weapon/CBomb.hpp
+++ b/Runtime/Weapon/CBomb.hpp
@@ -33,7 +33,7 @@ public:
   void Accept(IVisitor&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override {}
   void Touch(CActor&, CStateManager&) override;
   void Explode(const zeus::CVector3f&, CStateManager&);

--- a/Runtime/Weapon/CEnergyProjectile.cpp
+++ b/Runtime/Weapon/CEnergyProjectile.cpp
@@ -217,7 +217,7 @@ void CEnergyProjectile::Render(const CStateManager& mgr) const {
   }
 }
 
-void CEnergyProjectile::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CEnergyProjectile::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   auto bounds = x170_projectile.GetBounds();
   if (bounds && !frustum.aabbFrustumTest(*bounds))
     return;
@@ -225,8 +225,9 @@ void CEnergyProjectile::AddToRenderer(const zeus::CFrustum& frustum, const CStat
   CPlayerState::EPlayerVisor visor = mgr.GetPlayerState()->GetActiveVisor(mgr);
   if (visor != CPlayerState::EPlayerVisor::XRay &&
       ((xe8_projectileAttribs & EProjectileAttrib::Ice) != EProjectileAttrib::Ice ||
-       mgr.GetThermalDrawFlag() != EThermalDrawFlag::Hot))
+       mgr.GetThermalDrawFlag() != EThermalDrawFlag::Hot)) {
     x170_projectile.AddToRenderer();
+  }
   EnsureRendered(mgr);
 }
 

--- a/Runtime/Weapon/CEnergyProjectile.hpp
+++ b/Runtime/Weapon/CEnergyProjectile.hpp
@@ -40,7 +40,7 @@ public:
   void ResolveCollisionWithActor(const CRayCastResult& res, CActor& act, CStateManager& mgr);
   void Think(float dt, CStateManager& mgr);
   void Render(const CStateManager& mgr) const;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr);
   void Touch(CActor& act, CStateManager& mgr);
   virtual bool Explode(const zeus::CVector3f& pos, const zeus::CVector3f& normal, EWeaponCollisionResponseTypes type,
                        CStateManager& mgr, const CDamageVulnerability& dVuln, TUniqueId hitActor);

--- a/Runtime/Weapon/CFlameThrower.cpp
+++ b/Runtime/Weapon/CFlameThrower.cpp
@@ -90,7 +90,7 @@ void CFlameThrower::CreateFlameParticles(CStateManager& mgr) {
     CreateProjectileLight("FlameThrower_Light"sv, x348_flameGen->GetLight(), mgr);
 }
 
-void CFlameThrower::AddToRenderer(const zeus::CFrustum&, const CStateManager& mgr) const {
+void CFlameThrower::AddToRenderer(const zeus::CFrustum&, CStateManager& mgr) {
   g_Renderer->AddParticleGen(*x348_flameGen);
   EnsureRendered(mgr, x2e8_flameXf.origin, GetRenderBounds());
 }

--- a/Runtime/Weapon/CFlameThrower.hpp
+++ b/Runtime/Weapon/CFlameThrower.hpp
@@ -56,7 +56,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager& mgr) const override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void Touch(CActor& actor, CStateManager& mgr) override;

--- a/Runtime/Weapon/CPlasmaProjectile.cpp
+++ b/Runtime/Weapon/CPlasmaProjectile.cpp
@@ -394,7 +394,7 @@ bool CPlasmaProjectile::CanRenderUnsorted(const CStateManager& mgr) const {
   return false;
 }
 
-void CPlasmaProjectile::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CPlasmaProjectile::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   if (GetActive()) {
     g_Renderer->AddParticleGen(*x518_contactGen);
     if (x478_beamAttributes & 0x2) {

--- a/Runtime/Weapon/CPlasmaProjectile.hpp
+++ b/Runtime/Weapon/CPlasmaProjectile.hpp
@@ -121,7 +121,7 @@ public:
   void Fire(const zeus::CTransform& xf, CStateManager& mgr, bool b) override;
   void Touch(CActor& other, CStateManager& mgr) override;
   bool CanRenderUnsorted(const CStateManager& mgr) const override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void Render(const CStateManager& mgr) const override;
 };
 } // namespace urde

--- a/Runtime/Weapon/CPowerBomb.cpp
+++ b/Runtime/Weapon/CPowerBomb.cpp
@@ -89,7 +89,7 @@ void CPowerBomb::Think(float dt, CStateManager& mgr) {
   x15c_curTime += dt;
 }
 
-void CPowerBomb::AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {
+void CPowerBomb::AddToRenderer(const zeus::CFrustum&, CStateManager&) {
   g_Renderer->AddParticleGen(*x168_particle);
 }
 

--- a/Runtime/Weapon/CPowerBomb.hpp
+++ b/Runtime/Weapon/CPowerBomb.hpp
@@ -27,7 +27,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override {}
   std::optional<zeus::CAABox> GetTouchBounds() const override { return std::nullopt; }
   void Touch(CActor&, CStateManager&) override { /*x158_24_canStartFilter; */

--- a/Runtime/World/CActor.cpp
+++ b/Runtime/World/CActor.cpp
@@ -181,25 +181,29 @@ void CActor::PreRender(CStateManager& mgr, const zeus::CFrustum& planes) {
   }
 }
 
-void CActor::AddToRenderer(const zeus::CFrustum& planes, const CStateManager& mgr) const {
-  if (!x64_modelData || x64_modelData->IsNull())
+void CActor::AddToRenderer(const zeus::CFrustum& planes, CStateManager& mgr) {
+  if (!x64_modelData || x64_modelData->IsNull()) {
     return;
+  }
 
-  if (xe6_29_renderParticleDBInside)
+  if (xe6_29_renderParticleDBInside) {
     x64_modelData->RenderParticles(planes);
+  }
 
   if (!xe4_30_outOfFrustum) {
-    if (CanRenderUnsorted(mgr))
+    if (CanRenderUnsorted(mgr)) {
       Render(mgr);
-    else
+    } else {
       EnsureRendered(mgr);
+    }
   }
 
   if (mgr.GetPlayerState()->GetActiveVisor(mgr) != CPlayerState::EPlayerVisor::XRay &&
       mgr.GetPlayerState()->GetActiveVisor(mgr) != CPlayerState::EPlayerVisor::Thermal && xe5_24_shadowEnabled &&
-      x94_simpleShadow->Valid() && planes.aabbFrustumTest(x94_simpleShadow->GetBounds()))
+      x94_simpleShadow->Valid() && planes.aabbFrustumTest(x94_simpleShadow->GetBounds())) {
     g_Renderer->AddDrawable(x94_simpleShadow.get(), x94_simpleShadow->GetTransform().origin,
                             x94_simpleShadow->GetBounds(), 1, CBooRenderer::EDrawableSorting::SortedCallback);
+  }
 }
 
 void CActor::DrawTouchBounds() const {

--- a/Runtime/World/CActor.hpp
+++ b/Runtime/World/CActor.hpp
@@ -108,7 +108,7 @@ public:
     CEntity::SetActive(active);
   }
   virtual void PreRender(CStateManager&, const zeus::CFrustum&);
-  virtual void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const;
+  virtual void AddToRenderer(const zeus::CFrustum&, CStateManager&);
   virtual void Render(const CStateManager&) const;
   virtual bool CanRenderUnsorted(const CStateManager&) const;
   virtual void CalculateRenderBounds();

--- a/Runtime/World/CEffect.hpp
+++ b/Runtime/World/CEffect.hpp
@@ -8,7 +8,7 @@ class CEffect : public CActor {
 public:
   CEffect(TUniqueId uid, const CEntityInfo& info, bool active, std::string_view name, const zeus::CTransform& xf);
 
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
   void Render(const CStateManager&) const override {}
 };
 

--- a/Runtime/World/CExplosion.cpp
+++ b/Runtime/World/CExplosion.cpp
@@ -89,9 +89,10 @@ void CExplosion::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   xe4_30_outOfFrustum = !xf4_25_ || !frustum.aabbFrustumTest(x9c_renderBounds);
 }
 
-void CExplosion::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
-  if (xe4_30_outOfFrustum)
+void CExplosion::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
+  if (xe4_30_outOfFrustum) {
     return;
+  }
 
   if (!(xf4_24_renderThermalHot && mgr.GetThermalDrawFlag() == EThermalDrawFlag::Hot) &&
       !(xf4_26_renderXray && mgr.GetPlayerState()->GetActiveVisor(mgr) == CPlayerState::EPlayerVisor::XRay)) {

--- a/Runtime/World/CExplosion.hpp
+++ b/Runtime/World/CExplosion.hpp
@@ -33,7 +33,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override;
   bool CanRenderUnsorted(const CStateManager&) const override;
 };

--- a/Runtime/World/CFire.cpp
+++ b/Runtime/World/CFire.cpp
@@ -84,7 +84,7 @@ void CFire::Touch(CActor& act, CStateManager& mgr) {
                   CMaterialFilter::MakeIncludeExclude({EMaterialTypes::Solid}, {}), {});
 }
 
-void CFire::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CFire::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   bool drawParticles = true;
   if (!x148_27_) {
     using EPlayerVisor = CPlayerState::EPlayerVisor;

--- a/Runtime/World/CFire.hpp
+++ b/Runtime/World/CFire.hpp
@@ -42,6 +42,6 @@ public:
   }
 
   void Touch(CActor&, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
 };
 } // namespace urde

--- a/Runtime/World/CHUDBillboardEffect.cpp
+++ b/Runtime/World/CHUDBillboardEffect.cpp
@@ -78,7 +78,7 @@ void CHUDBillboardEffect::Think(float dt, CStateManager& mgr) {
   }
 }
 
-void CHUDBillboardEffect::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CHUDBillboardEffect::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   if (x104_25_enableRender && x104_24_renderAsParticleGen) {
     g_Renderer->AddParticleGen(*xe8_generator);
   }

--- a/Runtime/World/CHUDBillboardEffect.hpp
+++ b/Runtime/World/CHUDBillboardEffect.hpp
@@ -37,7 +37,7 @@ public:
   ~CHUDBillboardEffect() override;
   void Accept(IVisitor& visitor) override;
   void Think(float dt, CStateManager& mgr) override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
   void Render(const CStateManager& mgr) const override;
   bool IsElementGen() const { return x104_26_isElementGen; }

--- a/Runtime/World/CPatterned.cpp
+++ b/Runtime/World/CPatterned.cpp
@@ -1570,13 +1570,14 @@ void CPatterned::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   CActor::PreRender(mgr, frustum);
 }
 
-void CPatterned::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CPatterned::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   if (x402_29_drawParticles) {
     if (x64_modelData && !x64_modelData->IsNull()) {
       int mask, target;
       mgr.GetCharacterRenderMaskAndTarget(x402_31_thawed, mask, target);
-      if (CAnimData* aData = x64_modelData->GetAnimationData())
+      if (CAnimData* aData = x64_modelData->GetAnimationData()) {
         aData->GetParticleDB().AddToRendererClippedMasked(frustum, mask, target);
+      }
     }
   }
   CActor::AddToRenderer(frustum, mgr);

--- a/Runtime/World/CPatterned.hpp
+++ b/Runtime/World/CPatterned.hpp
@@ -273,7 +273,7 @@ public:
   }
   void Think(float, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager& mgr) const override;
 
   void CollidedWith(TUniqueId, const CCollisionInfoList&, CStateManager& mgr) override;

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -1597,7 +1597,7 @@ void CPlayer::CalculateRenderBounds() {
   }
 }
 
-void CPlayer::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CPlayer::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   if (x2f4_cameraState != EPlayerCameraState::FirstPerson && x2f8_morphBallState == EPlayerMorphBallState::Morphed) {
     if (x768_morphball->IsInFrustum(frustum)) {
       CActor::AddToRenderer(frustum, mgr);

--- a/Runtime/World/CPlayer.hpp
+++ b/Runtime/World/CPlayer.hpp
@@ -405,7 +405,7 @@ public:
   void RenderReflectedPlayer(CStateManager& mgr);
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
   void CalculateRenderBounds() override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void ComputeFreeLook(const CFinalInput& input);
   void UpdateFreeLookState(const CFinalInput& input, float dt, CStateManager& mgr);
   void UpdateFreeLook(float dt);

--- a/Runtime/World/CScriptAiJumpPoint.hpp
+++ b/Runtime/World/CScriptAiJumpPoint.hpp
@@ -29,7 +29,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void Think(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
   void Render(const CStateManager&) const override {}
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   bool GetInUse(TUniqueId uid) const;

--- a/Runtime/World/CScriptCameraWaypoint.hpp
+++ b/Runtime/World/CScriptCameraWaypoint.hpp
@@ -17,7 +17,7 @@ public:
 
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
   void Render(const CStateManager&) const override {}
   TUniqueId GetRandomNextWaypointId(CStateManager& mgr) const;
   float GetHFov() const { return xe8_hfov; }

--- a/Runtime/World/CScriptCoverPoint.hpp
+++ b/Runtime/World/CScriptCoverPoint.hpp
@@ -40,7 +40,7 @@ public:
 
   void Accept(IVisitor& visitor) override;
   void Think(float, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Render(const CStateManager&) const override {}
   std::optional<zeus::CAABox> GetTouchBounds() const override;

--- a/Runtime/World/CScriptDamageableTrigger.cpp
+++ b/Runtime/World/CScriptDamageableTrigger.cpp
@@ -116,9 +116,11 @@ void CScriptDamageableTrigger::Render(const CStateManager& mgr) const {
   CActor::Render(mgr);
 }
 
-void CScriptDamageableTrigger::AddToRenderer(const zeus::CFrustum& /*frustum*/, const CStateManager& mgr) const {
-  if (x300_26_outOfFrustum)
+void CScriptDamageableTrigger::AddToRenderer(const zeus::CFrustum& /*frustum*/, CStateManager& mgr) {
+  if (x300_26_outOfFrustum) {
     return;
+  }
+
   EnsureRendered(mgr, GetTranslation() - x244_faceTranslate, GetSortingBounds(mgr));
 }
 

--- a/Runtime/World/CScriptDamageableTrigger.hpp
+++ b/Runtime/World/CScriptDamageableTrigger.hpp
@@ -59,7 +59,7 @@ public:
   EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
                                                          const CWeaponMode&, EProjectileAttrib) const override;
   void Render(const CStateManager& mgr) const override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
   const CDamageVulnerability* GetDamageVulnerability() const override { return &x174_dVuln; }
   CHealthInfo* HealthInfo(CStateManager&) override { return &x16c_hInfo; }

--- a/Runtime/World/CScriptDebris.cpp
+++ b/Runtime/World/CScriptDebris.cpp
@@ -143,21 +143,28 @@ CScriptDebris::CScriptDebris(TUniqueId uid, std::string_view name, const CEntity
 
 void CScriptDebris::Accept(IVisitor& visitor) { visitor.Visit(this); }
 
-void CScriptDebris::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
-  if (x2d4_particleGens[0])
-    if (x270_curTime < x274_duration || x281_26_deferDeleteTillParticle1Done)
+void CScriptDebris::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
+  if (x2d4_particleGens[0]) {
+    if (x270_curTime < x274_duration || x281_26_deferDeleteTillParticle1Done) {
       g_Renderer->AddParticleGen(*x2d4_particleGens[0]);
+    }
+  }
 
-  if (x2d4_particleGens[1])
-    if (x270_curTime < x274_duration || x281_28_deferDeleteTillParticle2Done)
+  if (x2d4_particleGens[1]) {
+    if (x270_curTime < x274_duration || x281_28_deferDeleteTillParticle2Done) {
       g_Renderer->AddParticleGen(*x2d4_particleGens[1]);
+    }
+  }
 
-  if (x281_29_particle3Active)
+  if (x281_29_particle3Active) {
     g_Renderer->AddParticleGen(*x2d4_particleGens[2]);
+  }
 
-  if (x64_modelData && !x64_modelData->IsNull())
-    if (x270_curTime < x274_duration)
+  if (x64_modelData && !x64_modelData->IsNull()) {
+    if (x270_curTime < x274_duration) {
       CActor::AddToRenderer(frustum, mgr);
+    }
+  }
 }
 
 static zeus::CVector3f debris_cone(CStateManager& mgr, float coneAng, float minMag, float maxMag) {

--- a/Runtime/World/CScriptDebris.hpp
+++ b/Runtime/World/CScriptDebris.hpp
@@ -78,7 +78,7 @@ public:
                 bool noBounce, bool active);
 
   void Accept(IVisitor& visitor) override;
-  void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
   void Think(float dt, CStateManager& mgr) override;
   void Touch(CActor& other, CStateManager& mgr) override;

--- a/Runtime/World/CScriptDoor.cpp
+++ b/Runtime/World/CScriptDoor.cpp
@@ -197,9 +197,12 @@ void CScriptDoor::Think(float dt, CStateManager& mgr) {
   xe7_31_targetable = mgr.GetPlayerState()->GetCurrentVisor() == CPlayerState::EPlayerVisor::Scan;
 }
 
-void CScriptDoor::AddToRenderer(const zeus::CFrustum& /*frustum*/, const CStateManager& mgr) const {
-  if (!xe4_30_outOfFrustum)
-    CPhysicsActor::Render(mgr);
+void CScriptDoor::AddToRenderer(const zeus::CFrustum& /*frustum*/, CStateManager& mgr) {
+  if (xe4_30_outOfFrustum) {
+    return;
+  }
+
+  CPhysicsActor::Render(mgr);
 }
 
 /* ORIGINAL 0-00 OFFSET: 8007E0BC */

--- a/Runtime/World/CScriptDoor.hpp
+++ b/Runtime/World/CScriptDoor.hpp
@@ -51,7 +51,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
   void Think(float, CStateManager& mgr) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager& mgr) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager& mgr) override;
   void Render(const CStateManager&) const override {}
   void ForceClosed(CStateManager&);
   bool IsConnectedToArea(const CStateManager& mgr, TAreaId area) const;

--- a/Runtime/World/CScriptEMPulse.cpp
+++ b/Runtime/World/CScriptEMPulse.cpp
@@ -55,10 +55,11 @@ void CScriptEMPulse::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CS
   }
 }
 
-void CScriptEMPulse::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CScriptEMPulse::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   CActor::AddToRenderer(frustum, mgr);
-  if (GetActive())
+  if (GetActive()) {
     g_Renderer->AddParticleGen(*x114_particleGen);
+  }
 }
 
 void CScriptEMPulse::CalculateRenderBounds() { x9c_renderBounds = CalculateBoundingBox(); }

--- a/Runtime/World/CScriptEMPulse.hpp
+++ b/Runtime/World/CScriptEMPulse.hpp
@@ -27,7 +27,7 @@ public:
   void Accept(IVisitor&) override;
   void Think(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void CalculateRenderBounds() override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void Touch(CActor&, CStateManager&) override;

--- a/Runtime/World/CScriptEffect.cpp
+++ b/Runtime/World/CScriptEffect.cpp
@@ -207,31 +207,33 @@ void CScriptEffect::PreRender(CStateManager& mgr, const zeus::CFrustum&) {
     x13c_triggerId = kInvalidUniqueId;
 }
 
-void CScriptEffect::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CScriptEffect::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   if (!x111_26_canRender) {
-    const_cast<CScriptEffect&>(*this).x12c_remTime = zeus::max(x12c_remTime, x134_durationResetWhileVisible);
+    x12c_remTime = zeus::max(x12c_remTime, x134_durationResetWhileVisible);
     return;
   }
 
-  if (!frustum.aabbFrustumTest(x9c_renderBounds))
+  if (!frustum.aabbFrustumTest(x9c_renderBounds)) {
     return;
-  const_cast<CScriptEffect&>(*this).x12c_remTime = zeus::max(x12c_remTime, x134_durationResetWhileVisible);
+  }
+  x12c_remTime = zeus::max(x12c_remTime, x134_durationResetWhileVisible);
 
   if (x110_31_anyVisorVisible) {
     bool visible = false;
     const CPlayerState::EPlayerVisor visor = mgr.GetPlayerState()->GetActiveVisor(mgr);
-    if (visor == CPlayerState::EPlayerVisor::Combat || visor == CPlayerState::EPlayerVisor::Scan)
+    if (visor == CPlayerState::EPlayerVisor::Combat || visor == CPlayerState::EPlayerVisor::Scan) {
       visible = x110_28_combatVisorVisible;
-    else if (visor == CPlayerState::EPlayerVisor::XRay)
+    } else if (visor == CPlayerState::EPlayerVisor::XRay) {
       visible = x110_30_xrayVisorVisible;
-    else if (visor == CPlayerState::EPlayerVisor::Thermal)
+    } else if (visor == CPlayerState::EPlayerVisor::Thermal) {
       visible = x110_29_thermalVisorVisible;
+    }
 
     if (visible && x138_actorLights) {
       const CGameArea* area = mgr.GetWorld()->GetAreaAlways(GetAreaIdAlways());
-      const_cast<CScriptEffect&>(*this).x138_actorLights->BuildAreaLightList(
+      x138_actorLights->BuildAreaLightList(
           mgr, *area, zeus::CAABox{x9c_renderBounds.center(), x9c_renderBounds.center()});
-      const_cast<CScriptEffect&>(*this).x138_actorLights->BuildDynamicLightList(mgr, x9c_renderBounds);
+      x138_actorLights->BuildDynamicLightList(mgr, x9c_renderBounds);
     }
     EnsureRendered(mgr);
   }

--- a/Runtime/World/CScriptEffect.hpp
+++ b/Runtime/World/CScriptEffect.hpp
@@ -60,7 +60,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override;
   void Think(float, CStateManager&) override;
   bool CanRenderUnsorted(const CStateManager&) const override { return false; }

--- a/Runtime/World/CScriptGrapplePoint.cpp
+++ b/Runtime/World/CScriptGrapplePoint.cpp
@@ -46,7 +46,7 @@ void CScriptGrapplePoint::Render(const CStateManager&) const {
 
 std::optional<zeus::CAABox> CScriptGrapplePoint::GetTouchBounds() const { return {xe8_touchBounds}; }
 
-void CScriptGrapplePoint::AddToRenderer(const zeus::CFrustum&, const CStateManager& mgr) const {
+void CScriptGrapplePoint::AddToRenderer(const zeus::CFrustum&, CStateManager& mgr) {
   CActor::EnsureRendered(mgr);
 }
 

--- a/Runtime/World/CScriptGrapplePoint.hpp
+++ b/Runtime/World/CScriptGrapplePoint.hpp
@@ -21,7 +21,7 @@ public:
   void Think(float, CStateManager&) override;
   void Render(const CStateManager&) const override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   const CGrappleParameters& GetGrappleParameters() const { return x100_parameters; }
 };
 } // namespace urde

--- a/Runtime/World/CScriptGunTurret.cpp
+++ b/Runtime/World/CScriptGunTurret.cpp
@@ -444,11 +444,12 @@ void CScriptGunTurret::PlayAdditiveFlinchAnimation(CStateManager& mgr) {
     GetModelData()->GetAnimationData()->AddAdditiveAnimation(pair.second, 1.f, false, true);
 }
 
-void CScriptGunTurret::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CScriptGunTurret::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   CActor::AddToRenderer(frustum, mgr);
 
-  if (x258_type != ETurretComponent::Gun)
+  if (x258_type != ETurretComponent::Gun) {
     return;
+  }
 
   if (!x560_25_frozen) {
     switch (x520_state) {
@@ -471,8 +472,9 @@ void CScriptGunTurret::AddToRenderer(const zeus::CFrustum& frustum, const CState
     case ETurretState::ExitTargeting:
     case ETurretState::Frenzy:
       g_Renderer->AddParticleGen(*x478_targettingLight);
-      if (x520_state == ETurretState::Firing || x520_state == ETurretState::Frenzy)
+      if (x520_state == ETurretState::Firing || x520_state == ETurretState::Frenzy) {
         g_Renderer->AddParticleGen(*x488_chargingEffect);
+      }
       break;
     default:
       break;

--- a/Runtime/World/CScriptGunTurret.hpp
+++ b/Runtime/World/CScriptGunTurret.hpp
@@ -227,7 +227,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
   void Touch(CActor&, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   zeus::CVector3f GetOrbitPosition(const CStateManager&) const override;

--- a/Runtime/World/CScriptPlayerActor.cpp
+++ b/Runtime/World/CScriptPlayerActor.cpp
@@ -368,10 +368,11 @@ void CScriptPlayerActor::PreRender(CStateManager& mgr, const zeus::CFrustum& fru
   CScriptActor::PreRender(mgr, frustum);
 }
 
-void CScriptPlayerActor::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
-  const_cast<CScriptPlayerActor*>(this)->TouchModels_Internal(mgr);
-  if (GetActive())
+void CScriptPlayerActor::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
+  TouchModels_Internal(mgr);
+  if (GetActive()) {
     CActor::AddToRenderer(frustum, mgr);
+  }
 }
 
 void CScriptPlayerActor::Render(const CStateManager& mgr) const {

--- a/Runtime/World/CScriptPlayerActor.hpp
+++ b/Runtime/World/CScriptPlayerActor.hpp
@@ -67,7 +67,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void SetActive(bool active) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager& mgr) const override;
   void TouchModels(const CStateManager& mgr) const;
 };

--- a/Runtime/World/CScriptPointOfInterest.cpp
+++ b/Runtime/World/CScriptPointOfInterest.cpp
@@ -26,7 +26,7 @@ void CScriptPointOfInterest::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId
   CActor::AcceptScriptMsg(msg, uid, mgr);
 }
 
-void CScriptPointOfInterest::AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {}
+void CScriptPointOfInterest::AddToRenderer(const zeus::CFrustum&, CStateManager&) {}
 
 void CScriptPointOfInterest::Render(const CStateManager&) const {}
 

--- a/Runtime/World/CScriptPointOfInterest.hpp
+++ b/Runtime/World/CScriptPointOfInterest.hpp
@@ -17,7 +17,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void Think(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override;
   void CalculateRenderBounds() override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;

--- a/Runtime/World/CScriptShadowProjector.hpp
+++ b/Runtime/World/CScriptShadowProjector.hpp
@@ -37,7 +37,7 @@ public:
   void Think(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
   void CreateProjectedShadow();
 };
 } // namespace urde

--- a/Runtime/World/CScriptSound.hpp
+++ b/Runtime/World/CScriptSound.hpp
@@ -53,7 +53,7 @@ public:
                bool worldSfx, bool allowDuplicates, s32 pitch);
 
   void Accept(IVisitor& visitor) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
   void PreThink(float, CStateManager&) override;
   void Think(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;

--- a/Runtime/World/CScriptSpecialFunction.cpp
+++ b/Runtime/World/CScriptSpecialFunction.cpp
@@ -481,12 +481,14 @@ void CScriptSpecialFunction::PreRender(CStateManager&, const zeus::CFrustum& fru
     x1e4_28_frustumEntered = true;
 }
 
-void CScriptSpecialFunction::AddToRenderer(const zeus::CFrustum&, const CStateManager& mgr) const {
-  if (!GetActive())
+void CScriptSpecialFunction::AddToRenderer(const zeus::CFrustum&, CStateManager& mgr) {
+  if (!GetActive()) {
     return;
+  }
 
-  if (xe8_function == ESpecialFunction::FogVolume && x1e4_30_)
+  if (xe8_function == ESpecialFunction::FogVolume && x1e4_30_) {
     EnsureRendered(mgr);
+  }
 }
 
 void CScriptSpecialFunction::Render(const CStateManager& mgr) const {

--- a/Runtime/World/CScriptSpecialFunction.hpp
+++ b/Runtime/World/CScriptSpecialFunction.hpp
@@ -125,7 +125,7 @@ public:
   void Think(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override;
   std::optional<zeus::CAABox> GetTouchBounds() const override { return x1c8_touchBounds; }
 

--- a/Runtime/World/CScriptSpiderBallWaypoint.hpp
+++ b/Runtime/World/CScriptSpiderBallWaypoint.hpp
@@ -20,7 +20,7 @@ public:
   void Accept(IVisitor&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Render(const CStateManager& mgr) const override { CActor::Render(mgr); }
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override {}
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
   std::optional<zeus::CAABox> GetTouchBounds() const override { return xfc_aabox; }
   void AccumulateBounds(const zeus::CVector3f& v);
   void BuildWaypointListAndBounds(CStateManager& mgr);

--- a/Runtime/World/CScriptVisorFlare.cpp
+++ b/Runtime/World/CScriptVisorFlare.cpp
@@ -33,9 +33,10 @@ void CScriptVisorFlare::PreRender(CStateManager& stateMgr, const zeus::CFrustum&
   x11c_notInRenderLast = !stateMgr.RenderLast(x8_uid);
 }
 
-void CScriptVisorFlare::AddToRenderer(const zeus::CFrustum&, const CStateManager& stateMgr) const {
-  if (x11c_notInRenderLast)
+void CScriptVisorFlare::AddToRenderer(const zeus::CFrustum&, CStateManager& stateMgr) {
+  if (x11c_notInRenderLast) {
     EnsureRendered(stateMgr, stateMgr.GetPlayer().GetTranslation(), GetSortingBounds(stateMgr));
+  }
 }
 
 void CScriptVisorFlare::Render(const CStateManager& stateMgr) const { xe8_flare.Render(GetTranslation(), stateMgr); }

--- a/Runtime/World/CScriptVisorFlare.hpp
+++ b/Runtime/World/CScriptVisorFlare.hpp
@@ -20,7 +20,7 @@ public:
   void Think(float, CStateManager& stateMgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override;
 };
 

--- a/Runtime/World/CScriptVisorGoo.cpp
+++ b/Runtime/World/CScriptVisorGoo.cpp
@@ -101,7 +101,7 @@ void CScriptVisorGoo::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId,
   CActor::AcceptScriptMsg(msg, objId, mgr);
 }
 
-void CScriptVisorGoo::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
+void CScriptVisorGoo::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   // Empty
 }
 

--- a/Runtime/World/CScriptVisorGoo.hpp
+++ b/Runtime/World/CScriptVisorGoo.hpp
@@ -30,7 +30,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void Think(float, CStateManager& stateMgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void Touch(CActor&, CStateManager&) override;

--- a/Runtime/World/CScriptWater.cpp
+++ b/Runtime/World/CScriptWater.cpp
@@ -410,12 +410,14 @@ void CScriptWater::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) 
   }
 }
 
-void CScriptWater::AddToRenderer(const zeus::CFrustum& /*frustum*/, const CStateManager& mgr) const {
-  if (!xe4_30_outOfFrustum) {
-    zeus::CPlane plane(zeus::skUp, x34_transform.origin.z() + x130_bounds.max.z());
-    zeus::CAABox renderBounds = GetSortingBounds(mgr);
-    mgr.AddDrawableActorPlane(*this, plane, renderBounds);
+void CScriptWater::AddToRenderer(const zeus::CFrustum& /*frustum*/, CStateManager& mgr) {
+  if (xe4_30_outOfFrustum) {
+    return;
   }
+
+  const zeus::CPlane plane(zeus::skUp, x34_transform.origin.z() + x130_bounds.max.z());
+  const zeus::CAABox renderBounds = GetSortingBounds(mgr);
+  mgr.AddDrawableActorPlane(*this, plane, renderBounds);
 }
 
 void CScriptWater::Render(const CStateManager& mgr) const {

--- a/Runtime/World/CScriptWater.hpp
+++ b/Runtime/World/CScriptWater.hpp
@@ -105,7 +105,7 @@ public:
   void Think(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override;
   void Touch(CActor&, CStateManager&) override;
   void CalculateRenderBounds() override;

--- a/Runtime/World/CScriptWaypoint.cpp
+++ b/Runtime/World/CScriptWaypoint.cpp
@@ -33,7 +33,7 @@ void CScriptWaypoint::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender
       SendScriptMsgs(EScriptObjectState::Arrived, mgr, EScriptObjectMessage::None);
 }
 
-void CScriptWaypoint::AddToRenderer(const zeus::CFrustum&, const CStateManager&) const {
+void CScriptWaypoint::AddToRenderer(const zeus::CFrustum&, CStateManager&) {
   // Empty
 }
 

--- a/Runtime/World/CScriptWaypoint.hpp
+++ b/Runtime/World/CScriptWaypoint.hpp
@@ -25,7 +25,7 @@ public:
 
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   TUniqueId FollowWaypoint(CStateManager& mgr) const;
   TUniqueId NextWaypoint(CStateManager& mgr) const;
   float GetSpeed() const { return xe8_speed; }

--- a/Runtime/World/CSnakeWeedSwarm.cpp
+++ b/Runtime/World/CSnakeWeedSwarm.cpp
@@ -139,14 +139,17 @@ void CSnakeWeedSwarm::PreRender(CStateManager& mgr, const zeus::CFrustum& frustu
   }
 }
 
-void CSnakeWeedSwarm::AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const {
-  if (xe4_30_outOfFrustum)
+void CSnakeWeedSwarm::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
+  if (xe4_30_outOfFrustum) {
     return;
+  }
 
-  if (x1ec_particleGen1)
+  if (x1ec_particleGen1) {
     g_Renderer->AddParticleGen(*x1ec_particleGen1);
-  if (x1f4_particleGen2)
+  }
+  if (x1f4_particleGen2) {
     g_Renderer->AddParticleGen(*x1f4_particleGen2);
+  }
 
   if (x90_actorLights) {
     for (const auto& modelData : x1b0_modelData) {
@@ -158,8 +161,9 @@ void CSnakeWeedSwarm::AddToRenderer(const zeus::CFrustum& frustum, const CStateM
   }
 
   u32 posesToBuild = -1;
-  for (u32 i = 0; i < x134_boids.size(); ++i)
+  for (u32 i = 0; i < x134_boids.size(); ++i) {
     RenderBoid(i, x134_boids[i], posesToBuild);
+  }
   CGraphics::DisableAllLights();
 }
 

--- a/Runtime/World/CSnakeWeedSwarm.hpp
+++ b/Runtime/World/CSnakeWeedSwarm.hpp
@@ -103,7 +103,7 @@ public:
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Touch(CActor&, CStateManager&) override;
   void Think(float, CStateManager&) override;
 

--- a/Runtime/World/CWallCrawlerSwarm.cpp
+++ b/Runtime/World/CWallCrawlerSwarm.cpp
@@ -983,7 +983,7 @@ void CWallCrawlerSwarm::RenderParticles() const {
   }
 }
 
-void CWallCrawlerSwarm::AddToRenderer(const zeus::CFrustum&, const CStateManager& mgr) const {
+void CWallCrawlerSwarm::AddToRenderer(const zeus::CFrustum&, CStateManager& mgr) {
   if (!GetActive()) {
     return;
   }

--- a/Runtime/World/CWallCrawlerSwarm.hpp
+++ b/Runtime/World/CWallCrawlerSwarm.hpp
@@ -195,7 +195,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void AddToRenderer(const zeus::CFrustum&, const CStateManager&) const override;
+  void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   void Render(const CStateManager&) const override;
   bool CanRenderUnsorted(const CStateManager&) const override;
   void CalculateRenderBounds() override;


### PR DESCRIPTION
This member function alters instance state in a few implementations, so it shouldn't be made const. This also allows for the removal of several const_cast usages.

The state manager parameter also shouldn't be const. Retrieved data from the post constructed instance is further modified in some implementations. This removes the constness on this parameter in order to fix more const_cast usages in a follow-up change.