### PR TITLE
CCameraFilter: Make Draw() non-const

### DIFF
--- a/Runtime/Camera/CCameraFilter.cpp
+++ b/Runtime/Camera/CCameraFilter.cpp
@@ -104,9 +104,11 @@ void CCameraFilterPass<S>::DisableFilter(float time) {
 }
 
 template <class S>
-void CCameraFilterPass<S>::Draw() const {
-  if (m_shader)
-    const_cast<S&>(*m_shader).DrawFilter(x8_shape, x18_curColor, GetT(x4_nextType == EFilterType::Passthru));
+void CCameraFilterPass<S>::Draw() {
+  if (!m_shader) {
+    return;
+  }
+  m_shader->DrawFilter(x8_shape, x18_curColor, GetT(x4_nextType == EFilterType::Passthru));
 }
 
 float CCameraFilterPassBase::GetT(bool invert) const {

--- a/Runtime/Camera/CCameraFilter.hpp
+++ b/Runtime/Camera/CCameraFilter.hpp
@@ -58,7 +58,7 @@ public:
   virtual void SetFilter(EFilterType type, EFilterShape shape, float time, const zeus::CColor& color,
                          CAssetId txtr) = 0;
   virtual void DisableFilter(float time) = 0;
-  virtual void Draw() const = 0;
+  virtual void Draw() = 0;
 };
 
 template <class S>
@@ -69,7 +69,7 @@ public:
   void Update(float dt) override;
   void SetFilter(EFilterType type, EFilterShape shape, float time, const zeus::CColor& color, CAssetId txtr) override;
   void DisableFilter(float time) override;
-  void Draw() const override;
+  void Draw() override;
 };
 
 class CCameraFilterPassPoly {
@@ -107,8 +107,8 @@ class CCameraBlurPass {
   // bool x2d_noPersistentCopy = false;
   // u32 x30_persistentBuf = 0;
 
-  mutable std::optional<CCameraBlurFilter> m_shader;
-  mutable std::optional<CXRayBlurFilter> m_xrayShader;
+  std::optional<CCameraBlurFilter> m_shader;
+  std::optional<CXRayBlurFilter> m_xrayShader;
 
 public:
   void Draw(bool clearDepth = false);


### PR DESCRIPTION
Eliminates another usage of const_cast.