### PR TITLE
CGunWeapon: Eliminate usages of const_cast

### DIFF
--- a/Runtime/Character/CAnimData.hpp
+++ b/Runtime/Character/CAnimData.hpp
@@ -223,6 +223,7 @@ public:
   std::shared_ptr<CSkinnedModel> GetXRayModel() const { return xf4_xrayModel; }
   void SetInfraModel(const TLockedToken<CModel>& model, const TLockedToken<CSkinRules>& skinRules);
   std::shared_ptr<CSkinnedModel> GetInfraModel() const { return xf8_infraModel; }
+  TLockedToken<CSkinnedModel>& GetModelData() { return xd8_modelData; }
   const TLockedToken<CSkinnedModel>& GetModelData() const { return xd8_modelData; }
 
   static void PoseSkinnedModel(CSkinnedModel& model, const CPoseAsTransforms& pose, const CModelFlags& drawFlags,

--- a/Runtime/Weapon/CGunWeapon.cpp
+++ b/Runtime/Weapon/CGunWeapon.cpp
@@ -254,7 +254,7 @@ void CGunWeapon::PointGenerator(void* ctx, const std::vector<std::pair<zeus::CVe
 }
 
 void CGunWeapon::Draw(bool drawSuitArm, const CStateManager& mgr, const zeus::CTransform& xf, const CModelFlags& flags,
-                      const CActorLights* lights) const {
+                      const CActorLights* lights) {
   if (!x218_26_loaded)
     return;
 
@@ -498,7 +498,7 @@ void CGunWeapon::Unload(CStateManager& mgr) {
 
 bool CGunWeapon::IsLoaded() const { return x218_26_loaded; }
 
-void CGunWeapon::DrawHologram(const CStateManager& mgr, const zeus::CTransform& xf, const CModelFlags& flags) const {
+void CGunWeapon::DrawHologram(const CStateManager& mgr, const zeus::CTransform& xf, const CModelFlags& flags) {
   if (!x218_26_loaded)
     return;
 
@@ -510,9 +510,9 @@ void CGunWeapon::DrawHologram(const CStateManager& mgr, const zeus::CTransform& 
     CGraphics::SetModelMatrix(xf * zeus::CTransform::Scale(x10_solidModelData->GetScale()));
     // CGraphics::DisableAllLights();
     // g_Renderer->SetAmbientColor(zeus::skWhite);
-    CSkinnedModel& model = const_cast<CSkinnedModel&>(*x60_holoModelData->GetAnimationData()->GetModelData());
+    CSkinnedModel& model = *x60_holoModelData->GetAnimationData()->GetModelData();
     model.GetModelInst()->ActivateLights({CLight::BuildLocalAmbient({}, zeus::skWhite)});
-    const_cast<CGunWeapon*>(this)->x10_solidModelData->GetAnimationData()->Render(model, flags, std::nullopt, nullptr);
+    x10_solidModelData->GetAnimationData()->Render(model, flags, std::nullopt, nullptr);
     // g_Renderer->SetAmbientColor(zeus::skWhite);
     // CGraphics::DisableAllLights();
   }

--- a/Runtime/Weapon/CGunWeapon.hpp
+++ b/Runtime/Weapon/CGunWeapon.hpp
@@ -133,13 +133,13 @@ public:
   void Touch(const CStateManager& mgr);
   void TouchHolo(const CStateManager& mgr);
   virtual void Draw(bool drawSuitArm, const CStateManager& mgr, const zeus::CTransform& xf, const CModelFlags& flags,
-                    const CActorLights* lights) const;
+                    const CActorLights* lights);
   virtual void DrawMuzzleFx(const CStateManager& mgr) const;
   virtual void Update(float dt, CStateManager& mgr);
   virtual void Load(CStateManager& mgr, bool subtypeBasePose);
   virtual void Unload(CStateManager& mgr);
   virtual bool IsLoaded() const;
-  void DrawHologram(const CStateManager& mgr, const zeus::CTransform& xf, const CModelFlags& flags) const;
+  void DrawHologram(const CStateManager& mgr, const zeus::CTransform& xf, const CModelFlags& flags);
   void UpdateMuzzleFx(float dt, const zeus::CVector3f& scale, const zeus::CVector3f& pos, bool emitting);
   const CVelocityInfo& GetVelocityInfo() const { return x1d0_velInfo; }
   void SetRainSplashGenerator(CRainSplashGenerator* g) { x1bc_rainSplashGenerator = g; }

--- a/Runtime/Weapon/CPhazonBeam.cpp
+++ b/Runtime/Weapon/CPhazonBeam.cpp
@@ -167,18 +167,18 @@ void CPhazonBeam::Unload(CStateManager& mgr) {
 
 bool CPhazonBeam::IsLoaded() const { return CGunWeapon::IsLoaded() && x274_24_loaded; }
 
-void CPhazonBeam::DrawClipScaleCube() const {
+void CPhazonBeam::DrawClipScaleCube() {
   // Render AABB as completely transparent object, only modifying Z-buffer
   m_aaboxShaderScale.draw(zeus::skClear);
 }
 
-void CPhazonBeam::DrawClipTranslateCube() const {
+void CPhazonBeam::DrawClipTranslateCube() {
   // Render AABB as completely transparent object, only modifying Z-buffer
   m_aaboxShaderTranslate.draw(zeus::skClear);
 }
 
 void CPhazonBeam::Draw(bool drawSuitArm, const CStateManager& mgr, const zeus::CTransform& xf, const CModelFlags& flags,
-                       const CActorLights* lights) const {
+                       const CActorLights* lights) {
   CPlayerState::EPlayerVisor visor = mgr.GetPlayerState()->GetActiveVisor(mgr);
   bool drawIndirect = visor == CPlayerState::EPlayerVisor::Combat || visor == CPlayerState::EPlayerVisor::Scan;
 

--- a/Runtime/Weapon/CPhazonBeam.hpp
+++ b/Runtime/Weapon/CPhazonBeam.hpp
@@ -22,11 +22,11 @@ class CPhazonBeam final : public CGunWeapon {
   bool x274_26_veinsAlphaActive : 1;
   bool x274_27_phazonVeinsIdx : 1;
   float x278_fireTime = 1.f / 3.f;
-  mutable CAABoxShader m_aaboxShaderScale{true};
-  mutable CAABoxShader m_aaboxShaderTranslate{true};
+  CAABoxShader m_aaboxShaderScale{true};
+  CAABoxShader m_aaboxShaderTranslate{true};
   void ReInitVariables();
-  void DrawClipScaleCube() const;
-  void DrawClipTranslateCube() const;
+  void DrawClipScaleCube();
+  void DrawClipTranslateCube();
 
 public:
   CPhazonBeam(CAssetId characterId, EWeaponType type, TUniqueId playerId, EMaterialTypes playerMaterial,
@@ -49,7 +49,7 @@ public:
   void Unload(CStateManager& mgr) override;
   bool IsLoaded() const override;
   void Draw(bool drawSuitArm, const CStateManager& mgr, const zeus::CTransform& xf, const CModelFlags& flags,
-            const CActorLights* lights) const override;
+            const CActorLights* lights) override;
   void DrawMuzzleFx(const CStateManager& mgr) const override;
 };
 

--- a/Runtime/Weapon/CPlayerGun.cpp
+++ b/Runtime/Weapon/CPlayerGun.cpp
@@ -2129,20 +2129,20 @@ void CPlayerGun::CopyScreenTex() {
   CGraphics::ResolveSpareTexture(g_Viewport);
 }
 
-void CPlayerGun::DrawScreenTex(float z) const {
+void CPlayerGun::DrawScreenTex(float z) {
   // Use CopyScreenTex rendering to draw over framebuffer pixels in front of `z`
   // This is accomplished using orthographic projection quad with sweeping `y` coordinates
   // Depth is set to GEQUAL to obscure pixels in front rather than behind
   m_screenQuad.draw(zeus::skWhite, 1.f, CTexturedQuadFilter::DefaultRect, z);
 }
 
-void CPlayerGun::DrawClipCube(const zeus::CAABox& aabb) const {
+void CPlayerGun::DrawClipCube(const zeus::CAABox& aabb) {
   // Render AABB as completely transparent object, only modifying Z-buffer
   // AABB has already been set in constructor (since it's constant)
   m_aaboxShader.draw(zeus::skClear);
 }
 
-void CPlayerGun::Render(const CStateManager& mgr, const zeus::CVector3f& pos, const CModelFlags& flags) const {
+void CPlayerGun::Render(const CStateManager& mgr, const zeus::CVector3f& pos, const CModelFlags& flags) {
   SCOPED_GRAPHICS_DEBUG_GROUP("CPlayerGun::Render", zeus::skMagenta);
 
   CGraphics::CProjectionState projState = CGraphics::GetProjectionState();

--- a/Runtime/Weapon/CPlayerGun.hpp
+++ b/Runtime/Weapon/CPlayerGun.hpp
@@ -266,9 +266,9 @@ private:
     u32 _dummy = 0;
   };
 
-  mutable CTexturedQuadFilter m_screenQuad{EFilterType::Blend, CGraphics::g_SpareTexture.get(),
-                                           CTexturedQuadFilter::ZTest::GEqualZWrite};
-  mutable CAABoxShader m_aaboxShader{true};
+  CTexturedQuadFilter m_screenQuad{EFilterType::Blend, CGraphics::g_SpareTexture.get(),
+                                   CTexturedQuadFilter::ZTest::GEqualZWrite};
+  CAABoxShader m_aaboxShader{true};
 
   void InitBeamData();
   void InitBombData();
@@ -322,8 +322,8 @@ private:
   void DrawArm(const CStateManager& mgr, const zeus::CVector3f& pos, const CModelFlags& flags) const;
   zeus::CVector3f ConvertToScreenSpace(const zeus::CVector3f& pos, const CGameCamera& cam) const;
   static void CopyScreenTex();
-  void DrawScreenTex(float z) const;
-  void DrawClipCube(const zeus::CAABox& aabb) const;
+  void DrawScreenTex(float z);
+  void DrawClipCube(const zeus::CAABox& aabb);
 
 public:
   explicit CPlayerGun(TUniqueId playerId);
@@ -358,7 +358,7 @@ public:
   void StopContinuousBeam(CStateManager& mgr, bool b1);
   void Update(float grappleSwingT, float cameraBobT, float dt, CStateManager& mgr);
   void PreRender(const CStateManager& mgr, const zeus::CFrustum& frustum, const zeus::CVector3f& camPos);
-  void Render(const CStateManager& mgr, const zeus::CVector3f& pos, const CModelFlags& flags) const;
+  void Render(const CStateManager& mgr, const zeus::CVector3f& pos, const CModelFlags& flags);
   void AddToRenderer(const zeus::CFrustum& frustum, const CStateManager& mgr) const;
   u32 GetLastFireButtonStates() const { return x2ec_lastFireButtonStates; }
   void DropBomb(EBWeapon weapon, CStateManager& mgr);


### PR DESCRIPTION
Eliminates trivial usages of const_cast by making Draw related functions non-const. This also allows removing the mutable specifiers from several shader data members.