### PR TITLE
CMakeLists: Specify /std:c++latest on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,15 @@ endif()
 
 project(urde VERSION 0.1.0)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+# MSVC has a "latest" flag, which always uses the newest standard
+# when available. GCC and Clang posess no such flag, and must be
+# manually enforced. CMake, curiously, also doesn't have a "latest"
+# standard flag either.
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Force shared libs off" FORCE)
 set(BUILD_STATIC_LIBS ON CACHE BOOL "Force static libs on" FORCE)
 
@@ -88,6 +95,7 @@ if(MSVC)
 
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     add_compile_options(
+      /std:c++latest      # Use latest C++ standard.
       /permissive-        # Enforce various standards compliance features.
       /Zc:externConstexpr # Allow extern constexpr variables according to the standard.
       /Zc:throwingNew     # Assume new throws, allowing for better code generation.


### PR DESCRIPTION
Makes use of the latest standards on MSVC, allowing potential compilation issues to be diagnosed as soon as possible