### PR TITLE
CActor: Make Render() a non-const function

### DIFF
--- a/Runtime/CStateManager.cpp
+++ b/Runtime/CStateManager.cpp
@@ -285,24 +285,26 @@ void CStateManager::UpdateThermalVisor() {
   }
 }
 
-void CStateManager::RendererDrawCallback(const void* drawable, const void* ctx, int type) {
-  const CStateManager& mgr = *static_cast<const CStateManager*>(ctx);
+void CStateManager::RendererDrawCallback(void* drawable, void* ctx, int type) {
+  CStateManager& mgr = *static_cast<CStateManager*>(ctx);
   switch (type) {
   case 0: {
-    const CActor& actor = *static_cast<const CActor*>(drawable);
-    if (actor.xc8_drawnToken == mgr.x8dc_objectDrawToken)
+    CActor& actor = *static_cast<CActor*>(drawable);
+    if (actor.xc8_drawnToken == mgr.x8dc_objectDrawToken) {
       break;
-    if (actor.xc6_nextDrawNode != kInvalidUniqueId)
+    }
+    if (actor.xc6_nextDrawNode != kInvalidUniqueId) {
       mgr.RecursiveDrawTree(actor.xc6_nextDrawNode);
+    }
     actor.Render(mgr);
-    const_cast<CActor&>(actor).xc8_drawnToken = mgr.x8dc_objectDrawToken;
+    actor.xc8_drawnToken = mgr.x8dc_objectDrawToken;
     break;
   }
   case 1:
-    static_cast<const CSimpleShadow*>(drawable)->Render(mgr.x8f0_shadowTex);
+    static_cast<CSimpleShadow*>(drawable)->Render(mgr.x8f0_shadowTex);
     break;
   case 2:
-    static_cast<const CDecal*>(drawable)->Render();
+    static_cast<CDecal*>(drawable)->Render();
     break;
   default:
     break;
@@ -316,14 +318,13 @@ bool CStateManager::RenderLast(TUniqueId uid) {
   return true;
 }
 
-void CStateManager::AddDrawableActorPlane(const CActor& actor, const zeus::CPlane& plane,
-                                          const zeus::CAABox& aabb) const {
-  const_cast<CActor&>(actor).SetAddedToken(x8dc_objectDrawToken + 1);
+void CStateManager::AddDrawableActorPlane(CActor& actor, const zeus::CPlane& plane, const zeus::CAABox& aabb) const {
+  actor.SetAddedToken(x8dc_objectDrawToken + 1);
   g_Renderer->AddPlaneObject(&actor, aabb, plane, 0);
 }
 
-void CStateManager::AddDrawableActor(const CActor& actor, const zeus::CVector3f& vec, const zeus::CAABox& aabb) const {
-  const_cast<CActor&>(actor).SetAddedToken(x8dc_objectDrawToken + 1);
+void CStateManager::AddDrawableActor(CActor& actor, const zeus::CVector3f& vec, const zeus::CAABox& aabb) const {
+  actor.SetAddedToken(x8dc_objectDrawToken + 1);
   g_Renderer->AddDrawable(&actor, vec, aabb, 0, IRenderer::EDrawableSorting::SortedCallback);
 }
 
@@ -518,10 +519,11 @@ void CStateManager::DrawDebugStuff() const {
   }
 }
 
-void CStateManager::RenderCamerasAndAreaLights() const {
+void CStateManager::RenderCamerasAndAreaLights() {
   x870_cameraManager->RenderCameras(*this);
-  for (const CCameraFilterPassPoly& filter : xb84_camFilterPasses)
+  for (const CCameraFilterPassPoly& filter : xb84_camFilterPasses) {
     filter.Draw();
+  }
 }
 
 void CStateManager::DrawE3DeathEffect() {
@@ -716,10 +718,13 @@ void CStateManager::DrawWorld() {
   if (areaCount)
     SetupFogForArea(*areaArr[areaCount - 1]);
 
-  for (TUniqueId id : x86c_stateManagerContainer->xf370_)
-    if (const CActor* ent = static_cast<const CActor*>(GetObjectById(id)))
-      if (!thermal || ent->xe6_27_thermalVisorFlags & 0x1)
+  for (const TUniqueId id : x86c_stateManagerContainer->xf370_) {
+    if (auto* ent = static_cast<CActor*>(ObjectById(id))) {
+      if (!thermal || ent->xe6_27_thermalVisorFlags & 0x1) {
         ent->Render(*this);
+      }
+    }
+  }
 
   bool morphingPlayerVisible = false;
   int thermalActorCount = 0;
@@ -784,19 +789,25 @@ void CStateManager::DrawWorld() {
   if (thermal) {
     if (x86c_stateManagerContainer->xf39c_renderLast.size()) {
       CGraphics::SetDepthRange(DEPTH_SCREEN_ACTORS, DEPTH_GUN);
-      for (TUniqueId id : x86c_stateManagerContainer->xf39c_renderLast)
-        if (const CActor* actor = static_cast<const CActor*>(GetObjectById(id)))
-          if (actor->xe6_27_thermalVisorFlags & 0x1)
+      for (const TUniqueId id : x86c_stateManagerContainer->xf39c_renderLast) {
+        if (auto* actor = static_cast<CActor*>(ObjectById(id))) {
+          if (actor->xe6_27_thermalVisorFlags & 0x1) {
             actor->Render(*this);
+          }
+        }
+      }
       CGraphics::SetDepthRange(DEPTH_WORLD, DEPTH_FAR);
     }
     g_Renderer->DoThermalBlendCold();
     xf34_thermalFlag = EThermalDrawFlag::Hot;
 
-    for (TUniqueId id : x86c_stateManagerContainer->xf370_)
-      if (const CActor* actor = static_cast<const CActor*>(GetObjectById(id)))
-        if (actor->xe6_27_thermalVisorFlags & 0x2)
+    for (const TUniqueId id : x86c_stateManagerContainer->xf370_) {
+      if (auto* actor = static_cast<CActor*>(ObjectById(id))) {
+        if (actor->xe6_27_thermalVisorFlags & 0x2) {
           actor->Render(*this);
+        }
+      }
+    }
 
     for (int i = areaCount - 1; i >= 0; --i) {
       const CGameArea& area = *areaArr[i];
@@ -851,10 +862,13 @@ void CStateManager::DrawWorld() {
 
   if (x86c_stateManagerContainer->xf39c_renderLast.size()) {
     CGraphics::SetDepthRange(DEPTH_SCREEN_ACTORS, DEPTH_GUN);
-    for (TUniqueId id : x86c_stateManagerContainer->xf39c_renderLast)
-      if (const CActor* actor = static_cast<const CActor*>(GetObjectById(id)))
-        if (!thermal || actor->xe6_27_thermalVisorFlags & 0x2)
+    for (const TUniqueId id : x86c_stateManagerContainer->xf39c_renderLast) {
+      if (auto* actor = static_cast<CActor*>(ObjectById(id))) {
+        if (!thermal || actor->xe6_27_thermalVisorFlags & 0x2) {
           actor->Render(*this);
+        }
+      }
+    }
     CGraphics::SetDepthRange(DEPTH_WORLD, DEPTH_FAR);
   }
 
@@ -1173,14 +1187,16 @@ bool CStateManager::GetVisSetForArea(TAreaId a, TAreaId b, CPVSVisSet& setOut) c
   return false;
 }
 
-void CStateManager::RecursiveDrawTree(TUniqueId node) const {
-  if (TCastToConstPtr<CActor> actor = GetObjectById(node)) {
+void CStateManager::RecursiveDrawTree(TUniqueId node) {
+  if (const TCastToPtr<CActor> actor = ObjectById(node)) {
     if (x8dc_objectDrawToken != actor->xc8_drawnToken) {
-      if (actor->xc6_nextDrawNode != kInvalidUniqueId)
+      if (actor->xc6_nextDrawNode != kInvalidUniqueId) {
         RecursiveDrawTree(actor->xc6_nextDrawNode);
-      if (x8dc_objectDrawToken == actor->xcc_addedToken)
+      }
+      if (x8dc_objectDrawToken == actor->xcc_addedToken) {
         actor->Render(*this);
-      const_cast<CActor*>(actor.GetPtr())->xc8_drawnToken = x8dc_objectDrawToken;
+      }
+      actor->xc8_drawnToken = x8dc_objectDrawToken;
     }
   }
 }

--- a/Runtime/CStateManager.hpp
+++ b/Runtime/CStateManager.hpp
@@ -221,7 +221,7 @@ private:
   bool m_warping = false;
 
   void UpdateThermalVisor();
-  static void RendererDrawCallback(const void*, const void*, int);
+  static void RendererDrawCallback(void*, void*, int);
 
 public:
   CStateManager(const std::weak_ptr<CRelayTracker>&, const std::weak_ptr<CMapWorldInfo>&,
@@ -231,8 +231,8 @@ public:
 
   u32 GetInputFrameIdx() const { return x8d4_inputFrameIdx; }
   bool RenderLast(TUniqueId);
-  void AddDrawableActorPlane(const CActor& actor, const zeus::CPlane&, const zeus::CAABox& aabb) const;
-  void AddDrawableActor(const CActor& actor, const zeus::CVector3f& vec, const zeus::CAABox& aabb) const;
+  void AddDrawableActorPlane(CActor& actor, const zeus::CPlane&, const zeus::CAABox& aabb) const;
+  void AddDrawableActor(CActor& actor, const zeus::CVector3f& vec, const zeus::CAABox& aabb) const;
   bool SpecialSkipCinematic();
   TAreaId GetVisAreaId() const;
   s32 GetWeaponIdCount(TUniqueId, EWeaponType) const;
@@ -255,7 +255,7 @@ public:
   const std::vector<CLight>& GetDynamicLightList() const { return x8e0_dynamicLights; }
   void BuildDynamicLightListForWorld();
   void DrawDebugStuff() const;
-  void RenderCamerasAndAreaLights() const;
+  void RenderCamerasAndAreaLights();
   void DrawE3DeathEffect();
   void DrawAdditionalFilters();
   zeus::CFrustum SetupDrawFrustum(const SViewport& vp) const;
@@ -275,7 +275,7 @@ public:
   void PreRender();
   void GetCharacterRenderMaskAndTarget(bool thawed, int& mask, int& target) const;
   bool GetVisSetForArea(TAreaId, TAreaId, CPVSVisSet& setOut) const;
-  void RecursiveDrawTree(TUniqueId) const;
+  void RecursiveDrawTree(TUniqueId);
   void SendScriptMsg(CEntity* dest, TUniqueId src, EScriptObjectMessage msg);
   void SendScriptMsg(TUniqueId dest, TUniqueId src, EScriptObjectMessage msg);
   void SendScriptMsg(TUniqueId src, TEditorId dest, EScriptObjectMessage msg, EScriptObjectState state);

--- a/Runtime/Camera/CBallCamera.cpp
+++ b/Runtime/Camera/CBallCamera.cpp
@@ -242,7 +242,7 @@ void CBallCamera::Reset(const zeus::CTransform& xf, CStateManager& mgr) {
   }
 }
 
-void CBallCamera::Render(const CStateManager& mgr) const {
+void CBallCamera::Render(CStateManager& mgr) {
   // Empty
 }
 

--- a/Runtime/Camera/CBallCamera.hpp
+++ b/Runtime/Camera/CBallCamera.hpp
@@ -247,7 +247,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
   void ProcessInput(const CFinalInput& input, CStateManager& mgr) override;
   void Reset(const zeus::CTransform&, CStateManager& mgr) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   EBallCameraBehaviour GetBehaviour() const { return x188_behaviour; }
   EBallCameraState GetState() const { return x400_state; }
   void SetState(EBallCameraState state, CStateManager& mgr);

--- a/Runtime/Camera/CCameraManager.cpp
+++ b/Runtime/Camera/CCameraManager.cpp
@@ -603,9 +603,10 @@ void CCameraManager::ProcessInput(const CFinalInput& input, CStateManager& state
   }
 }
 
-void CCameraManager::RenderCameras(const CStateManager& mgr) {
-  for (CEntity* cam : mgr.GetCameraObjectList())
+void CCameraManager::RenderCameras(CStateManager& mgr) {
+  for (CEntity* cam : mgr.GetCameraObjectList()) {
     static_cast<CGameCamera*>(cam)->Render(mgr);
+  }
 }
 
 void CCameraManager::SetupBallCamera(CStateManager& mgr) {

--- a/Runtime/Camera/CCameraManager.hpp
+++ b/Runtime/Camera/CCameraManager.hpp
@@ -139,7 +139,7 @@ public:
 
   void ProcessInput(const CFinalInput& input, CStateManager& stateMgr);
 
-  void RenderCameras(const CStateManager& mgr);
+  void RenderCameras(CStateManager& mgr);
   void SetupBallCamera(CStateManager& mgr);
   void SetPlayerCamera(CStateManager& mgr, TUniqueId newCamId);
   int GetFluidCounter() const { return x74_fluidCounter; }

--- a/Runtime/Camera/CInterpolationCamera.cpp
+++ b/Runtime/Camera/CInterpolationCamera.cpp
@@ -27,7 +27,7 @@ void CInterpolationCamera::ProcessInput(const CFinalInput& input, CStateManager&
   // Empty
 }
 
-void CInterpolationCamera::Render(const CStateManager& mgr) const {
+void CInterpolationCamera::Render(CStateManager& mgr) {
   // Empty
 }
 

--- a/Runtime/Camera/CInterpolationCamera.hpp
+++ b/Runtime/Camera/CInterpolationCamera.hpp
@@ -30,7 +30,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void ProcessInput(const CFinalInput&, CStateManager& mgr) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   void Reset(const zeus::CTransform&, CStateManager& mgr) override;
   void Think(float, CStateManager&) override;
   void SetInterpolation(const zeus::CTransform& xf, const zeus::CVector3f& lookPos, float maxTime, float positionSpeed,

--- a/Runtime/Camera/CPathCamera.hpp
+++ b/Runtime/Camera/CPathCamera.hpp
@@ -29,7 +29,7 @@ public:
   void Accept(IVisitor&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void Render(const CStateManager&) const override {}
+  void Render(CStateManager&) override {}
   void ProcessInput(const CFinalInput&, CStateManager& mgr) override;
   void Reset(const zeus::CTransform&, CStateManager& mgr) override;
   zeus::CTransform MoveAlongSpline(float, CStateManager&);

--- a/Runtime/Graphics/CBooRenderer.cpp
+++ b/Runtime/Graphics/CBooRenderer.cpp
@@ -72,8 +72,8 @@ public:
   static void Clear();
   static void Sort();
   static void InsertPlaneObject(float closeDist, float farDist, const zeus::CAABox& aabb, bool invertTest,
-                                const zeus::CPlane& plane, bool zOnly, EDrawableType dtype, const void* data);
-  static void Insert(const zeus::CVector3f& pos, const zeus::CAABox& aabb, EDrawableType dtype, const void* data,
+                                const zeus::CPlane& plane, bool zOnly, EDrawableType dtype, void* data);
+  static void Insert(const zeus::CVector3f& pos, const zeus::CAABox& aabb, EDrawableType dtype, void* data,
                      const zeus::CPlane& plane, u16 extraSort);
   static void Shutdown();
   static void Init();
@@ -173,14 +173,14 @@ void Buckets::Sort() {
 }
 
 void Buckets::InsertPlaneObject(float closeDist, float farDist, const zeus::CAABox& aabb, bool invertTest,
-                                const zeus::CPlane& plane, bool zOnly, EDrawableType dtype, const void* data) {
+                                const zeus::CPlane& plane, bool zOnly, EDrawableType dtype, void* data) {
   if (sPlaneObjectData->size() == sPlaneObjectData->capacity()) {
     return;
   }
   sPlaneObjectData->emplace_back(dtype, closeDist, farDist, aabb, invertTest, plane, zOnly, data);
 }
 
-void Buckets::Insert(const zeus::CVector3f& pos, const zeus::CAABox& aabb, EDrawableType dtype, const void* data,
+void Buckets::Insert(const zeus::CVector3f& pos, const zeus::CAABox& aabb, EDrawableType dtype, void* data,
                      const zeus::CPlane& plane, u16 extraSort) {
   if (sData->size() == sData->capacity()) {
     Log.report(logvisor::Fatal, fmt("Rendering buckets filled to capacity"));
@@ -291,12 +291,12 @@ void CBooRenderer::RenderBucketItems(CAreaListItem* item) {
     for (CDrawable* drawable : bucket) {
       switch (drawable->GetType()) {
       case EDrawableType::Particle: {
-        static_cast<CParticleGen*>((void*)drawable->GetData())->Render();
+        static_cast<CParticleGen*>(drawable->GetData())->Render();
         break;
       }
       case EDrawableType::WorldSurface: {
         // SetupRendererStates();
-        CBooSurface* surf = static_cast<CBooSurface*>((void*)drawable->GetData());
+        auto* surf = static_cast<CBooSurface*>(drawable->GetData());
         CBooModel* model = surf->m_parent;
         if (model) {
           ActivateLightsForModel(item, *model);
@@ -988,18 +988,18 @@ void CBooRenderer::PostRenderFogs() {
 void CBooRenderer::SetModelMatrix(const zeus::CTransform& xf) {
   CGraphics::SetModelMatrix(xf);
 }
-void CBooRenderer::AddParticleGen(const CParticleGen& gen) {
+void CBooRenderer::AddParticleGen(CParticleGen& gen) {
   if (auto bounds = gen.GetBounds()) {
     zeus::CVector3f pt = bounds.value().closestPointAlongVector(xb0_viewPlane.normal());
     Buckets::Insert(pt, bounds.value(), EDrawableType::Particle, &gen, xb0_viewPlane, 0);
   }
 }
 
-void CBooRenderer::AddParticleGen(const CParticleGen& gen, const zeus::CVector3f& pos, const zeus::CAABox& bounds) {
+void CBooRenderer::AddParticleGen(CParticleGen& gen, const zeus::CVector3f& pos, const zeus::CAABox& bounds) {
   Buckets::Insert(pos, bounds, EDrawableType::Particle, &gen, xb0_viewPlane, 0);
 }
 
-void CBooRenderer::AddPlaneObject(const void* obj, const zeus::CAABox& aabb, const zeus::CPlane& plane, int type) {
+void CBooRenderer::AddPlaneObject(void* obj, const zeus::CAABox& aabb, const zeus::CPlane& plane, int type) {
   zeus::CVector3f closePoint = aabb.closestPointAlongVector(xb0_viewPlane.normal());
   zeus::CVector3f farPoint = aabb.furthestPointAlongVector(xb0_viewPlane.normal());
   float closeDist = xb0_viewPlane.pointToPlaneDist(closePoint);
@@ -1015,7 +1015,7 @@ void CBooRenderer::AddPlaneObject(const void* obj, const zeus::CAABox& aabb, con
   }
 }
 
-void CBooRenderer::AddDrawable(const void* obj, const zeus::CVector3f& pos, const zeus::CAABox& aabb, int mode,
+void CBooRenderer::AddDrawable(void* obj, const zeus::CVector3f& pos, const zeus::CAABox& aabb, int mode,
                                EDrawableSorting sorting) {
   if (sorting == EDrawableSorting::UnsortedCallback)
     xa8_drawableCallback(obj, xac_callbackContext, mode);
@@ -1023,7 +1023,7 @@ void CBooRenderer::AddDrawable(const void* obj, const zeus::CVector3f& pos, cons
     Buckets::Insert(pos, aabb, EDrawableType(mode + 2), obj, xb0_viewPlane, 0);
 }
 
-void CBooRenderer::SetDrawableCallback(TDrawableCallback cb, const void* ctx) {
+void CBooRenderer::SetDrawableCallback(TDrawableCallback cb, void* ctx) {
   xa8_drawableCallback = cb;
   xac_callbackContext = ctx;
 }

--- a/Runtime/Graphics/CBooRenderer.hpp
+++ b/Runtime/Graphics/CBooRenderer.hpp
@@ -96,7 +96,7 @@ class CBooRenderer final : public IRenderer {
   zeus::CFrustum x44_frustumPlanes;
 
   TDrawableCallback xa8_drawableCallback;
-  const void* xac_callbackContext;
+  void* xac_callbackContext;
 
   zeus::CPlane xb0_viewPlane = {0.f, 1.f, 0.f, 0.f};
 
@@ -212,12 +212,12 @@ public:
   void DrawModelFlat(const CModel& model, const CModelFlags& flags, bool unsortedOnly) override;
   void PostRenderFogs() override;
   void SetModelMatrix(const zeus::CTransform& xf) override;
-  void AddParticleGen(const CParticleGen& gen) override;
-  void AddParticleGen(const CParticleGen& gen, const zeus::CVector3f& pos, const zeus::CAABox& bounds) override;
-  void AddPlaneObject(const void* obj, const zeus::CAABox& aabb, const zeus::CPlane& plane, int type) override;
-  void AddDrawable(const void* obj, const zeus::CVector3f& pos, const zeus::CAABox& aabb, int mode,
+  void AddParticleGen(CParticleGen& gen) override;
+  void AddParticleGen(CParticleGen& gen, const zeus::CVector3f& pos, const zeus::CAABox& bounds) override;
+  void AddPlaneObject(void* obj, const zeus::CAABox& aabb, const zeus::CPlane& plane, int type) override;
+  void AddDrawable(void* obj, const zeus::CVector3f& pos, const zeus::CAABox& aabb, int mode,
                    EDrawableSorting sorting) override;
-  void SetDrawableCallback(TDrawableCallback cb, const void* ctx) override;
+  void SetDrawableCallback(TDrawableCallback cb, void* ctx) override;
   void SetWorldViewpoint(const zeus::CTransform& xf) override;
   void SetPerspective(float fovy, float width, float height, float znear, float zfar) override;
   void SetPerspective(float fovy, float aspect, float znear, float zfar) override;

--- a/Runtime/Graphics/CDrawable.hpp
+++ b/Runtime/Graphics/CDrawable.hpp
@@ -9,17 +9,18 @@ enum class EDrawableType : u16 { WorldSurface, Particle, Actor, SimpleShadow, De
 class CDrawable {
   EDrawableType x0_type;
   u16 x2_extraSort;
-  const void* x4_data;
+  void* x4_data;
   zeus::CAABox x8_aabb;
   float x20_viewDist;
 
 public:
-  CDrawable(EDrawableType dtype, u16 extraSort, float planeDot, const zeus::CAABox& aabb, const void* data)
+  CDrawable(EDrawableType dtype, u16 extraSort, float planeDot, const zeus::CAABox& aabb, void* data)
   : x0_type(dtype), x2_extraSort(extraSort), x4_data(data), x8_aabb(aabb), x20_viewDist(planeDot) {}
 
   EDrawableType GetType() const { return x0_type; }
   const zeus::CAABox& GetBounds() const { return x8_aabb; }
   float GetDistance() const { return x20_viewDist; }
+  void* GetData() { return x4_data; }
   const void* GetData() const { return x4_data; }
   u16 GetExtraSort() const { return x2_extraSort; }
 };

--- a/Runtime/Graphics/CDrawablePlaneObject.hpp
+++ b/Runtime/Graphics/CDrawablePlaneObject.hpp
@@ -14,7 +14,7 @@ class CDrawablePlaneObject : public CDrawable {
 
 public:
   CDrawablePlaneObject(EDrawableType dtype, float closeDist, float farDist, const zeus::CAABox& aabb, bool invertTest,
-                       const zeus::CPlane& plane, bool zOnly, const void* data)
+                       const zeus::CPlane& plane, bool zOnly, void* data)
   : CDrawable(dtype, 0, closeDist, aabb, data), x24_targetBucket(0), x28_farDist(farDist), x2c_plane(plane) {
     x3c_24_invertTest = invertTest;
     x3c_25_zOnly = zOnly;

--- a/Runtime/Graphics/IRenderer.hpp
+++ b/Runtime/Graphics/IRenderer.hpp
@@ -27,7 +27,7 @@ struct SShader;
 
 class IRenderer {
 public:
-  using TDrawableCallback = void (*)(const void*, const void*, int);
+  using TDrawableCallback = void (*)(void*, void*, int);
   using TReflectionCallback = std::function<void(void*, const zeus::CVector3f&)>;
 
   enum class EDrawableSorting { SortedCallback, UnsortedCallback };
@@ -47,12 +47,12 @@ public:
   virtual void DrawModelFlat(const CModel& model, const CModelFlags& flags, bool unsortedOnly) = 0;
   virtual void PostRenderFogs() = 0;
   virtual void SetModelMatrix(const zeus::CTransform& xf) = 0;
-  virtual void AddParticleGen(const CParticleGen& gen) = 0;
-  virtual void AddParticleGen(const CParticleGen& gen, const zeus::CVector3f& pos, const zeus::CAABox& bounds) = 0;
-  virtual void AddPlaneObject(const void* obj, const zeus::CAABox& aabb, const zeus::CPlane& plane, int type) = 0;
-  virtual void AddDrawable(const void* obj, const zeus::CVector3f& pos, const zeus::CAABox& aabb, int mode,
+  virtual void AddParticleGen(CParticleGen& gen) = 0;
+  virtual void AddParticleGen(CParticleGen& gen, const zeus::CVector3f& pos, const zeus::CAABox& bounds) = 0;
+  virtual void AddPlaneObject(void* obj, const zeus::CAABox& aabb, const zeus::CPlane& plane, int type) = 0;
+  virtual void AddDrawable(void* obj, const zeus::CVector3f& pos, const zeus::CAABox& aabb, int mode,
                            EDrawableSorting sorting) = 0;
-  virtual void SetDrawableCallback(TDrawableCallback cb, const void* ctx) = 0;
+  virtual void SetDrawableCallback(TDrawableCallback cb, void* ctx) = 0;
   virtual void SetWorldViewpoint(const zeus::CTransform& xf) = 0;
   virtual void SetPerspective(float fovy, float width, float height, float znear, float zfar) = 0;
   virtual void SetPerspective(float fovy, float aspect, float znear, float zfar) = 0;

--- a/Runtime/MP1/World/CAtomicAlpha.cpp
+++ b/Runtime/MP1/World/CAtomicAlpha.cpp
@@ -50,7 +50,7 @@ void CAtomicAlpha::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CSta
   }
 }
 
-void CAtomicAlpha::Render(const CStateManager& mgr) const {
+void CAtomicAlpha::Render(CStateManager& mgr) {
   if (mgr.GetPlayerState()->GetActiveVisor(mgr) != CPlayerState::EPlayerVisor::XRay && x568_25_invisible)
     return;
 

--- a/Runtime/MP1/World/CAtomicAlpha.hpp
+++ b/Runtime/MP1/World/CAtomicAlpha.hpp
@@ -39,7 +39,7 @@ public:
                CAssetId, bool, bool);
 
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void Think(float, CStateManager&) override;
   void DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node, EUserEventType type, float dt) override;

--- a/Runtime/MP1/World/CBeetle.cpp
+++ b/Runtime/MP1/World/CBeetle.cpp
@@ -151,7 +151,7 @@ void CBeetle::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   CPatterned::PreRender(mgr, frustum);
 }
 
-void CBeetle::Render(const CStateManager& mgr) const {
+void CBeetle::Render(CStateManager& mgr) {
   if (x3fc_flavor == EFlavorType::One && x400_25_alive) {
     zeus::CTransform tailXf = GetLctrTransform("Target_Tail"sv);
     if (x428_damageCooldownTimer >= 0.f && x42c_color.a() == 1.f) {

--- a/Runtime/MP1/World/CBeetle.hpp
+++ b/Runtime/MP1/World/CBeetle.hpp
@@ -67,7 +67,7 @@ public:
   void Think(float dt, CStateManager& mgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
 
   const CDamageVulnerability* GetDamageVulnerability() const override;
   const CDamageVulnerability* GetDamageVulnerability(const zeus::CVector3f& pos, const zeus::CVector3f& dir,

--- a/Runtime/MP1/World/CBloodFlower.cpp
+++ b/Runtime/MP1/World/CBloodFlower.cpp
@@ -143,7 +143,7 @@ void CBloodFlower::LaunchPollenProjectile(const zeus::CTransform& xf, CStateMana
   }
 }
 
-void CBloodFlower::Render(const CStateManager& mgr) const {
+void CBloodFlower::Render(CStateManager& mgr) {
   CPatterned::Render(mgr);
   x574_podEffect->Render(GetActorLights());
 }

--- a/Runtime/MP1/World/CBloodFlower.hpp
+++ b/Runtime/MP1/World/CBloodFlower.hpp
@@ -54,7 +54,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float dt, CStateManager& mgr) override;
   void DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node, EUserEventType type, float dt) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void Touch(CActor&, CStateManager&) override {}
   EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f& v1, const zeus::CVector3f& v2,
                                                          const CWeaponMode& weaponMode,

--- a/Runtime/MP1/World/CBouncyGrenade.cpp
+++ b/Runtime/MP1/World/CBouncyGrenade.cpp
@@ -98,7 +98,7 @@ void CBouncyGrenade::CollidedWith(TUniqueId id, const CCollisionInfoList& list, 
 
 std::optional<zeus::CAABox> CBouncyGrenade::GetTouchBounds() const { return GetModelData()->GetBounds(GetTransform()); }
 
-void CBouncyGrenade::Render(const CStateManager& mgr) const {
+void CBouncyGrenade::Render(CStateManager& mgr) {
   if (!x2b4_24_exploded) {
     GetModelData()->Render(mgr, GetTransform(), nullptr, {0, 0, 3, zeus::skWhite});
   } else if (mgr.GetPlayerState()->GetActiveVisor(mgr) == CPlayerState::EPlayerVisor::XRay) {

--- a/Runtime/MP1/World/CBouncyGrenade.hpp
+++ b/Runtime/MP1/World/CBouncyGrenade.hpp
@@ -80,7 +80,7 @@ public:
   void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void CollidedWith(TUniqueId id, const CCollisionInfoList& list, CStateManager& mgr) override;
   [[nodiscard]] std::optional<zeus::CAABox> GetTouchBounds() const override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void Think(float dt, CStateManager& mgr) override;
   void Touch(CActor& act, CStateManager& mgr) override;
 

--- a/Runtime/MP1/World/CChozoGhost.cpp
+++ b/Runtime/MP1/World/CChozoGhost.cpp
@@ -212,7 +212,7 @@ void CChozoGhost::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
                               *GetBodyController());
 }
 
-void CChozoGhost::Render(const CStateManager& mgr) const {
+void CChozoGhost::Render(CStateManager& mgr) {
   if (x6c8_spaceWarpTime > 0.f)
     mgr.DrawSpaceWarp(x6cc_spaceWarpPosition, std::sin((M_PIF * x6c8_spaceWarpTime) / x56c_fadeOutDelay));
 

--- a/Runtime/MP1/World/CChozoGhost.hpp
+++ b/Runtime/MP1/World/CChozoGhost.hpp
@@ -109,7 +109,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
   void Think(float dt, CStateManager&) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void Touch(CActor& act, CStateManager& mgr) override;
   EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f& pos, const zeus::CVector3f& dir,
                                                          const CWeaponMode& mode,

--- a/Runtime/MP1/World/CFlickerBat.cpp
+++ b/Runtime/MP1/World/CFlickerBat.cpp
@@ -96,7 +96,7 @@ void CFlickerBat::Think(float dt, CStateManager& mgr) {
   CPatterned::Think(dt, mgr);
 }
 
-void CFlickerBat::Render(const CStateManager& mgr) const {
+void CFlickerBat::Render(CStateManager& mgr) {
   if (!x580_24_wasInXray && x580_26_inLOS &&
       (GetFlickerBatState() == EFlickerBatState::FadeIn || GetFlickerBatState() == EFlickerBatState::FadeOut)) {
     float strength = 0.f;

--- a/Runtime/MP1/World/CFlickerBat.hpp
+++ b/Runtime/MP1/World/CFlickerBat.hpp
@@ -31,7 +31,7 @@ public:
   void Accept(IVisitor&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   void Touch(CActor&, CStateManager&) override;
   void DoUserAnimEvent(CStateManager&, const CInt32POINode&, EUserEventType, float dt) override;
   void Death(CStateManager& mgr, const zeus::CVector3f& direction, EScriptObjectState state) override;

--- a/Runtime/MP1/World/CGrenadeLauncher.cpp
+++ b/Runtime/MP1/World/CGrenadeLauncher.cpp
@@ -137,7 +137,7 @@ void CGrenadeLauncher::PreRender(CStateManager& mgr, const zeus::CFrustum& frust
   CActor::PreRender(mgr, frustum);
 }
 
-void CGrenadeLauncher::Render(const CStateManager& mgr) const {
+void CGrenadeLauncher::Render(CStateManager& mgr) {
   if (x3fd_visible) {
     CPhysicsActor::Render(mgr);
   }

--- a/Runtime/MP1/World/CGrenadeLauncher.hpp
+++ b/Runtime/MP1/World/CGrenadeLauncher.hpp
@@ -104,7 +104,7 @@ public:
   [[nodiscard]] std::optional<zeus::CAABox> GetTouchBounds() const override;
   CHealthInfo* HealthInfo(CStateManager& mgr) override { return &x25c_healthInfo; }
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void Think(float dt, CStateManager& mgr) override;
   void Touch(CActor& act, CStateManager& mgr) override;
 

--- a/Runtime/MP1/World/CMetroidBeta.cpp
+++ b/Runtime/MP1/World/CMetroidBeta.cpp
@@ -170,70 +170,106 @@ void CMetroidBeta::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CSta
     break;
   }
 }
+
 void CMetroidBeta::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) {
   CPatterned::AddToRenderer(frustum, mgr);
 }
-void CMetroidBeta::Render(const CStateManager& mgr) const { CPatterned::Render(mgr); }
+
+void CMetroidBeta::Render(CStateManager& mgr) { CPatterned::Render(mgr); }
+
 const CDamageVulnerability* CMetroidBeta::GetDamageVulnerability() const { return CAi::GetDamageVulnerability(); }
+
 const CDamageVulnerability* CMetroidBeta::GetDamageVulnerability(const zeus::CVector3f& vec1,
                                                                  const zeus::CVector3f& vec2,
                                                                  const CDamageInfo& dInfo) const {
   return CActor::GetDamageVulnerability(vec1, vec2, dInfo);
 }
+
 void CMetroidBeta::Touch(CActor& act, CStateManager& mgr) { CPatterned::Touch(act, mgr); }
+
 zeus::CVector3f CMetroidBeta::GetAimPosition(const CStateManager& mgr, float dt) const {
   return CPatterned::GetAimPosition(mgr, dt);
 }
+
 void CMetroidBeta::DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node, EUserEventType eType, float dt) {
   CPatterned::DoUserAnimEvent(mgr, node, eType, dt);
 }
+
 const CCollisionPrimitive* CMetroidBeta::GetCollisionPrimitive() const {
   return CPhysicsActor::GetCollisionPrimitive();
 }
+
 void CMetroidBeta::CollidedWith(TUniqueId collidee, const CCollisionInfoList& info, CStateManager& mgr) {
   CPatterned::CollidedWith(collidee, info, mgr);
 }
+
 zeus::CVector3f CMetroidBeta::GetOrigin(const CStateManager& mgr, const CTeamAiRole& role,
                                         const zeus::CVector3f& aimPos) const {
   return CAi::GetOrigin(mgr, role, aimPos);
 }
+
 void CMetroidBeta::Patrol(CStateManager& mgr, EStateMsg msg, float arg) { CPatterned::Patrol(mgr, msg, arg); }
+
 void CMetroidBeta::PathFind(CStateManager& mgr, EStateMsg msg, float arg) { CPatterned::PathFind(mgr, msg, arg); }
+
 void CMetroidBeta::SelectTarget(CStateManager& mgr, EStateMsg msg, float arg) { CAi::SelectTarget(mgr, msg, arg); }
+
 void CMetroidBeta::TargetPatrol(CStateManager& mgr, EStateMsg msg, float arg) {
   CPatterned::TargetPatrol(mgr, msg, arg);
 }
+
 void CMetroidBeta::Generate(CStateManager& mgr, EStateMsg msg, float arg) {
   CAi::Generate(mgr, msg, arg);
 }
+
 void CMetroidBeta::Attack(CStateManager& mgr, EStateMsg msg, float arg) { CAi::Attack(mgr, msg, arg); }
+
 void CMetroidBeta::TurnAround(CStateManager& mgr, EStateMsg msg, float arg) { CAi::TurnAround(mgr, msg, arg); }
+
 void CMetroidBeta::TelegraphAttack(CStateManager& mgr, EStateMsg msg, float arg) {
   CAi::TelegraphAttack(mgr, msg, arg);
 }
+
 void CMetroidBeta::WallHang(CStateManager& mgr, EStateMsg msg, float arg) { CAi::WallHang(mgr, msg, arg); }
+
 void CMetroidBeta::SpecialAttack(CStateManager& mgr, EStateMsg msg, float arg) { CAi::SpecialAttack(mgr, msg, arg); }
+
 bool CMetroidBeta::InAttackPosition(CStateManager& mgr, float arg) { return CAi::InAttackPosition(mgr, arg); }
+
 bool CMetroidBeta::Attacked(CStateManager& mgr, float arg) { return CPatterned::Attacked(mgr, arg); }
+
 bool CMetroidBeta::PathShagged(CStateManager& mgr, float arg) { return CPatterned::PathShagged(mgr, arg); }
+
 bool CMetroidBeta::InDetectionRange(CStateManager& mgr, float arg) { return CPatterned::InDetectionRange(mgr, arg); }
+
 bool CMetroidBeta::AnimOver(CStateManager& mgr, float arg) { return CPatterned::AnimOver(mgr, arg); }
+
 bool CMetroidBeta::ShouldAttack(CStateManager& mgr, float arg) { return CAi::ShouldAttack(mgr, arg); }
+
 bool CMetroidBeta::InPosition(CStateManager& mgr, float arg) { return CPatterned::InPosition(mgr, arg); }
+
 bool CMetroidBeta::ShouldTurn(CStateManager& mgr, float arg) { return CAi::ShouldTurn(mgr, arg); }
+
 bool CMetroidBeta::AttackOver(CStateManager& mgr, float arg) { return CAi::AttackOver(mgr, arg); }
+
 bool CMetroidBeta::ShotAt(CStateManager& mgr, float arg) { return CAi::ShotAt(mgr, arg); }
+
 bool CMetroidBeta::ShouldWallHang(CStateManager& mgr, float arg) { return CAi::ShouldWallHang(mgr, arg); }
+
 bool CMetroidBeta::StartAttack(CStateManager& mgr, float arg) { return CAi::StartAttack(mgr, arg); }
+
 bool CMetroidBeta::BreakAttack(CStateManager& mgr, float arg) { return CAi::BreakAttack(mgr, arg); }
+
 bool CMetroidBeta::ShouldSpecialAttack(CStateManager& mgr, float arg) { return CAi::ShouldSpecialAttack(mgr, arg); }
 
 void CMetroidBeta::RenderHitGunEffect() const {}
 
 void CMetroidBeta::RenderHitBallEffect() const {}
+
 static SSphereJointInfo skPelvisInfo[1] {
     {"Pelvis", 1.5f},
 };
+
 void CMetroidBeta::CreateCollisionActorManager(CStateManager& mgr) {
   std::vector<CJointCollisionDescription> joints;
   AddSphereJoints(skPelvisInfo, 1, joints);
@@ -272,6 +308,7 @@ void CMetroidBeta::AddSphereJoints(SSphereJointInfo* sphereJoints, s32 count,
     joints.push_back(CJointCollisionDescription::SphereCollision(id, sphereJoint.radius, sphereJoint.name, 1000.0f));
   }
 }
+
 void CMetroidBeta::SetCollisionActorHealthAndVulnerability(CStateManager& mgr) {
   CHealthInfo* hInfo = HealthInfo(mgr);
   if (TCastToPtr<CCollisionActor> colAct = mgr.ObjectById(x790_)) {
@@ -279,6 +316,7 @@ void CMetroidBeta::SetCollisionActorHealthAndVulnerability(CStateManager& mgr) {
     colAct->SetDamageVulnerability(*GetDamageVulnerability());
   }
 }
+
 void CMetroidBeta::RemoveFromTeam(CStateManager& mgr) {
   if (x678_teamMgr == kInvalidUniqueId)
     return;
@@ -288,6 +326,7 @@ void CMetroidBeta::RemoveFromTeam(CStateManager& mgr) {
       teamMgr->RemoveTeamAiRole(GetUniqueId());
   }
 }
+
 void CMetroidBeta::AddToTeam(CStateManager& mgr) {
   if (x678_teamMgr == kInvalidUniqueId)
     return;

--- a/Runtime/MP1/World/CMetroidBeta.hpp
+++ b/Runtime/MP1/World/CMetroidBeta.hpp
@@ -103,7 +103,7 @@ public:
   void Think(float dt, CStateManager& mgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
   void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   const CDamageVulnerability* GetDamageVulnerability() const override;
   const CDamageVulnerability* GetDamageVulnerability(const zeus::CVector3f& vec1, const zeus::CVector3f& vec2,
                                                      const CDamageInfo& dInfo) const override;

--- a/Runtime/MP1/World/CParasite.cpp
+++ b/Runtime/MP1/World/CParasite.cpp
@@ -303,7 +303,7 @@ void CParasite::Think(float dt, CStateManager& mgr) {
   x742_27_landed = false;
 }
 
-void CParasite::Render(const CStateManager& mgr) const { CWallWalker::Render(mgr); }
+void CParasite::Render(CStateManager& mgr) { CWallWalker::Render(mgr); }
 
 const CDamageVulnerability* CParasite::GetDamageVulnerability() const {
   switch (x5d0_walkerType) {

--- a/Runtime/MP1/World/CParasite.hpp
+++ b/Runtime/MP1/World/CParasite.hpp
@@ -117,7 +117,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PreThink(float, CStateManager&) override;
   void Think(float dt, CStateManager& mgr) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   const CDamageVulnerability* GetDamageVulnerability() const override;
   CDamageInfo GetContactDamage() const override;
   void Touch(CActor& actor, CStateManager&) override;

--- a/Runtime/MP1/World/CPuddleSpore.cpp
+++ b/Runtime/MP1/World/CPuddleSpore.cpp
@@ -134,7 +134,7 @@ void CPuddleSpore::Think(float dt, CStateManager& mgr) {
   CPatterned::Think(dt, mgr);
 }
 
-void CPuddleSpore::Render(const CStateManager& mgr) const {
+void CPuddleSpore::Render(CStateManager& mgr) {
   CPatterned::Render(mgr);
   if (x56c_ > 0.01f) {
     for (const auto& elemGen : x5dc_elemGens)

--- a/Runtime/MP1/World/CPuddleSpore.hpp
+++ b/Runtime/MP1/World/CPuddleSpore.hpp
@@ -46,7 +46,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
   void PreThink(float, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   void Touch(CActor&, CStateManager&) override;
   void FluidFXThink(EFluidState, CScriptWater&, CStateManager&) override;
   void KnockBack(const zeus::CVector3f& dir, CStateManager& mgr, const CDamageInfo& dInfo, EKnockBackType type,

--- a/Runtime/MP1/World/CRidley.cpp
+++ b/Runtime/MP1/World/CRidley.cpp
@@ -669,7 +669,7 @@ void CRidley::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
   }
 }
 
-void CRidley::Render(const CStateManager& mgr) const {
+void CRidley::Render(CStateManager& mgr) {
   zeus::CColor multiplyColor = zeus::skBlack;
   if (xb24_ > 0.f) {
     multiplyColor = zeus::CColor::lerp(zeus::skWhite, x430_damageColor, xb24_ / 0.33f);

--- a/Runtime/MP1/World/CRidley.hpp
+++ b/Runtime/MP1/World/CRidley.hpp
@@ -206,7 +206,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
   void Think(float dt, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   zeus::CAABox GetSortingBounds(const CStateManager&) const override { return GetBoundingBox(); }
   const CDamageVulnerability* GetDamageVulnerability() const override {

--- a/Runtime/MP1/World/CSeedling.cpp
+++ b/Runtime/MP1/World/CSeedling.cpp
@@ -107,7 +107,7 @@ void CSeedling::Think(float dt, CStateManager& mgr) {
     x71c_attackCoolOff -= dt;
 }
 
-void CSeedling::Render(const CStateManager& mgr) const {
+void CSeedling::Render(CStateManager& mgr) {
   if (x400_25_alive && x6bc_spikeData) {
     const size_t index = x722_24_renderOnlyClusterA ? 0 : size_t(x722_25_curNeedleCluster);
     CModelFlags flags;

--- a/Runtime/MP1/World/CSeedling.hpp
+++ b/Runtime/MP1/World/CSeedling.hpp
@@ -31,7 +31,7 @@ public:
   void Accept(IVisitor&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   void DoUserAnimEvent(CStateManager& mgr, const CInt32POINode& node, EUserEventType type, float dt) override;
   CProjectileInfo* GetProjectileInfo() override { return &x6c0_projectileInfo; }
   std::optional<zeus::CAABox> GetTouchBounds() const override;

--- a/Runtime/MP1/World/CShockWave.cpp
+++ b/Runtime/MP1/World/CShockWave.cpp
@@ -65,7 +65,7 @@ std::optional<zeus::CAABox> CShockWave::GetTouchBounds() const {
   return zeus::CAABox({-x150_, -x150_, 0.f}, {x150_, x150_, 1.f}).getTransformedAABox(GetTransform());
 }
 
-void CShockWave::Render(const CStateManager& mgr) const {
+void CShockWave::Render(CStateManager& mgr) {
   CActor::Render(mgr);
   x110_elementGen->Render();
 }

--- a/Runtime/MP1/World/CShockWave.hpp
+++ b/Runtime/MP1/World/CShockWave.hpp
@@ -59,7 +59,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
   void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   [[nodiscard]] std::optional<zeus::CAABox> GetTouchBounds() const override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void Think(float dt, CStateManager& mgr) override;
   void Touch(CActor& actor, CStateManager& mgr) override;
 

--- a/Runtime/MP1/World/CSpacePirate.cpp
+++ b/Runtime/MP1/World/CSpacePirate.cpp
@@ -1060,7 +1060,7 @@ void CSpacePirate::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) 
   }
 }
 
-void CSpacePirate::Render(const CStateManager& mgr) const {
+void CSpacePirate::Render(CStateManager& mgr) {
   float time = x400_25_alive ? CGraphics::GetSecondsMod900() : 0.f;
   CTimeProvider prov(time);
   g_Renderer->SetGXRegister1Color(x8cc_trooperColor);

--- a/Runtime/MP1/World/CSpacePirate.hpp
+++ b/Runtime/MP1/World/CSpacePirate.hpp
@@ -245,7 +245,7 @@ public:
   void Think(float dt, CStateManager& mgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
 
   void CalculateRenderBounds() override;
   void Touch(CActor& other, CStateManager& mgr) override;

--- a/Runtime/MP1/World/CThardus.cpp
+++ b/Runtime/MP1/World/CThardus.cpp
@@ -443,7 +443,7 @@ void CThardus::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) {
     xb4_drawFlags = CModelFlags(0, 0, 3, zeus::skWhite);
   }
 }
-void CThardus::Render(const CStateManager& mgr) const {
+void CThardus::Render(CStateManager& mgr) {
   CPatterned::Render(mgr);
   if (mgr.GetPlayerState()->GetActiveVisor(mgr) == CPlayerState::EPlayerVisor::Thermal && x7c4_ != 0) {
     RenderFlare(mgr, x7c0_);

--- a/Runtime/MP1/World/CThardus.hpp
+++ b/Runtime/MP1/World/CThardus.hpp
@@ -177,7 +177,7 @@ public:
   void Think(float dt, CStateManager& mgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   bool CanRenderUnsorted(const CStateManager&) const override { return false; }
   void Touch(CActor& act, CStateManager& mgr) override;
   zeus::CVector3f GetOrbitPosition(const CStateManager& mgr) const override;

--- a/Runtime/Particle/CDecal.cpp
+++ b/Runtime/Particle/CDecal.cpp
@@ -164,7 +164,7 @@ void CDecal::RenderQuad(CQuadDecal& decal, const SQuadDescr& desc) const {
   }
 }
 
-void CDecal::RenderMdl() const {
+void CDecal::RenderMdl() {
   const CDecalDescription& desc = *x0_description;
   zeus::CColor color = zeus::skWhite;
   zeus::CVector3f dmop;
@@ -179,7 +179,7 @@ void CDecal::RenderMdl() const {
 
   zeus::CTransform dmrtXf;
   if (dmrtIsConst) {
-    desc.x50_DMRT->GetValue(x58_frameIdx, const_cast<zeus::CVector3f&>(x60_rotation));
+    desc.x50_DMRT->GetValue(x58_frameIdx, x60_rotation);
     dmrtXf = zeus::CTransform::RotateZ(zeus::degToRad(x60_rotation.z()));
     dmrtXf.rotateLocalY(zeus::degToRad(x60_rotation.y()));
     dmrtXf.rotateLocalX(zeus::degToRad(x60_rotation.x()));
@@ -232,7 +232,7 @@ void CDecal::RenderMdl() const {
   }
 }
 
-void CDecal::Render() const {
+void CDecal::Render() {
   SCOPED_GRAPHICS_DEBUG_GROUP("CDecal::Render", zeus::skYellow);
   CGlobalRandom gr(sDecalRandom);
   if (x5c_29_modelInvalid && x5c_30_quad2Invalid && x5c_31_quad1Invalid)
@@ -245,12 +245,12 @@ void CDecal::Render() const {
   if (desc.x0_Quads[0].x14_TEX && !x5c_31_quad1Invalid) {
     CParticleGlobals::instance()->SetParticleLifetime(x3c_decalQuads[0].x4_lifetime);
     CParticleGlobals::instance()->UpdateParticleLifetimeTweenValues(x58_frameIdx);
-    RenderQuad(const_cast<CQuadDecal&>(x3c_decalQuads[0]), desc.x0_Quads[0]);
+    RenderQuad(x3c_decalQuads[0], desc.x0_Quads[0]);
   }
   if (desc.x0_Quads[1].x14_TEX && !x5c_30_quad2Invalid) {
     CParticleGlobals::instance()->SetParticleLifetime(x3c_decalQuads[1].x4_lifetime);
     CParticleGlobals::instance()->UpdateParticleLifetimeTweenValues(x58_frameIdx);
-    RenderQuad(const_cast<CQuadDecal&>(x3c_decalQuads[1]), desc.x0_Quads[1]);
+    RenderQuad(x3c_decalQuads[1], desc.x0_Quads[1]);
   }
   if (desc.x38_DMDL && !x5c_29_modelInvalid) {
     CParticleGlobals::instance()->SetParticleLifetime(x54_modelLifetime);

--- a/Runtime/Particle/CDecal.hpp
+++ b/Runtime/Particle/CDecal.hpp
@@ -55,8 +55,8 @@ class CDecal {
 public:
   CDecal(const TToken<CDecalDescription>& desc, const zeus::CTransform& xf);
   void RenderQuad(CQuadDecal& decal, const SQuadDescr& desc) const;
-  void RenderMdl() const;
-  void Render() const;
+  void RenderMdl();
+  void Render();
   void Update(float dt);
 
   static void SetGlobalSeed(u16);

--- a/Runtime/Weapon/CBomb.hpp
+++ b/Runtime/Weapon/CBomb.hpp
@@ -34,7 +34,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override {}
+  void Render(CStateManager&) override {}
   void Touch(CActor&, CStateManager&) override;
   void Explode(const zeus::CVector3f&, CStateManager&);
   void UpdateLight(float, CStateManager&);

--- a/Runtime/Weapon/CEnergyProjectile.cpp
+++ b/Runtime/Weapon/CEnergyProjectile.cpp
@@ -185,7 +185,7 @@ void CEnergyProjectile::Think(float dt, CStateManager& mgr) {
     mgr.FreeScriptObject(GetUniqueId());
 }
 
-void CEnergyProjectile::Render(const CStateManager& mgr) const {
+void CEnergyProjectile::Render(CStateManager& mgr) {
   SCOPED_GRAPHICS_DEBUG_GROUP(fmt::format(fmt("CEnergyProjectile::Render WPSC_{}"), x2cc_wpscId).c_str(), zeus::skOrange);
 
   CPlayerState::EPlayerVisor visor = mgr.GetPlayerState()->GetActiveVisor(mgr);

--- a/Runtime/Weapon/CEnergyProjectile.hpp
+++ b/Runtime/Weapon/CEnergyProjectile.hpp
@@ -39,7 +39,7 @@ public:
   void ResolveCollisionWithWorld(const CRayCastResult& res, CStateManager& mgr);
   void ResolveCollisionWithActor(const CRayCastResult& res, CActor& act, CStateManager& mgr);
   void Think(float dt, CStateManager& mgr);
-  void Render(const CStateManager& mgr) const;
+  void Render(CStateManager& mgr);
   void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr);
   void Touch(CActor& act, CStateManager& mgr);
   virtual bool Explode(const zeus::CVector3f& pos, const zeus::CVector3f& normal, EWeaponCollisionResponseTypes type,

--- a/Runtime/Weapon/CFlameThrower.cpp
+++ b/Runtime/Weapon/CFlameThrower.cpp
@@ -95,7 +95,7 @@ void CFlameThrower::AddToRenderer(const zeus::CFrustum&, CStateManager& mgr) {
   EnsureRendered(mgr, x2e8_flameXf.origin, GetRenderBounds());
 }
 
-void CFlameThrower::Render(const CStateManager&) const {}
+void CFlameThrower::Render(CStateManager&) {}
 
 std::optional<zeus::CAABox> CFlameThrower::GetTouchBounds() const { return std::nullopt; }
 

--- a/Runtime/Weapon/CFlameThrower.hpp
+++ b/Runtime/Weapon/CFlameThrower.hpp
@@ -57,7 +57,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void Touch(CActor& actor, CStateManager& mgr) override;
   void SetTransform(const zeus::CTransform& xf, float);

--- a/Runtime/Weapon/CPlasmaProjectile.cpp
+++ b/Runtime/Weapon/CPlasmaProjectile.cpp
@@ -404,7 +404,7 @@ void CPlasmaProjectile::AddToRenderer(const zeus::CFrustum& frustum, CStateManag
   EnsureRendered(mgr, GetBeamTransform().origin, GetSortingBounds(mgr));
 }
 
-void CPlasmaProjectile::Render(const CStateManager& mgr) const {
+void CPlasmaProjectile::Render(CStateManager& mgr) {
   if (!GetActive())
     return;
   SCOPED_GRAPHICS_DEBUG_GROUP("CPlasmaProjectile::Render", zeus::skOrange);

--- a/Runtime/Weapon/CPlasmaProjectile.hpp
+++ b/Runtime/Weapon/CPlasmaProjectile.hpp
@@ -122,6 +122,6 @@ public:
   void Touch(CActor& other, CStateManager& mgr) override;
   bool CanRenderUnsorted(const CStateManager& mgr) const override;
   void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
 };
 } // namespace urde

--- a/Runtime/Weapon/CPowerBomb.hpp
+++ b/Runtime/Weapon/CPowerBomb.hpp
@@ -28,7 +28,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override {}
+  void Render(CStateManager&) override {}
   std::optional<zeus::CAABox> GetTouchBounds() const override { return std::nullopt; }
   void Touch(CActor&, CStateManager&) override { /*x158_24_canStartFilter; */
   }

--- a/Runtime/Weapon/CWeapon.cpp
+++ b/Runtime/Weapon/CWeapon.cpp
@@ -37,7 +37,7 @@ void CWeapon::Think(float dt, CStateManager& mgr) {
   CEntity::Think(dt, mgr);
 }
 
-void CWeapon::Render(const CStateManager&) const {
+void CWeapon::Render(CStateManager&) {
   // Empty
 }
 

--- a/Runtime/Weapon/CWeapon.hpp
+++ b/Runtime/Weapon/CWeapon.hpp
@@ -45,7 +45,7 @@ public:
   void SetInterferenceDuration(float dur) { x154_interferenceDuration = dur; }
 
   void Think(float, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
                                                          const CWeaponMode&, EProjectileAttrib) const override;
   void FluidFXThink(EFluidState state, CScriptWater& water, CStateManager& mgr) override;

--- a/Runtime/World/CActor.cpp
+++ b/Runtime/World/CActor.cpp
@@ -257,7 +257,7 @@ bool CActor::IsModelOpaque(const CStateManager& mgr) const {
   return x64_modelData->IsDefinitelyOpaque(CModelData::GetRenderingModel(mgr));
 }
 
-void CActor::Render(const CStateManager& mgr) const {
+void CActor::Render(CStateManager& mgr) {
   if (x64_modelData && !x64_modelData->IsNull()) {
     bool renderPrePostParticles = xe6_29_renderParticleDBInside && x64_modelData && x64_modelData->HasAnimData();
     if (renderPrePostParticles)
@@ -512,12 +512,12 @@ float CActor::GetPitch() const { return zeus::CQuaternion(x34_transform.buildMat
 
 float CActor::GetYaw() const { return zeus::CQuaternion(x34_transform.buildMatrix3f()).yaw(); }
 
-void CActor::EnsureRendered(const CStateManager& mgr) const {
-  zeus::CAABox aabb = GetSortingBounds(mgr);
+void CActor::EnsureRendered(const CStateManager& mgr) {
+  const zeus::CAABox aabb = GetSortingBounds(mgr);
   EnsureRendered(mgr, aabb.closestPointAlongVector(CGraphics::g_ViewMatrix.basis[1]), aabb);
 }
 
-void CActor::EnsureRendered(const CStateManager& stateMgr, const zeus::CVector3f& pos, const zeus::CAABox& aabb) const {
+void CActor::EnsureRendered(const CStateManager& stateMgr, const zeus::CVector3f& pos, const zeus::CAABox& aabb) {
   if (x64_modelData) {
     x64_modelData->RenderUnsortedParts(x64_modelData->GetRenderingModel(stateMgr), x34_transform, x90_actorLights.get(),
                                        xb4_drawFlags);

--- a/Runtime/World/CActor.hpp
+++ b/Runtime/World/CActor.hpp
@@ -109,7 +109,7 @@ public:
   }
   virtual void PreRender(CStateManager&, const zeus::CFrustum&);
   virtual void AddToRenderer(const zeus::CFrustum&, CStateManager&);
-  virtual void Render(const CStateManager&) const;
+  virtual void Render(CStateManager&);
   virtual bool CanRenderUnsorted(const CStateManager&) const;
   virtual void CalculateRenderBounds();
   virtual CHealthInfo* HealthInfo(CStateManager&);
@@ -168,8 +168,8 @@ public:
   float GetYaw() const;
   const CModelData* GetModelData() const { return x64_modelData.get(); }
   CModelData* GetModelData() { return x64_modelData.get(); }
-  void EnsureRendered(const CStateManager&) const;
-  void EnsureRendered(const CStateManager&, const zeus::CVector3f&, const zeus::CAABox&) const;
+  void EnsureRendered(const CStateManager&);
+  void EnsureRendered(const CStateManager&, const zeus::CVector3f&, const zeus::CAABox&);
   void ProcessSoundEvent(u32 sfxId, float weight, u32 flags, float falloff, float maxDist, float minVol, float maxVol,
                          const zeus::CVector3f& toListener, const zeus::CVector3f& position, TAreaId aid,
                          CStateManager& mgr, bool translateId);

--- a/Runtime/World/CEffect.hpp
+++ b/Runtime/World/CEffect.hpp
@@ -9,7 +9,7 @@ public:
   CEffect(TUniqueId uid, const CEntityInfo& info, bool active, std::string_view name, const zeus::CTransform& xf);
 
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
-  void Render(const CStateManager&) const override {}
+  void Render(CStateManager&) override {}
 };
 
 } // namespace urde

--- a/Runtime/World/CExplosion.cpp
+++ b/Runtime/World/CExplosion.cpp
@@ -103,7 +103,7 @@ void CExplosion::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr
   EnsureRendered(mgr);
 }
 
-void CExplosion::Render(const CStateManager& mgr) const {
+void CExplosion::Render(CStateManager& mgr) {
   if (mgr.GetThermalDrawFlag() == EThermalDrawFlag::Hot && xf4_24_renderThermalHot) {
     CElementGen::SetSubtractBlend(true);
     CBooModel::SetRenderModelBlack(true);

--- a/Runtime/World/CExplosion.hpp
+++ b/Runtime/World/CExplosion.hpp
@@ -34,7 +34,7 @@ public:
   void Think(float, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   bool CanRenderUnsorted(const CStateManager&) const override;
 };
 

--- a/Runtime/World/CFishCloud.cpp
+++ b/Runtime/World/CFishCloud.cpp
@@ -522,7 +522,7 @@ void CFishCloud::RenderBoid(int idx, const CBoid& boid, u32& drawMask,
   }
 }
 
-void CFishCloud::Render(const CStateManager& mgr) const {
+void CFishCloud::Render(CStateManager& mgr) {
   if (!GetActive())
     return;
   SCOPED_GRAPHICS_DEBUG_GROUP(fmt::format(fmt("CFishCloud::Render {} {} {}"),

--- a/Runtime/World/CFishCloud.hpp
+++ b/Runtime/World/CFishCloud.hpp
@@ -145,7 +145,7 @@ public:
   void Think(float dt, CStateManager& mgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId sender, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void CalculateRenderBounds() override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void Touch(CActor& other, CStateManager& mgr) override;

--- a/Runtime/World/CHUDBillboardEffect.cpp
+++ b/Runtime/World/CHUDBillboardEffect.cpp
@@ -96,7 +96,7 @@ void CHUDBillboardEffect::PreRender(CStateManager& mgr, const zeus::CFrustum& fr
   x104_24_renderAsParticleGen = !mgr.RenderLast(GetUniqueId());
 }
 
-void CHUDBillboardEffect::Render(const CStateManager& mgr) const {
+void CHUDBillboardEffect::Render(CStateManager& mgr) {
   if (x104_25_enableRender && !x104_24_renderAsParticleGen) {
     SCOPED_GRAPHICS_DEBUG_GROUP("CHUDBillboardEffect::Render", zeus::skPurple);
     xe8_generator->Render();

--- a/Runtime/World/CHUDBillboardEffect.hpp
+++ b/Runtime/World/CHUDBillboardEffect.hpp
@@ -39,7 +39,7 @@ public:
   void Think(float dt, CStateManager& mgr) override;
   void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   bool IsElementGen() const { return x104_26_isElementGen; }
   void SetRunIndefinitely(bool b) { x104_27_runIndefinitely = b; }
   CParticleGen* GetParticleGen() const { return xe8_generator.get(); }

--- a/Runtime/World/CPatterned.cpp
+++ b/Runtime/World/CPatterned.cpp
@@ -1591,7 +1591,7 @@ void CPatterned::RenderIceModelWithFlags(const CModelFlags& flags) const {
     animData->Render(*iceModel, useFlags, {*x510_vertexMorph}, iceModel->GetMorphMagnitudes());
 }
 
-void CPatterned::Render(const CStateManager& mgr) const {
+void CPatterned::Render(CStateManager& mgr) {
   int mask = 0;
   int target = 0;
   if (x402_29_drawParticles) {

--- a/Runtime/World/CPatterned.hpp
+++ b/Runtime/World/CPatterned.hpp
@@ -274,7 +274,7 @@ public:
   void Think(float, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
 
   void CollidedWith(TUniqueId, const CCollisionInfoList&, CStateManager& mgr) override;
   void Touch(CActor& act, CStateManager& mgr) override;

--- a/Runtime/World/CPhysicsActor.cpp
+++ b/Runtime/World/CPhysicsActor.cpp
@@ -25,7 +25,7 @@ CPhysicsActor::CPhysicsActor(TUniqueId uid, bool active, std::string_view name, 
   ComputeDerivedQuantities();
 }
 
-void CPhysicsActor::Render(const CStateManager& mgr) const { CActor::Render(mgr); }
+void CPhysicsActor::Render(CStateManager& mgr) { CActor::Render(mgr); }
 
 zeus::CVector3f CPhysicsActor::GetOrbitPosition(const CStateManager&) const { return GetBoundingBox().center(); }
 

--- a/Runtime/World/CPhysicsActor.hpp
+++ b/Runtime/World/CPhysicsActor.hpp
@@ -121,7 +121,7 @@ public:
                 CModelData&& mData, const CMaterialList& matList, const zeus::CAABox& box, const SMoverData& moverData,
                 const CActorParameters& actorParms, float stepUp, float stepDown);
 
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   zeus::CVector3f GetOrbitPosition(const CStateManager& mgr) const override;
   zeus::CVector3f GetAimPosition(const CStateManager& mgr, float val) const override;
   virtual const CCollisionPrimitive* GetCollisionPrimitive() const;

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -1406,7 +1406,7 @@ void CPlayer::RenderGun(const CStateManager& mgr, const zeus::CVector3f& pos) co
   }
 }
 
-void CPlayer::Render(const CStateManager& mgr) const {
+void CPlayer::Render(CStateManager& mgr) {
   bool doRender = x2f4_cameraState != EPlayerCameraState::Spawned;
   if (!doRender) {
     if (TCastToConstPtr<CCinematicCamera> cam = mgr.GetCameraManager()->GetCurrentCamera(mgr)) {

--- a/Runtime/World/CPlayer.hpp
+++ b/Runtime/World/CPlayer.hpp
@@ -401,7 +401,7 @@ public:
   bool GetExplorationMode() const;
   bool GetCombatMode() const;
   void RenderGun(const CStateManager& mgr, const zeus::CVector3f& pos) const;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void RenderReflectedPlayer(CStateManager& mgr);
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
   void CalculateRenderBounds() override;

--- a/Runtime/World/CScriptAiJumpPoint.hpp
+++ b/Runtime/World/CScriptAiJumpPoint.hpp
@@ -30,7 +30,7 @@ public:
   void Think(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
-  void Render(const CStateManager&) const override {}
+  void Render(CStateManager&) override {}
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   bool GetInUse(TUniqueId uid) const;
   TUniqueId GetJumpPoint() const { return x10c_currentWaypoint; }

--- a/Runtime/World/CScriptCameraWaypoint.hpp
+++ b/Runtime/World/CScriptCameraWaypoint.hpp
@@ -18,7 +18,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
-  void Render(const CStateManager&) const override {}
+  void Render(CStateManager&) override {}
   TUniqueId GetRandomNextWaypointId(CStateManager& mgr) const;
   float GetHFov() const { return xe8_hfov; }
 };

--- a/Runtime/World/CScriptCoverPoint.hpp
+++ b/Runtime/World/CScriptCoverPoint.hpp
@@ -42,7 +42,7 @@ public:
   void Think(float, CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
-  void Render(const CStateManager&) const override {}
+  void Render(CStateManager&) override {}
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void SetInUse(bool inUse);
   bool GetInUse(TUniqueId uid) const;

--- a/Runtime/World/CScriptDamageableTrigger.cpp
+++ b/Runtime/World/CScriptDamageableTrigger.cpp
@@ -105,7 +105,7 @@ EWeaponCollisionResponseTypes CScriptDamageableTrigger::GetCollisionResponseType
                                                  : EWeaponCollisionResponseTypes::Unknown15;
 }
 
-void CScriptDamageableTrigger::Render(const CStateManager& mgr) const {
+void CScriptDamageableTrigger::Render(CStateManager& mgr) {
   if (x30_24_active && x1dc_faceFlag != 0 && std::fabs(x1e0_alpha) >= 0.00001f) {
     zeus::CAABox aabb = x14c_bounds.getTransformedAABox(x214_faceDirInv);
     zeus::CTransform xf = x34_transform * zeus::CTransform::Translate(x244_faceTranslate) * x1e4_faceDir;

--- a/Runtime/World/CScriptDamageableTrigger.hpp
+++ b/Runtime/World/CScriptDamageableTrigger.hpp
@@ -58,7 +58,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   EWeaponCollisionResponseTypes GetCollisionResponseType(const zeus::CVector3f&, const zeus::CVector3f&,
                                                          const CWeaponMode&, EProjectileAttrib) const override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void AddToRenderer(const zeus::CFrustum& frustum, CStateManager& mgr) override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
   const CDamageVulnerability* GetDamageVulnerability() const override { return &x174_dVuln; }

--- a/Runtime/World/CScriptDebris.cpp
+++ b/Runtime/World/CScriptDebris.cpp
@@ -379,7 +379,7 @@ void CScriptDebris::PreRender(CStateManager& mgr, const zeus::CFrustum& frustum)
   xb4_drawFlags = CModelFlags(5, 0, 3, zeus::CColor::lerp(zeus::skWhite, x268_endsColor, t));
 }
 
-void CScriptDebris::Render(const CStateManager& mgr) const { CPhysicsActor::Render(mgr); }
+void CScriptDebris::Render(CStateManager& mgr) { CPhysicsActor::Render(mgr); }
 
 void CScriptDebris::CollidedWith(TUniqueId, const CCollisionInfoList& colList, CStateManager&) {
   if (colList.GetCount() == 0)

--- a/Runtime/World/CScriptDebris.hpp
+++ b/Runtime/World/CScriptDebris.hpp
@@ -84,7 +84,7 @@ public:
   void Touch(CActor& other, CStateManager& mgr) override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void PreRender(CStateManager& mgr, const zeus::CFrustum& frustum) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
 
   void CollidedWith(TUniqueId uid, const CCollisionInfoList&, CStateManager&) override;
 };

--- a/Runtime/World/CScriptDoor.hpp
+++ b/Runtime/World/CScriptDoor.hpp
@@ -52,7 +52,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, CStateManager& mgr) override;
   void Think(float, CStateManager& mgr) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager& mgr) override;
-  void Render(const CStateManager&) const override {}
+  void Render(CStateManager&) override {}
   void ForceClosed(CStateManager&);
   bool IsConnectedToArea(const CStateManager& mgr, TAreaId area) const;
   void OpenDoor(TUniqueId, CStateManager&);

--- a/Runtime/World/CScriptEffect.cpp
+++ b/Runtime/World/CScriptEffect.cpp
@@ -239,7 +239,7 @@ void CScriptEffect::AddToRenderer(const zeus::CFrustum& frustum, CStateManager& 
   }
 }
 
-void CScriptEffect::Render(const CStateManager& mgr) const {
+void CScriptEffect::Render(CStateManager& mgr) {
   /* The following code is kept for reference, this is now performed in CElementGen
   if (x138_actorLights)
   x138_actorLights->ActivateLights();

--- a/Runtime/World/CScriptEffect.hpp
+++ b/Runtime/World/CScriptEffect.hpp
@@ -61,7 +61,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   void Think(float, CStateManager&) override;
   bool CanRenderUnsorted(const CStateManager&) const override { return false; }
   void SetActive(bool active) override {

--- a/Runtime/World/CScriptGrapplePoint.cpp
+++ b/Runtime/World/CScriptGrapplePoint.cpp
@@ -40,7 +40,7 @@ void CScriptGrapplePoint::Think(float, CStateManager&) {
   // Empty
 }
 
-void CScriptGrapplePoint::Render(const CStateManager&) const {
+void CScriptGrapplePoint::Render(CStateManager&) {
   // Empty
 }
 

--- a/Runtime/World/CScriptGrapplePoint.hpp
+++ b/Runtime/World/CScriptGrapplePoint.hpp
@@ -19,7 +19,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
   const CGrappleParameters& GetGrappleParameters() const { return x100_parameters; }

--- a/Runtime/World/CScriptGunTurret.cpp
+++ b/Runtime/World/CScriptGunTurret.cpp
@@ -484,7 +484,7 @@ void CScriptGunTurret::AddToRenderer(const zeus::CFrustum& frustum, CStateManage
   }
 }
 
-void CScriptGunTurret::Render(const CStateManager& mgr) const {
+void CScriptGunTurret::Render(CStateManager& mgr) {
   CPhysicsActor::Render(mgr);
 
   if (x258_type == ETurretComponent::Gun) {

--- a/Runtime/World/CScriptGunTurret.hpp
+++ b/Runtime/World/CScriptGunTurret.hpp
@@ -228,7 +228,7 @@ public:
   void Think(float, CStateManager&) override;
   void Touch(CActor&, CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   zeus::CVector3f GetOrbitPosition(const CStateManager&) const override;
   zeus::CVector3f GetAimPosition(const CStateManager&, float) const override;

--- a/Runtime/World/CScriptPlatform.cpp
+++ b/Runtime/World/CScriptPlatform.cpp
@@ -293,7 +293,7 @@ void CScriptPlatform::PreRender(CStateManager& mgr, const zeus::CFrustum& frustu
     x354_boundsTrigger = kInvalidUniqueId;
 }
 
-void CScriptPlatform::Render(const CStateManager& mgr) const {
+void CScriptPlatform::Render(CStateManager& mgr) {
   bool xray = mgr.GetPlayerState()->GetActiveVisor(mgr) == CPlayerState::EPlayerVisor::XRay;
   if (xray && !x356_31_xrayFog)
     g_Renderer->SetWorldFog(ERglFogMode::None, 0.f, 1.f, zeus::skBlack);

--- a/Runtime/World/CScriptPlatform.hpp
+++ b/Runtime/World/CScriptPlatform.hpp
@@ -91,7 +91,7 @@ public:
   void PreThink(float, CStateManager&) override;
   void Think(float, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   zeus::CTransform GetPrimitiveTransform() const override;
   const CCollisionPrimitive* GetCollisionPrimitive() const override;

--- a/Runtime/World/CScriptPlayerActor.cpp
+++ b/Runtime/World/CScriptPlayerActor.cpp
@@ -375,7 +375,7 @@ void CScriptPlayerActor::AddToRenderer(const zeus::CFrustum& frustum, CStateMana
   }
 }
 
-void CScriptPlayerActor::Render(const CStateManager& mgr) const {
+void CScriptPlayerActor::Render(CStateManager& mgr) {
   CBooModel::SetReflectionCube(m_reflectionCube);
 
   bool phazonSuit = x2e8_suitRes.GetCharacterNodeId() == 3;

--- a/Runtime/World/CScriptPlayerActor.hpp
+++ b/Runtime/World/CScriptPlayerActor.hpp
@@ -68,7 +68,7 @@ public:
   void SetActive(bool active) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager& mgr) const override;
+  void Render(CStateManager& mgr) override;
   void TouchModels(const CStateManager& mgr) const;
 };
 } // namespace urde

--- a/Runtime/World/CScriptPointOfInterest.cpp
+++ b/Runtime/World/CScriptPointOfInterest.cpp
@@ -28,7 +28,7 @@ void CScriptPointOfInterest::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId
 
 void CScriptPointOfInterest::AddToRenderer(const zeus::CFrustum&, CStateManager&) {}
 
-void CScriptPointOfInterest::Render(const CStateManager&) const {}
+void CScriptPointOfInterest::Render(CStateManager&) {}
 
 void CScriptPointOfInterest::CalculateRenderBounds() {
   if (xe8_pointSize == 0.f)

--- a/Runtime/World/CScriptPointOfInterest.hpp
+++ b/Runtime/World/CScriptPointOfInterest.hpp
@@ -18,7 +18,7 @@ public:
   void Think(float, CStateManager&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   void CalculateRenderBounds() override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
 };

--- a/Runtime/World/CScriptSpecialFunction.cpp
+++ b/Runtime/World/CScriptSpecialFunction.cpp
@@ -491,7 +491,7 @@ void CScriptSpecialFunction::AddToRenderer(const zeus::CFrustum&, CStateManager&
   }
 }
 
-void CScriptSpecialFunction::Render(const CStateManager& mgr) const {
+void CScriptSpecialFunction::Render(CStateManager& mgr) {
   if (xe8_function == ESpecialFunction::FogVolume) {
     float z = mgr.IntegrateVisorFog(xfc_float1 * std::sin(CGraphics::GetSecondsMod900()));
     if (z > 0.f) {

--- a/Runtime/World/CScriptSpecialFunction.hpp
+++ b/Runtime/World/CScriptSpecialFunction.hpp
@@ -126,7 +126,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   std::optional<zeus::CAABox> GetTouchBounds() const override { return x1c8_touchBounds; }
 
   void SkipCinematic(CStateManager&);

--- a/Runtime/World/CScriptSpiderBallWaypoint.hpp
+++ b/Runtime/World/CScriptSpiderBallWaypoint.hpp
@@ -19,7 +19,7 @@ public:
   CScriptSpiderBallWaypoint(TUniqueId, std::string_view, const CEntityInfo&, const zeus::CTransform&, bool, u32);
   void Accept(IVisitor&) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
-  void Render(const CStateManager& mgr) const override { CActor::Render(mgr); }
+  void Render(CStateManager& mgr) override { CActor::Render(mgr); }
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override {}
   std::optional<zeus::CAABox> GetTouchBounds() const override { return xfc_aabox; }
   void AccumulateBounds(const zeus::CVector3f& v);

--- a/Runtime/World/CScriptSpindleCamera.cpp
+++ b/Runtime/World/CScriptSpindleCamera.cpp
@@ -337,7 +337,7 @@ void CScriptSpindleCamera::Think(float dt, CStateManager& mgr) {
   }
 }
 
-void CScriptSpindleCamera::Render(const CStateManager&) const {
+void CScriptSpindleCamera::Render(CStateManager&) {
   // Empty
 }
 

--- a/Runtime/World/CScriptSpindleCamera.hpp
+++ b/Runtime/World/CScriptSpindleCamera.hpp
@@ -105,7 +105,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   void Reset(const zeus::CTransform& xf, CStateManager& mgr) override;
   void ProcessInput(const CFinalInput& input, CStateManager& mgr) override;
 };

--- a/Runtime/World/CScriptTargetingPoint.hpp
+++ b/Runtime/World/CScriptTargetingPoint.hpp
@@ -23,7 +23,7 @@ public:
   void Accept(IVisitor& visitor) override;
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void Render(const CStateManager&) const override {}
+  void Render(CStateManager&) override {}
 
   bool GetLocked() const;
 };

--- a/Runtime/World/CScriptVisorFlare.cpp
+++ b/Runtime/World/CScriptVisorFlare.cpp
@@ -39,6 +39,6 @@ void CScriptVisorFlare::AddToRenderer(const zeus::CFrustum&, CStateManager& stat
   }
 }
 
-void CScriptVisorFlare::Render(const CStateManager& stateMgr) const { xe8_flare.Render(GetTranslation(), stateMgr); }
+void CScriptVisorFlare::Render(CStateManager& stateMgr) { xe8_flare.Render(GetTranslation(), stateMgr); }
 
 } // namespace urde

--- a/Runtime/World/CScriptVisorFlare.hpp
+++ b/Runtime/World/CScriptVisorFlare.hpp
@@ -21,7 +21,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
 };
 
 } // namespace urde

--- a/Runtime/World/CScriptVisorGoo.cpp
+++ b/Runtime/World/CScriptVisorGoo.cpp
@@ -105,7 +105,7 @@ void CScriptVisorGoo::AddToRenderer(const zeus::CFrustum& frustum, CStateManager
   // Empty
 }
 
-void CScriptVisorGoo::Render(const CStateManager& mgr) const {
+void CScriptVisorGoo::Render(CStateManager& mgr) {
   // Empty
 }
 

--- a/Runtime/World/CScriptVisorGoo.hpp
+++ b/Runtime/World/CScriptVisorGoo.hpp
@@ -31,7 +31,7 @@ public:
   void Think(float, CStateManager& stateMgr) override;
   void AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId objId, CStateManager& stateMgr) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;
   void Touch(CActor&, CStateManager&) override;
 };

--- a/Runtime/World/CScriptWater.cpp
+++ b/Runtime/World/CScriptWater.cpp
@@ -423,7 +423,7 @@ void CScriptWater::AddToRenderer(const zeus::CFrustum& /*frustum*/, CStateManage
   mgr.AddDrawableActorPlane(*this, plane, renderBounds);
 }
 
-void CScriptWater::Render(const CStateManager& mgr) const {
+void CScriptWater::Render(CStateManager& mgr) {
   if (x30_24_active && !xe4_30_outOfFrustum) {
     float zOffset = 0.5f * (x9c_renderBounds.max.z() + x9c_renderBounds.min.z()) - x34_transform.origin.z();
     zeus::CAABox aabb = x9c_renderBounds.getTransformedAABox(zeus::CTransform::Translate(

--- a/Runtime/World/CScriptWater.hpp
+++ b/Runtime/World/CScriptWater.hpp
@@ -105,7 +105,7 @@ public:
   void AcceptScriptMsg(EScriptObjectMessage, TUniqueId, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   void Touch(CActor&, CStateManager&) override;
   void CalculateRenderBounds() override;
   zeus::CAABox GetSortingBounds(const CStateManager&) const override;

--- a/Runtime/World/CWallCrawlerSwarm.cpp
+++ b/Runtime/World/CWallCrawlerSwarm.cpp
@@ -1082,7 +1082,7 @@ void CWallCrawlerSwarm::RenderBoid(const CBoid* boid, u32& drawMask, bool therma
   }
 }
 
-void CWallCrawlerSwarm::Render(const CStateManager& mgr) const {
+void CWallCrawlerSwarm::Render(CStateManager& mgr) {
   SCOPED_GRAPHICS_DEBUG_GROUP(fmt::format(fmt("CWallCrawlerSwarm::Render {} {} {}"),
                                           x8_uid, xc_editorId, x10_name).c_str(), zeus::skOrange);
   u32 drawMask = 0xffffffff;

--- a/Runtime/World/CWallCrawlerSwarm.hpp
+++ b/Runtime/World/CWallCrawlerSwarm.hpp
@@ -196,7 +196,7 @@ public:
   void Think(float, CStateManager&) override;
   void PreRender(CStateManager&, const zeus::CFrustum&) override;
   void AddToRenderer(const zeus::CFrustum&, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   bool CanRenderUnsorted(const CStateManager&) const override;
   void CalculateRenderBounds() override;
   std::optional<zeus::CAABox> GetTouchBounds() const override;

--- a/Runtime/World/CWallWalker.cpp
+++ b/Runtime/World/CWallWalker.cpp
@@ -164,7 +164,7 @@ void CWallWalker::Think(float dt, CStateManager& mgr) {
   }
 }
 
-void CWallWalker::Render(const CStateManager& mgr) const { CPatterned::Render(mgr); }
+void CWallWalker::Render(CStateManager& mgr) { CPatterned::Render(mgr); }
 
 void CWallWalker::UpdateWPDestination(CStateManager& mgr) {
   if (TCastToPtr<CScriptWaypoint> wp = mgr.ObjectById(x2dc_destObj)) {

--- a/Runtime/World/CWallWalker.hpp
+++ b/Runtime/World/CWallWalker.hpp
@@ -55,7 +55,7 @@ public:
 
   void PreThink(float, CStateManager&) override;
   void Think(float, CStateManager&) override;
-  void Render(const CStateManager&) const override;
+  void Render(CStateManager&) override;
   const CCollisionPrimitive* GetCollisionPrimitive() const override { return &x590_colSphere; }
   void UpdateWPDestination(CStateManager&);
 };


### PR DESCRIPTION
A few implementations of Render() contain const-casts nested within their call hierarchy to get around the fact that this function is marked const. We can just make the member function non-const to allow removal of these casts in follow up changes.