### PR TITLE
IAnimReader: Make use of size_t for capacity and iterators

### DIFF
--- a/Runtime/Character/CAnimData.cpp
+++ b/Runtime/Character/CAnimData.cpp
@@ -135,11 +135,13 @@ SAdvancementDeltas CAnimData::AdvanceAdditiveAnims(float dt) {
     std::shared_ptr<CAnimTreeNode>& anim = additive.second.GetAnim();
     if (additive.second.IsActive()) {
       while (time.GreaterThanZero() && std::fabs(time.GetSeconds()) >= 0.00001f) {
-        x210_passedIntCount += anim->GetInt32POIList(time, g_Int32POINodes.data(), 16, x210_passedIntCount, 0);
-        x20c_passedBoolCount += anim->GetBoolPOIList(time, g_BoolPOINodes.data(), 8, x20c_passedBoolCount, 0);
+        x210_passedIntCount +=
+            u32(anim->GetInt32POIList(time, g_Int32POINodes.data(), g_Int32POINodes.size(), x210_passedIntCount, 0));
+        x20c_passedBoolCount +=
+            u32(anim->GetBoolPOIList(time, g_BoolPOINodes.data(), g_BoolPOINodes.size(), x20c_passedBoolCount, 0));
         x214_passedParticleCount +=
-            anim->GetParticlePOIList(time, g_ParticlePOINodes.data(), 8, x214_passedParticleCount, 0);
-        x218_passedSoundCount += anim->GetSoundPOIList(time, g_SoundPOINodes.data(), 8, x218_passedSoundCount, 0);
+            u32(anim->GetParticlePOIList(time, g_ParticlePOINodes.data(), 8, x214_passedParticleCount, 0));
+        x218_passedSoundCount += u32(anim->GetSoundPOIList(time, g_SoundPOINodes.data(), 8, x218_passedSoundCount, 0));
 
         SAdvancementResults results = AdvanceAdditiveAnim(anim, time);
         deltas.x0_posDelta += results.x8_deltas.x0_posDelta;
@@ -149,11 +151,13 @@ SAdvancementDeltas CAnimData::AdvanceAdditiveAnims(float dt) {
     } else {
       CCharAnimTime remTime = anim->VGetTimeRemaining();
       while (remTime.GreaterThanZero() && std::fabs(remTime.GetSeconds()) >= 0.00001f) {
-        x210_passedIntCount += anim->GetInt32POIList(time, g_Int32POINodes.data(), 16, x210_passedIntCount, 0);
-        x20c_passedBoolCount += anim->GetBoolPOIList(time, g_BoolPOINodes.data(), 8, x20c_passedBoolCount, 0);
+        x210_passedIntCount +=
+            u32(anim->GetInt32POIList(time, g_Int32POINodes.data(), g_Int32POINodes.size(), x210_passedIntCount, 0));
+        x20c_passedBoolCount +=
+            u32(anim->GetBoolPOIList(time, g_BoolPOINodes.data(), g_BoolPOINodes.size(), x20c_passedBoolCount, 0));
         x214_passedParticleCount +=
-            anim->GetParticlePOIList(time, g_ParticlePOINodes.data(), 8, x214_passedParticleCount, 0);
-        x218_passedSoundCount += anim->GetSoundPOIList(time, g_SoundPOINodes.data(), 8, x218_passedSoundCount, 0);
+            u32(anim->GetParticlePOIList(time, g_ParticlePOINodes.data(), 8, x214_passedParticleCount, 0));
+        x218_passedSoundCount += u32(anim->GetSoundPOIList(time, g_SoundPOINodes.data(), 8, x218_passedSoundCount, 0));
 
         SAdvancementResults results = AdvanceAdditiveAnim(anim, time);
         deltas.x0_posDelta += results.x8_deltas.x0_posDelta;
@@ -263,8 +267,9 @@ SAdvancementDeltas CAnimData::GetAdvancementDeltas(const CCharAnimTime& a, const
 }
 
 CCharAnimTime CAnimData::GetTimeOfUserEvent(EUserEventType type, const CCharAnimTime& time) const {
-  u32 count = x1f8_animRoot->GetInt32POIList(time, g_TransientInt32POINodes.data(), 16, 0, 64);
-  for (u32 i = 0; i < count; ++i) {
+  const size_t count =
+      x1f8_animRoot->GetInt32POIList(time, g_TransientInt32POINodes.data(), g_TransientInt32POINodes.size(), 0, 64);
+  for (size_t i = 0; i < count; ++i) {
     CInt32POINode& poi = g_TransientInt32POINodes[i];
     if (poi.GetPoiType() == EPOIType::UserEvent && EUserEventType(poi.GetValue()) == type) {
       CCharAnimTime ret = poi.GetTime();
@@ -283,8 +288,8 @@ void CAnimData::MultiplyPlaybackRate(float mul) { x200_speedScale *= mul; }
 void CAnimData::SetPlaybackRate(float set) { x200_speedScale = set; }
 
 void CAnimData::SetRandomPlaybackRate(CRandom16& r) {
-  for (u32 i = 0; i < x210_passedIntCount; ++i) {
-    CInt32POINode& poi = g_Int32POINodes[i];
+  for (size_t i = 0; i < x210_passedIntCount; ++i) {
+    const CInt32POINode& poi = g_Int32POINodes[i];
     if (poi.GetPoiType() == EPOIType::RandRate) {
       float tmp = (r.Next() % poi.GetValue()) / 100.f;
       if ((r.Next() % 100) < 50)
@@ -304,10 +309,10 @@ void CAnimData::CalcPlaybackAlignmentParms(const CAnimPlaybackParms& parms,
   x220_27_ = false;
   if (parms.GetDeltaOrient() && parms.GetObjectXform()) {
     ResetPOILists();
-    x210_passedIntCount +=
-        node->GetInt32POIList(CCharAnimTime::Infinity(), g_Int32POINodes.data(), 16, x210_passedIntCount, 64);
-    for (u32 i = 0; i < x210_passedIntCount; ++i) {
-      CInt32POINode& poi = g_Int32POINodes[i];
+    x210_passedIntCount += u32(node->GetInt32POIList(CCharAnimTime::Infinity(), g_Int32POINodes.data(),
+                                                     g_Int32POINodes.size(), x210_passedIntCount, 64));
+    for (size_t i = 0; i < x210_passedIntCount; ++i) {
+      const CInt32POINode& poi = g_Int32POINodes[i];
       if (poi.GetPoiType() == EPOIType::UserEvent && EUserEventType(poi.GetValue()) == EUserEventType::AlignTargetRot) {
         SAdvancementResults res = node->VGetAdvancementResults(poi.GetTime(), 0.f);
         orient = zeus::CQuaternion::slerp(zeus::CQuaternion(),
@@ -328,10 +333,10 @@ void CAnimData::CalcPlaybackAlignmentParms(const CAnimPlaybackParms& parms,
     CCharAnimTime timeStart, timeAlign;
     if (parms.GetTargetPos() && parms.GetObjectXform()) {
       ResetPOILists();
-      x210_passedIntCount +=
-          node->GetInt32POIList(CCharAnimTime::Infinity(), g_Int32POINodes.data(), 16, x210_passedIntCount, 64);
-      for (u32 i = 0; i < x210_passedIntCount; ++i) {
-        CInt32POINode& poi = g_Int32POINodes[i];
+      x210_passedIntCount += u32(node->GetInt32POIList(CCharAnimTime::Infinity(), g_Int32POINodes.data(),
+                                                       g_Int32POINodes.size(), x210_passedIntCount, 64));
+      for (size_t i = 0; i < x210_passedIntCount; ++i) {
+        const CInt32POINode& poi = g_Int32POINodes[i];
         if (poi.GetPoiType() == EPOIType::UserEvent) {
           if (EUserEventType(poi.GetValue()) == EUserEventType::AlignTargetPosStart) {
             didStart = true;
@@ -380,9 +385,9 @@ void CAnimData::CalcPlaybackAlignmentParms(const CAnimPlaybackParms& parms,
     zeus::CVector3f startPos;
     if (parms.GetTargetPos() && parms.GetObjectXform()) {
       ResetPOILists();
-      x210_passedIntCount +=
-          node->GetInt32POIList(CCharAnimTime::Infinity(), g_Int32POINodes.data(), 16, x210_passedIntCount, 64);
-      for (u32 i = 0; i < x210_passedIntCount; ++i) {
+      x210_passedIntCount += u32(node->GetInt32POIList(CCharAnimTime::Infinity(), g_Int32POINodes.data(),
+                                                       g_Int32POINodes.size(), x210_passedIntCount, 64));
+      for (size_t i = 0; i < x210_passedIntCount; ++i) {
         CInt32POINode& poi = g_Int32POINodes[i];
         if (poi.GetPoiType() == EPOIType::UserEvent) {
           if (EUserEventType(poi.GetValue()) == EUserEventType::AlignTargetPosStart) {
@@ -678,23 +683,27 @@ SAdvancementDeltas CAnimData::DoAdvance(float dt, bool& suspendParticles, CRando
     CCharAnimTime time(scaleDt);
     if (x220_25_loop) {
       while (time.GreaterThanZero() && !time.EpsilonZero()) {
-        x210_passedIntCount += x1f8_animRoot->GetInt32POIList(time, g_Int32POINodes.data(), 16, x210_passedIntCount, 0);
-        x20c_passedBoolCount += x1f8_animRoot->GetBoolPOIList(time, g_BoolPOINodes.data(), 16, x20c_passedBoolCount, 0);
+        x210_passedIntCount += u32(x1f8_animRoot->GetInt32POIList(time, g_Int32POINodes.data(), g_Int32POINodes.size(),
+                                                                  x210_passedIntCount, 0));
+        x20c_passedBoolCount += u32(
+            x1f8_animRoot->GetBoolPOIList(time, g_BoolPOINodes.data(), g_BoolPOINodes.size(), x20c_passedBoolCount, 0));
         x214_passedParticleCount +=
-            x1f8_animRoot->GetParticlePOIList(time, g_ParticlePOINodes.data(), 16, x214_passedParticleCount, 0);
+            u32(x1f8_animRoot->GetParticlePOIList(time, g_ParticlePOINodes.data(), 16, x214_passedParticleCount, 0));
         x218_passedSoundCount +=
-            x1f8_animRoot->GetSoundPOIList(time, g_SoundPOINodes.data(), 16, x218_passedSoundCount, 0);
+            u32(x1f8_animRoot->GetSoundPOIList(time, g_SoundPOINodes.data(), 16, x218_passedSoundCount, 0));
         AdvanceAnim(time, offsetPost, quatPost);
       }
     } else {
       CCharAnimTime remTime = x1f8_animRoot->VGetTimeRemaining();
       while (!remTime.EpsilonZero() && !time.EpsilonZero()) {
-        x210_passedIntCount += x1f8_animRoot->GetInt32POIList(time, g_Int32POINodes.data(), 16, x210_passedIntCount, 0);
-        x20c_passedBoolCount += x1f8_animRoot->GetBoolPOIList(time, g_BoolPOINodes.data(), 16, x20c_passedBoolCount, 0);
+        x210_passedIntCount += u32(x1f8_animRoot->GetInt32POIList(time, g_Int32POINodes.data(), g_Int32POINodes.size(),
+                                                                  x210_passedIntCount, 0));
+        x20c_passedBoolCount += u32(
+            x1f8_animRoot->GetBoolPOIList(time, g_BoolPOINodes.data(), g_BoolPOINodes.size(), x20c_passedBoolCount, 0));
         x214_passedParticleCount +=
-            x1f8_animRoot->GetParticlePOIList(time, g_ParticlePOINodes.data(), 16, x214_passedParticleCount, 0);
+            u32(x1f8_animRoot->GetParticlePOIList(time, g_ParticlePOINodes.data(), 16, x214_passedParticleCount, 0));
         x218_passedSoundCount +=
-            x1f8_animRoot->GetSoundPOIList(time, g_SoundPOINodes.data(), 16, x218_passedSoundCount, 0);
+            u32(x1f8_animRoot->GetSoundPOIList(time, g_SoundPOINodes.data(), 16, x218_passedSoundCount, 0));
         AdvanceAnim(time, offsetPost, quatPost);
         remTime = x1f8_animRoot->VGetTimeRemaining();
         time = std::max(0.f, std::min(remTime.GetSeconds(), time.GetSeconds()));
@@ -721,8 +730,8 @@ SAdvancementDeltas CAnimData::Advance(float dt, const zeus::CVector3f& scale, CS
   if (suspendParticles)
     x120_particleDB.SuspendAllActiveEffects(stateMgr);
 
-  for (u32 i = 0; i < x214_passedParticleCount; ++i) {
-    CParticlePOINode& node = g_ParticlePOINodes[i];
+  for (size_t i = 0; i < x214_passedParticleCount; ++i) {
+    const CParticlePOINode& node = g_ParticlePOINodes[i];
     if (node.GetCharacterIndex() == -1 || node.GetCharacterIndex() == x204_charIdx) {
       x120_particleDB.AddParticleEffect(node.GetString(), node.GetFlags(), node.GetParticleData(), scale, stateMgr, aid,
                                         false, x21c_particleLightIdx);
@@ -750,8 +759,8 @@ void CAnimData::AdvanceAnim(CCharAnimTime& time, zeus::CVector3f& offset, zeus::
     x1f8_animRoot = CAnimTreeNode::Cast(std::move(*simplified));
 
   if ((x220_28_ || x220_27_) && x210_passedIntCount > 0) {
-    for (u32 i = 0; i < x210_passedIntCount; ++i) {
-      CInt32POINode& node = g_Int32POINodes[i];
+    for (size_t i = 0; i < x210_passedIntCount; ++i) {
+      const CInt32POINode& node = g_Int32POINodes[i];
       if (node.GetPoiType() == EPOIType::UserEvent) {
         switch (EUserEventType(node.GetValue())) {
         case EUserEventType::AlignTargetPosStart: {

--- a/Runtime/Character/CAnimSourceReader.cpp
+++ b/Runtime/Character/CAnimSourceReader.cpp
@@ -132,8 +132,8 @@ void CAnimSourceReaderBase::UpdatePOIStates() {
   }
 }
 
-u32 CAnimSourceReaderBase::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                                           u32 unk) const {
+size_t CAnimSourceReaderBase::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity,
+                                              size_t iterator, u32 unk) const {
   if (x4_sourceInfo->HasPOIData()) {
     const std::vector<CBoolPOINode>& boolNodes = x4_sourceInfo->GetBoolPOIStream();
     return _getPOIList(time, listOut, capacity, iterator, unk, boolNodes, xc_curTime, *x4_sourceInfo,
@@ -142,8 +142,8 @@ u32 CAnimSourceReaderBase::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINo
   return 0;
 }
 
-u32 CAnimSourceReaderBase::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity,
-                                            u32 iterator, u32 unk) const {
+size_t CAnimSourceReaderBase::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity,
+                                               size_t iterator, u32 unk) const {
   if (x4_sourceInfo->HasPOIData()) {
     const std::vector<CInt32POINode>& int32Nodes = x4_sourceInfo->GetInt32POIStream();
     return _getPOIList(time, listOut, capacity, iterator, unk, int32Nodes, xc_curTime, *x4_sourceInfo,
@@ -152,8 +152,8 @@ u32 CAnimSourceReaderBase::VGetInt32POIList(const CCharAnimTime& time, CInt32POI
   return 0;
 }
 
-u32 CAnimSourceReaderBase::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity,
-                                               u32 iterator, u32 unk) const {
+size_t CAnimSourceReaderBase::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity,
+                                                  size_t iterator, u32 unk) const {
   if (x4_sourceInfo->HasPOIData()) {
     const std::vector<CParticlePOINode>& particleNodes = x4_sourceInfo->GetParticlePOIStream();
     return _getPOIList(time, listOut, capacity, iterator, unk, particleNodes, xc_curTime, *x4_sourceInfo,
@@ -162,8 +162,8 @@ u32 CAnimSourceReaderBase::VGetParticlePOIList(const CCharAnimTime& time, CParti
   return 0;
 }
 
-u32 CAnimSourceReaderBase::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity,
-                                            u32 iterator, u32 unk) const {
+size_t CAnimSourceReaderBase::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity,
+                                               size_t iterator, u32 unk) const {
   if (x4_sourceInfo->HasPOIData()) {
     const std::vector<CSoundPOINode>& soundNodes = x4_sourceInfo->GetSoundPOIStream();
     return _getPOIList(time, listOut, capacity, iterator, unk, soundNodes, xc_curTime, *x4_sourceInfo,

--- a/Runtime/Character/CAnimSourceReader.hpp
+++ b/Runtime/Character/CAnimSourceReader.hpp
@@ -61,13 +61,13 @@ protected:
 public:
   CAnimSourceReaderBase(std::unique_ptr<IAnimSourceInfo>&& sourceInfo, const CCharAnimTime& time);
 
-  u32 VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator, u32) const override;
-  u32 VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
-  u32 VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator,
+  size_t VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator, u32) const override;
+  size_t VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
                           u32) const override;
-  u32 VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
+  size_t VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity, size_t iterator,
+                             u32) const override;
+  size_t VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                          u32) const override;
   bool VGetBoolPOIState(std::string_view name) const override;
   s32 VGetInt32POIState(std::string_view name) const override;
   CParticleData::EParentedMode VGetParticlePOIState(std::string_view name) const override;

--- a/Runtime/Character/CAnimTreeAnimReaderContainer.cpp
+++ b/Runtime/Character/CAnimTreeAnimReaderContainer.cpp
@@ -38,23 +38,23 @@ zeus::CQuaternion CAnimTreeAnimReaderContainer::VGetRotation(const CSegId& seg) 
   return x14_reader->VGetRotation(seg);
 }
 
-u32 CAnimTreeAnimReaderContainer::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity,
-                                                  u32 iterator, u32 unk) const {
+size_t CAnimTreeAnimReaderContainer::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity,
+                                                     size_t iterator, u32 unk) const {
   return x14_reader->GetBoolPOIList(time, listOut, capacity, iterator, unk);
 }
 
-u32 CAnimTreeAnimReaderContainer::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity,
-                                                   u32 iterator, u32 unk) const {
+size_t CAnimTreeAnimReaderContainer::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut,
+                                                      size_t capacity, size_t iterator, u32 unk) const {
   return x14_reader->GetInt32POIList(time, listOut, capacity, iterator, unk);
 }
 
-u32 CAnimTreeAnimReaderContainer::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut,
-                                                      u32 capacity, u32 iterator, u32 unk) const {
+size_t CAnimTreeAnimReaderContainer::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut,
+                                                         size_t capacity, size_t iterator, u32 unk) const {
   return x14_reader->GetParticlePOIList(time, listOut, capacity, iterator, unk);
 }
 
-u32 CAnimTreeAnimReaderContainer::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity,
-                                                   u32 iterator, u32 unk) const {
+size_t CAnimTreeAnimReaderContainer::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut,
+                                                      size_t capacity, size_t iterator, u32 unk) const {
   return x14_reader->GetSoundPOIList(time, listOut, capacity, iterator, unk);
 }
 

--- a/Runtime/Character/CAnimTreeAnimReaderContainer.hpp
+++ b/Runtime/Character/CAnimTreeAnimReaderContainer.hpp
@@ -30,13 +30,13 @@ public:
   bool VHasOffset(const CSegId& seg) const override;
   zeus::CVector3f VGetOffset(const CSegId& seg) const override;
   zeus::CQuaternion VGetRotation(const CSegId& seg) const override;
-  u32 VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator, u32) const override;
-  u32 VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
-  u32 VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator,
+  size_t VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator, u32) const override;
+  size_t VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
                           u32) const override;
-  u32 VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
+  size_t VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity, size_t iterator,
+                             u32) const override;
+  size_t VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                          u32) const override;
   bool VGetBoolPOIState(std::string_view name) const override;
   s32 VGetInt32POIState(std::string_view name) const override;
   CParticleData::EParentedMode VGetParticlePOIState(std::string_view name) const override;

--- a/Runtime/Character/CAnimTreeDoubleChild.cpp
+++ b/Runtime/Character/CAnimTreeDoubleChild.cpp
@@ -53,48 +53,52 @@ SAdvancementResults CAnimTreeDoubleChild::VAdvanceView(const CCharAnimTime& a) {
   return (resA.x0_remTime > resB.x0_remTime) ? resA : resB;
 }
 
-u32 CAnimTreeDoubleChild::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                                          u32 unk) const {
-  u32 newCapacity = x14_a->GetBoolPOIList(time, listOut, capacity, iterator, unk);
+size_t CAnimTreeDoubleChild::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity,
+                                             size_t iterator, u32 unk) const {
+  size_t newCapacity = x14_a->GetBoolPOIList(time, listOut, capacity, iterator, unk);
   newCapacity += x18_b->GetBoolPOIList(time, listOut, capacity, newCapacity + iterator, unk);
-  if (newCapacity > capacity)
+  if (newCapacity > capacity) {
     newCapacity = capacity;
+  }
 
   std::sort(listOut, listOut + newCapacity);
 
   return newCapacity;
 }
 
-u32 CAnimTreeDoubleChild::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity,
-                                           u32 iterator, u32 unk) const {
-  u32 newCapacity = x14_a->GetInt32POIList(time, listOut, capacity, iterator, unk);
+size_t CAnimTreeDoubleChild::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity,
+                                              size_t iterator, u32 unk) const {
+  size_t newCapacity = x14_a->GetInt32POIList(time, listOut, capacity, iterator, unk);
   newCapacity += x18_b->GetInt32POIList(time, listOut, capacity, newCapacity + iterator, unk);
-  if (newCapacity > capacity)
+  if (newCapacity > capacity) {
     newCapacity = capacity;
+  }
 
   std::sort(listOut, listOut + newCapacity);
 
   return newCapacity;
 }
 
-u32 CAnimTreeDoubleChild::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity,
-                                              u32 iterator, u32 unk) const {
-  u32 newCapacity = x14_a->GetParticlePOIList(time, listOut, capacity, iterator, unk);
+size_t CAnimTreeDoubleChild::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity,
+                                                 size_t iterator, u32 unk) const {
+  size_t newCapacity = x14_a->GetParticlePOIList(time, listOut, capacity, iterator, unk);
   newCapacity += x18_b->GetParticlePOIList(time, listOut, capacity, newCapacity + iterator, unk);
-  if (newCapacity > capacity)
+  if (newCapacity > capacity) {
     newCapacity = capacity;
+  }
 
   std::sort(listOut, listOut + newCapacity);
 
   return newCapacity;
 }
 
-u32 CAnimTreeDoubleChild::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity,
-                                           u32 iterator, u32 unk) const {
-  u32 newCapacity = x14_a->GetSoundPOIList(time, listOut, capacity, iterator, unk);
+size_t CAnimTreeDoubleChild::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity,
+                                              size_t iterator, u32 unk) const {
+  size_t newCapacity = x14_a->GetSoundPOIList(time, listOut, capacity, iterator, unk);
   newCapacity += x18_b->GetSoundPOIList(time, listOut, capacity, newCapacity + iterator, unk);
-  if (newCapacity > capacity)
+  if (newCapacity > capacity) {
     newCapacity = capacity;
+  }
 
   std::sort(listOut, listOut + newCapacity);
 

--- a/Runtime/Character/CAnimTreeDoubleChild.hpp
+++ b/Runtime/Character/CAnimTreeDoubleChild.hpp
@@ -34,13 +34,13 @@ public:
   CAnimTreeDoubleChild(const std::weak_ptr<CAnimTreeNode>& a, const std::weak_ptr<CAnimTreeNode>& b,
                        std::string_view name);
   SAdvancementResults VAdvanceView(const CCharAnimTime& a) override;
-  u32 VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator, u32) const override;
-  u32 VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
-  u32 VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator,
+  size_t VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator, u32) const override;
+  size_t VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
                           u32) const override;
-  u32 VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
+  size_t VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity, size_t iterator,
+                             u32) const override;
+  size_t VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                          u32) const override;
   bool VGetBoolPOIState(std::string_view name) const override;
   s32 VGetInt32POIState(std::string_view name) const override;
   CParticleData::EParentedMode VGetParticlePOIState(std::string_view name) const override;

--- a/Runtime/Character/CAnimTreeLoopIn.cpp
+++ b/Runtime/Character/CAnimTreeLoopIn.cpp
@@ -57,26 +57,26 @@ std::unique_ptr<IAnimReader> CAnimTreeLoopIn::VClone() const {
                                            x20_animCtx, x4_name, x30_fundamentals, x88_curTime);
 }
 
-u32 CAnimTreeLoopIn::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                                     u32 unk) const {
+size_t CAnimTreeLoopIn::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity,
+                                        size_t iterator, u32 unk) const {
   return _getPOIList<CBoolPOINode>(time, listOut, capacity, iterator, unk, x30_fundamentals.GetBoolPointsOfInterest(),
                                    x88_curTime);
 }
 
-u32 CAnimTreeLoopIn::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                                      u32 unk) const {
+size_t CAnimTreeLoopIn::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity,
+                                         size_t iterator, u32 unk) const {
   return _getPOIList<CInt32POINode>(time, listOut, capacity, iterator, unk, x30_fundamentals.GetInt32PointsOfInterest(),
                                     x88_curTime);
 }
 
-u32 CAnimTreeLoopIn::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity,
-                                         u32 iterator, u32 unk) const {
+size_t CAnimTreeLoopIn::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity,
+                                            size_t iterator, u32 unk) const {
   return _getPOIList<CParticlePOINode>(time, listOut, capacity, iterator, unk,
                                        x30_fundamentals.GetParticlePointsOfInterest(), x88_curTime);
 }
 
-u32 CAnimTreeLoopIn::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                                      u32 unk) const {
+size_t CAnimTreeLoopIn::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity,
+                                         size_t iterator, u32 unk) const {
   return _getPOIList<CSoundPOINode>(time, listOut, capacity, iterator, unk, x30_fundamentals.GetSoundPointsOfInterest(),
                                     x88_curTime);
 }

--- a/Runtime/Character/CAnimTreeLoopIn.hpp
+++ b/Runtime/Character/CAnimTreeLoopIn.hpp
@@ -30,13 +30,13 @@ public:
   std::optional<std::unique_ptr<IAnimReader>> VSimplified() override;
   std::shared_ptr<IAnimReader> VGetBestUnblendedChild() const override;
   std::unique_ptr<IAnimReader> VClone() const override;
-  u32 VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator, u32) const override;
-  u32 VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
-  u32 VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator,
+  size_t VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator, u32) const override;
+  size_t VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
                           u32) const override;
-  u32 VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
+  size_t VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity, size_t iterator,
+                             u32) const override;
+  size_t VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                          u32) const override;
   CSteadyStateAnimInfo VGetSteadyStateAnimInfo() const override;
   CCharAnimTime VGetTimeRemaining() const override;
   SAdvancementResults VAdvanceView(const CCharAnimTime& dt) override;

--- a/Runtime/Character/CAnimTreeSequence.cpp
+++ b/Runtime/Character/CAnimTreeSequence.cpp
@@ -93,24 +93,24 @@ CSteadyStateAnimInfo CAnimTreeSequence::VGetSteadyStateAnimInfo() const {
   return x3c_fundamentals.GetSteadyStateAnimInfo();
 }
 
-u32 CAnimTreeSequence::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                                       u32 unk) const {
+size_t CAnimTreeSequence::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity,
+                                          size_t iterator, u32 unk) const {
   return _getPOIList(time, listOut, capacity, iterator, unk, x3c_fundamentals.GetBoolPointsOfInterest(), x94_curTime);
 }
 
-u32 CAnimTreeSequence::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                                        u32 unk) const {
+size_t CAnimTreeSequence::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity,
+                                           size_t iterator, u32 unk) const {
   return _getPOIList(time, listOut, capacity, iterator, unk, x3c_fundamentals.GetInt32PointsOfInterest(), x94_curTime);
 }
 
-u32 CAnimTreeSequence::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity,
-                                           u32 iterator, u32 unk) const {
+size_t CAnimTreeSequence::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity,
+                                              size_t iterator, u32 unk) const {
   return _getPOIList(time, listOut, capacity, iterator, unk, x3c_fundamentals.GetParticlePointsOfInterest(),
                      x94_curTime);
 }
 
-u32 CAnimTreeSequence::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                                        u32 unk) const {
+size_t CAnimTreeSequence::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity,
+                                           size_t iterator, u32 unk) const {
   return _getPOIList(time, listOut, capacity, iterator, unk, x3c_fundamentals.GetSoundPointsOfInterest(), x94_curTime);
 }
 

--- a/Runtime/Character/CAnimTreeSequence.hpp
+++ b/Runtime/Character/CAnimTreeSequence.hpp
@@ -32,13 +32,13 @@ public:
   SAdvancementResults VAdvanceView(const CCharAnimTime& dt) override;
   CCharAnimTime VGetTimeRemaining() const override;
   CSteadyStateAnimInfo VGetSteadyStateAnimInfo() const override;
-  u32 VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator, u32) const override;
-  u32 VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
-  u32 VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator,
+  size_t VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator, u32) const override;
+  size_t VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
                           u32) const override;
-  u32 VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
+  size_t VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity, size_t iterator,
+                             u32) const override;
+  size_t VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                          u32) const override;
   std::unique_ptr<IAnimReader> VClone() const override;
 };
 

--- a/Runtime/Character/CAnimTreeSingleChild.cpp
+++ b/Runtime/Character/CAnimTreeSingleChild.cpp
@@ -15,23 +15,23 @@ zeus::CVector3f CAnimTreeSingleChild::VGetOffset(const CSegId& seg) const { retu
 
 zeus::CQuaternion CAnimTreeSingleChild::VGetRotation(const CSegId& seg) const { return x14_child->VGetRotation(seg); }
 
-u32 CAnimTreeSingleChild::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                                          u32 unk) const {
+size_t CAnimTreeSingleChild::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity,
+                                             size_t iterator, u32 unk) const {
   return x14_child->GetBoolPOIList(time, listOut, capacity, iterator, unk);
 }
 
-u32 CAnimTreeSingleChild::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity,
-                                           u32 iterator, u32 unk) const {
+size_t CAnimTreeSingleChild::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity,
+                                              size_t iterator, u32 unk) const {
   return x14_child->GetInt32POIList(time, listOut, capacity, iterator, unk);
 }
 
-u32 CAnimTreeSingleChild::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity,
-                                              u32 iterator, u32 unk) const {
+size_t CAnimTreeSingleChild::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity,
+                                                 size_t iterator, u32 unk) const {
   return x14_child->GetParticlePOIList(time, listOut, capacity, iterator, unk);
 }
 
-u32 CAnimTreeSingleChild::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity,
-                                           u32 iterator, u32 unk) const {
+size_t CAnimTreeSingleChild::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity,
+                                              size_t iterator, u32 unk) const {
   return x14_child->GetSoundPOIList(time, listOut, capacity, iterator, unk);
 }
 

--- a/Runtime/Character/CAnimTreeSingleChild.hpp
+++ b/Runtime/Character/CAnimTreeSingleChild.hpp
@@ -20,13 +20,13 @@ public:
   bool VHasOffset(const CSegId& seg) const override;
   zeus::CVector3f VGetOffset(const CSegId& seg) const override;
   zeus::CQuaternion VGetRotation(const CSegId& seg) const override;
-  u32 VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator, u32) const override;
-  u32 VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
-  u32 VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator,
+  size_t VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator, u32) const override;
+  size_t VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
                           u32) const override;
-  u32 VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
+  size_t VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity, size_t iterator,
+                             u32) const override;
+  size_t VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                          u32) const override;
   bool VGetBoolPOIState(std::string_view name) const override;
   s32 VGetInt32POIState(std::string_view name) const override;
   CParticleData::EParentedMode VGetParticlePOIState(std::string_view name) const override;

--- a/Runtime/Character/CAnimTreeTimeScale.cpp
+++ b/Runtime/Character/CAnimTreeTimeScale.cpp
@@ -59,43 +59,55 @@ std::optional<std::unique_ptr<IAnimReader>> CAnimTreeTimeScale::VSimplified() {
   return std::nullopt;
 }
 
-u32 CAnimTreeTimeScale::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                                        u32 unk) const {
-  CCharAnimTime useTime = (time == CCharAnimTime::Infinity()) ? x14_child->VGetTimeRemaining() : GetRealLifeTime(time);
-  u32 ret = x14_child->GetBoolPOIList(useTime, listOut, capacity, iterator, unk);
-  if (x28_targetAccelTime > CCharAnimTime())
-    for (u32 i = 0; i < ret; ++i)
+size_t CAnimTreeTimeScale::VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity,
+                                           size_t iterator, u32 unk) const {
+  const CCharAnimTime useTime =
+      time == CCharAnimTime::Infinity() ? x14_child->VGetTimeRemaining() : GetRealLifeTime(time);
+  const size_t ret = x14_child->GetBoolPOIList(useTime, listOut, capacity, iterator, unk);
+  if (x28_targetAccelTime > CCharAnimTime()) {
+    for (size_t i = 0; i < ret; ++i) {
       listOut[iterator + i].SetTime(GetRealLifeTime(listOut[i].GetTime()));
+    }
+  }
   return ret;
 }
 
-u32 CAnimTreeTimeScale::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                                         u32 unk) const {
-  CCharAnimTime useTime = (time == CCharAnimTime::Infinity()) ? x14_child->VGetTimeRemaining() : GetRealLifeTime(time);
-  u32 ret = x14_child->GetInt32POIList(useTime, listOut, capacity, iterator, unk);
-  if (x28_targetAccelTime > CCharAnimTime())
-    for (u32 i = 0; i < ret; ++i)
+size_t CAnimTreeTimeScale::VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity,
+                                            size_t iterator, u32 unk) const {
+  const CCharAnimTime useTime =
+      time == CCharAnimTime::Infinity() ? x14_child->VGetTimeRemaining() : GetRealLifeTime(time);
+  const size_t ret = x14_child->GetInt32POIList(useTime, listOut, capacity, iterator, unk);
+  if (x28_targetAccelTime > CCharAnimTime()) {
+    for (size_t i = 0; i < ret; ++i) {
       listOut[iterator + i].SetTime(GetRealLifeTime(listOut[i].GetTime()));
+    }
+  }
   return ret;
 }
 
-u32 CAnimTreeTimeScale::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity,
-                                            u32 iterator, u32 unk) const {
-  CCharAnimTime useTime = (time == CCharAnimTime::Infinity()) ? x14_child->VGetTimeRemaining() : GetRealLifeTime(time);
-  u32 ret = x14_child->GetParticlePOIList(useTime, listOut, capacity, iterator, unk);
-  if (x28_targetAccelTime > CCharAnimTime())
-    for (u32 i = 0; i < ret; ++i)
+size_t CAnimTreeTimeScale::VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity,
+                                               size_t iterator, u32 unk) const {
+  const CCharAnimTime useTime =
+      time == CCharAnimTime::Infinity() ? x14_child->VGetTimeRemaining() : GetRealLifeTime(time);
+  const size_t ret = x14_child->GetParticlePOIList(useTime, listOut, capacity, iterator, unk);
+  if (x28_targetAccelTime > CCharAnimTime()) {
+    for (size_t i = 0; i < ret; ++i) {
       listOut[iterator + i].SetTime(GetRealLifeTime(listOut[i].GetTime()));
+    }
+  }
   return ret;
 }
 
-u32 CAnimTreeTimeScale::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                                         u32 unk) const {
-  CCharAnimTime useTime = (time == CCharAnimTime::Infinity()) ? x14_child->VGetTimeRemaining() : GetRealLifeTime(time);
-  u32 ret = x14_child->GetSoundPOIList(useTime, listOut, capacity, iterator, unk);
-  if (x28_targetAccelTime > CCharAnimTime())
-    for (u32 i = 0; i < ret; ++i)
+size_t CAnimTreeTimeScale::VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity,
+                                            size_t iterator, u32 unk) const {
+  const CCharAnimTime useTime =
+      (time == CCharAnimTime::Infinity()) ? x14_child->VGetTimeRemaining() : GetRealLifeTime(time);
+  const size_t ret = x14_child->GetSoundPOIList(useTime, listOut, capacity, iterator, unk);
+  if (x28_targetAccelTime > CCharAnimTime()) {
+    for (size_t i = 0; i < ret; ++i) {
       listOut[iterator + i].SetTime(GetRealLifeTime(listOut[i].GetTime()));
+    }
+  }
   return ret;
 }
 

--- a/Runtime/Character/CAnimTreeTimeScale.hpp
+++ b/Runtime/Character/CAnimTreeTimeScale.hpp
@@ -27,13 +27,13 @@ public:
   void VSetPhase(float) override;
   std::optional<std::unique_ptr<IAnimReader>> VSimplified() override;
 
-  u32 VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator, u32) const override;
-  u32 VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
-  u32 VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator,
+  size_t VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator, u32) const override;
+  size_t VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
                           u32) const override;
-  u32 VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                       u32) const override;
+  size_t VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity, size_t iterator,
+                             u32) const override;
+  size_t VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                          u32) const override;
   bool VGetBoolPOIState(std::string_view name) const override;
   s32 VGetInt32POIState(std::string_view name) const override;
   CParticleData::EParentedMode VGetParticlePOIState(std::string_view name) const override;

--- a/Runtime/Character/CPOINode.cpp
+++ b/Runtime/Character/CPOINode.cpp
@@ -36,22 +36,24 @@ bool CPOINode::operator>(const CPOINode& other) const { return x1c_time < other.
 bool CPOINode::operator<(const CPOINode& other) const { return x1c_time > other.x1c_time; }
 
 template <class T>
-u32 _getPOIList(const CCharAnimTime& time, T* listOut, u32 capacity, u32 iterator, u32 unk1,
-                const std::vector<T>& stream, const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo,
-                u32 passedCount) {
-  u32 ret = 0;
+size_t _getPOIList(const CCharAnimTime& time, T* listOut, size_t capacity, size_t iterator, u32 unk1,
+                   const std::vector<T>& stream, const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo,
+                   size_t passedCount) {
+  size_t ret = 0;
   if (animInfo.HasPOIData() && stream.size()) {
-    CCharAnimTime dur = animInfo.GetAnimationDuration();
+    const CCharAnimTime dur = animInfo.GetAnimationDuration();
     CCharAnimTime targetTime = curTime + time;
-    if (targetTime >= dur)
+    if (targetTime >= dur) {
       targetTime = dur;
+    }
 
-    if (passedCount >= stream.size())
+    if (passedCount >= stream.size()) {
       return ret;
+    }
 
     CCharAnimTime nodeTime = stream[passedCount].GetTime();
     while (passedCount < stream.size() && nodeTime <= targetTime) {
-      u32 idx = iterator + ret;
+      const size_t idx = iterator + ret;
       if (idx < capacity) {
         listOut[idx] = T::CopyNodeMinusStartTime(stream[passedCount], curTime);
         ++ret;
@@ -65,17 +67,18 @@ u32 _getPOIList(const CCharAnimTime& time, T* listOut, u32 capacity, u32 iterato
 }
 
 template <class T>
-u32 _getPOIList(const CCharAnimTime& time, T* listOut, u32 capacity, u32 iterator, u32 unk1,
-                const std::vector<T>& stream, const CCharAnimTime& curTime) {
-  u32 ret = 0;
+size_t _getPOIList(const CCharAnimTime& time, T* listOut, size_t capacity, size_t iterator, u32 unk1,
+                   const std::vector<T>& stream, const CCharAnimTime& curTime) {
+  size_t ret = 0;
 
-  CCharAnimTime targetTime = curTime + time;
+  const CCharAnimTime targetTime = curTime + time;
 
-  for (u32 it = iterator; it < stream.size(); ++it) {
-    CCharAnimTime nodeTime = stream[it].GetTime();
-    if (nodeTime > targetTime)
+  for (size_t it = iterator; it < stream.size(); ++it) {
+    const CCharAnimTime nodeTime = stream[it].GetTime();
+    if (nodeTime > targetTime) {
       return ret;
-    u32 idx = iterator + ret;
+    }
+    const size_t idx = iterator + ret;
     if (nodeTime >= curTime && idx < capacity) {
       listOut[idx] = T::CopyNodeMinusStartTime(stream[it], curTime);
       ++ret;
@@ -85,32 +88,36 @@ u32 _getPOIList(const CCharAnimTime& time, T* listOut, u32 capacity, u32 iterato
   return ret;
 }
 
-template u32 _getPOIList<CBoolPOINode>(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                                       u32 unk1, const std::vector<CBoolPOINode>& stream, const CCharAnimTime& curTime,
-                                       const IAnimSourceInfo& animInfo, u32 passedCount);
-template u32 _getPOIList<CBoolPOINode>(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                                       u32 unk1, const std::vector<CBoolPOINode>& stream, const CCharAnimTime& curTime);
+template size_t _getPOIList<CBoolPOINode>(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity,
+                                          size_t iterator, u32 unk1, const std::vector<CBoolPOINode>& stream,
+                                          const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo,
+                                          size_t passedCount);
+template size_t _getPOIList<CBoolPOINode>(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity,
+                                          size_t iterator, u32 unk1, const std::vector<CBoolPOINode>& stream,
+                                          const CCharAnimTime& curTime);
 
-template u32 _getPOIList<CInt32POINode>(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                                        u32 unk1, const std::vector<CInt32POINode>& stream,
-                                        const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo, u32 passedCount);
-template u32 _getPOIList<CInt32POINode>(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                                        u32 unk1, const std::vector<CInt32POINode>& stream,
-                                        const CCharAnimTime& curTime);
-
-template u32 _getPOIList<CParticlePOINode>(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity,
-                                           u32 iterator, u32 unk1, const std::vector<CParticlePOINode>& stream,
+template size_t _getPOIList<CInt32POINode>(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity,
+                                           size_t iterator, u32 unk1, const std::vector<CInt32POINode>& stream,
                                            const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo,
-                                           u32 passedCount);
-template u32 _getPOIList<CParticlePOINode>(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity,
-                                           u32 iterator, u32 unk1, const std::vector<CParticlePOINode>& stream,
+                                           size_t passedCount);
+template size_t _getPOIList<CInt32POINode>(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity,
+                                           size_t iterator, u32 unk1, const std::vector<CInt32POINode>& stream,
                                            const CCharAnimTime& curTime);
 
-template u32 _getPOIList<CSoundPOINode>(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                                        u32 unk1, const std::vector<CSoundPOINode>& stream,
-                                        const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo, u32 passedCount);
-template u32 _getPOIList<CSoundPOINode>(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                                        u32 unk1, const std::vector<CSoundPOINode>& stream,
-                                        const CCharAnimTime& curTime);
+template size_t _getPOIList<CParticlePOINode>(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity,
+                                              size_t iterator, u32 unk1, const std::vector<CParticlePOINode>& stream,
+                                              const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo,
+                                              size_t passedCount);
+template size_t _getPOIList<CParticlePOINode>(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity,
+                                              size_t iterator, u32 unk1, const std::vector<CParticlePOINode>& stream,
+                                              const CCharAnimTime& curTime);
+
+template size_t _getPOIList<CSoundPOINode>(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity,
+                                           size_t iterator, u32 unk1, const std::vector<CSoundPOINode>& stream,
+                                           const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo,
+                                           size_t passedCount);
+template size_t _getPOIList<CSoundPOINode>(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity,
+                                           size_t iterator, u32 unk1, const std::vector<CSoundPOINode>& stream,
+                                           const CCharAnimTime& curTime);
 
 } // namespace urde

--- a/Runtime/Character/CPOINode.hpp
+++ b/Runtime/Character/CPOINode.hpp
@@ -53,12 +53,12 @@ public:
 };
 
 template <class T>
-u32 _getPOIList(const CCharAnimTime& time, T* listOut, u32 capacity, u32 iterator, u32 unk1,
-                const std::vector<T>& stream, const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo,
-                u32 passedCount);
+size_t _getPOIList(const CCharAnimTime& time, T* listOut, size_t capacity, size_t iterator, u32 unk1,
+                   const std::vector<T>& stream, const CCharAnimTime& curTime, const IAnimSourceInfo& animInfo,
+                   size_t passedCount);
 
 template <class T>
-u32 _getPOIList(const CCharAnimTime& time, T* listOut, u32 capacity, u32 iterator, u32 unk1,
-                const std::vector<T>& stream, const CCharAnimTime& curTime);
+size_t _getPOIList(const CCharAnimTime& time, T* listOut, size_t capacity, size_t iterator, u32 unk1,
+                   const std::vector<T>& stream, const CCharAnimTime& curTime);
 
 } // namespace urde

--- a/Runtime/Character/CSequenceHelper.cpp
+++ b/Runtime/Character/CSequenceHelper.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/Character/CSequenceHelper.hpp"
 
+#include <array>
+
 #include "Runtime/Character/CAnimSysContext.hpp"
 #include "Runtime/Character/CBoolPOINode.hpp"
 #include "Runtime/Character/CInt32POINode.hpp"
@@ -45,37 +47,41 @@ CSequenceFundamentals CSequenceHelper::ComputeSequenceFundamentals() {
   if (x10_treeNodes.size() > 0) {
     std::shared_ptr<CAnimTreeNode> node = CAnimTreeNode::Cast(x10_treeNodes[0]->Clone());
     for (size_t i = 0; i < x10_treeNodes.size(); ++i) {
-      CBoolPOINode boolNodeArr[64];
-      u32 numBools = node->GetBoolPOIList(CCharAnimTime::Infinity(), boolNodeArr, 64, 0, 0);
+      std::array<CBoolPOINode, 64> boolNodeArr;
+      const size_t numBools =
+          node->GetBoolPOIList(CCharAnimTime::Infinity(), boolNodeArr.data(), boolNodeArr.size(), 0, 0);
       boolNodes.reserve(boolNodes.size() + numBools);
-      for (u32 j = 0; j < numBools; ++j) {
+      for (size_t j = 0; j < numBools; ++j) {
         CBoolPOINode& n = boolNodeArr[j];
         n.SetTime(n.GetTime() + duration);
         boolNodes.push_back(n);
       }
 
-      CInt32POINode int32NodeArr[64];
-      u32 numInt32s = node->GetInt32POIList(CCharAnimTime::Infinity(), int32NodeArr, 64, 0, 0);
+      std::array<CInt32POINode, 64> int32NodeArr;
+      const size_t numInt32s =
+          node->GetInt32POIList(CCharAnimTime::Infinity(), int32NodeArr.data(), int32NodeArr.size(), 0, 0);
       int32Nodes.reserve(int32Nodes.size() + numInt32s);
-      for (u32 j = 0; j < numInt32s; ++j) {
+      for (size_t j = 0; j < numInt32s; ++j) {
         CInt32POINode& n = int32NodeArr[j];
         n.SetTime(n.GetTime() + duration);
         int32Nodes.push_back(n);
       }
 
-      CParticlePOINode particleNodeArr[64];
-      u32 numParticles = node->GetParticlePOIList(CCharAnimTime::Infinity(), particleNodeArr, 64, 0, 0);
+      std::array<CParticlePOINode, 64> particleNodeArr;
+      const size_t numParticles =
+          node->GetParticlePOIList(CCharAnimTime::Infinity(), particleNodeArr.data(), particleNodeArr.size(), 0, 0);
       particleNodes.reserve(particleNodes.size() + numParticles);
-      for (u32 j = 0; j < numParticles; ++j) {
+      for (size_t j = 0; j < numParticles; ++j) {
         CParticlePOINode& n = particleNodeArr[j];
         n.SetTime(n.GetTime() + duration);
         particleNodes.push_back(n);
       }
 
-      CSoundPOINode soundNodeArr[64];
-      u32 numSounds = node->GetSoundPOIList(CCharAnimTime::Infinity(), soundNodeArr, 64, 0, 0);
+      std::array<CSoundPOINode, 64> soundNodeArr;
+      const size_t numSounds =
+          node->GetSoundPOIList(CCharAnimTime::Infinity(), soundNodeArr.data(), soundNodeArr.size(), 0, 0);
       soundNodes.reserve(soundNodes.size() + numSounds);
-      for (u32 j = 0; j < numSounds; ++j) {
+      for (size_t j = 0; j < numSounds; ++j) {
         CSoundPOINode& n = soundNodeArr[j];
         n.SetTime(n.GetTime() + duration);
         soundNodes.push_back(n);

--- a/Runtime/Character/IAnimReader.cpp
+++ b/Runtime/Character/IAnimReader.cpp
@@ -22,31 +22,35 @@ SAdvancementResults IAnimReader::VGetAdvancementResults(const CCharAnimTime& a, 
   return ret;
 }
 
-u32 IAnimReader::GetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                                u32 unk) const {
-  if (time.GreaterThanZero())
+size_t IAnimReader::GetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator,
+                                   u32 unk) const {
+  if (time.GreaterThanZero()) {
     return VGetBoolPOIList(time, listOut, capacity, iterator, unk);
+  }
   return 0;
 }
 
-u32 IAnimReader::GetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                                 u32 unk) const {
-  if (time.GreaterThanZero())
-    return VGetInt32POIList(time, listOut, capacity, iterator, unk);
-  return 0;
-}
-
-u32 IAnimReader::GetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator,
+size_t IAnimReader::GetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
                                     u32 unk) const {
-  if (time.GreaterThanZero())
-    return VGetParticlePOIList(time, listOut, capacity, iterator, unk);
+  if (time.GreaterThanZero()) {
+    return VGetInt32POIList(time, listOut, capacity, iterator, unk);
+  }
   return 0;
 }
 
-u32 IAnimReader::GetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                                 u32 unk) const {
-  if (time.GreaterThanZero())
+size_t IAnimReader::GetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity,
+                                       size_t iterator, u32 unk) const {
+  if (time.GreaterThanZero()) {
+    return VGetParticlePOIList(time, listOut, capacity, iterator, unk);
+  }
+  return 0;
+}
+
+size_t IAnimReader::GetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                                    u32 unk) const {
+  if (time.GreaterThanZero()) {
     return VGetSoundPOIList(time, listOut, capacity, iterator, unk);
+  }
   return 0;
 }
 

--- a/Runtime/Character/IAnimReader.hpp
+++ b/Runtime/Character/IAnimReader.hpp
@@ -114,14 +114,14 @@ public:
   virtual bool VHasOffset(const CSegId& seg) const = 0;
   virtual zeus::CVector3f VGetOffset(const CSegId& seg) const = 0;
   virtual zeus::CQuaternion VGetRotation(const CSegId& seg) const = 0;
-  virtual u32 VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator,
-                              u32) const = 0;
-  virtual u32 VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator,
-                               u32) const = 0;
-  virtual u32 VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator,
+  virtual size_t VGetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator,
+                                 u32) const = 0;
+  virtual size_t VGetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
                                   u32) const = 0;
-  virtual u32 VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator,
-                               u32) const = 0;
+  virtual size_t VGetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity, size_t iterator,
+                                     u32) const = 0;
+  virtual size_t VGetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                                  u32) const = 0;
   virtual bool VGetBoolPOIState(std::string_view name) const = 0;
   virtual s32 VGetInt32POIState(std::string_view name) const = 0;
   virtual CParticleData::EParentedMode VGetParticlePOIState(std::string_view name) const = 0;
@@ -133,10 +133,13 @@ public:
   virtual void VSetPhase(float) = 0;
   virtual SAdvancementResults VGetAdvancementResults(const CCharAnimTime& a, const CCharAnimTime& b) const;
 
-  u32 GetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, u32 capacity, u32 iterator, u32) const;
-  u32 GetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, u32 capacity, u32 iterator, u32) const;
-  u32 GetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, u32 capacity, u32 iterator, u32) const;
-  u32 GetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, u32 capacity, u32 iterator, u32) const;
+  size_t GetBoolPOIList(const CCharAnimTime& time, CBoolPOINode* listOut, size_t capacity, size_t iterator, u32) const;
+  size_t GetInt32POIList(const CCharAnimTime& time, CInt32POINode* listOut, size_t capacity, size_t iterator,
+                         u32) const;
+  size_t GetParticlePOIList(const CCharAnimTime& time, CParticlePOINode* listOut, size_t capacity, size_t iterator,
+                            u32) const;
+  size_t GetSoundPOIList(const CCharAnimTime& time, CSoundPOINode* listOut, size_t capacity, size_t iterator,
+                         u32) const;
 
   std::optional<std::unique_ptr<IAnimReader>> Simplified() { return VSimplified(); }
 

--- a/Runtime/Character/IMetaAnim.cpp
+++ b/Runtime/Character/IMetaAnim.cpp
@@ -1,5 +1,7 @@
 #include "Runtime/Character/IMetaAnim.hpp"
 
+#include <array>
+
 #include "Runtime/Character/CAnimTreeNode.hpp"
 #include "Runtime/Character/CBoolPOINode.hpp"
 #include "Runtime/Character/CCharAnimTime.hpp"
@@ -29,17 +31,19 @@ void IMetaAnim::AdvanceAnim(IAnimReader& anim, const CCharAnimTime& dt) {
 }
 
 CCharAnimTime IMetaAnim::GetTime(const CPreAdvanceIndicator& ind, const IAnimReader& anim) {
-  if (ind.IsTime())
+  if (ind.IsTime()) {
     return ind.GetTime();
+  }
 
-  CBoolPOINode nodes[64];
-  CCharAnimTime rem = anim.VGetTimeRemaining();
-  u32 count = anim.VGetBoolPOIList(rem, nodes, 64, 0, 0);
+  std::array<CBoolPOINode, 64> nodes;
+  const CCharAnimTime rem = anim.VGetTimeRemaining();
+  const size_t count = anim.VGetBoolPOIList(rem, nodes.data(), nodes.size(), 0, 0);
   const char* cmpStr = ind.GetString();
-  for (u32 i = 0; i < count; ++i) {
-    CBoolPOINode& node = nodes[i];
-    if (node.GetString() != cmpStr || !node.GetValue())
+  for (size_t i = 0; i < count; ++i) {
+    const CBoolPOINode& node = nodes[i];
+    if (node.GetString() != cmpStr || !node.GetValue()) {
       continue;
+    }
     return node.GetTime();
   }
 


### PR DESCRIPTION
Allows using container sizes and capacities without needing to cast them, allowing for dehardcoding of array sizes in some scenarios.