### PR TITLE
CModel: Mark CModelFlag instances as constexpr where applicable

### DIFF
--- a/Runtime/MP1/World/CBeetle.cpp
+++ b/Runtime/MP1/World/CBeetle.cpp
@@ -162,7 +162,7 @@ void CBeetle::Render(CStateManager& mgr) {
         x5ac_tailModel->Render(mgr, tailXf, x90_actorLights.get(), flags);
       }
     } else if (x5ac_tailModel) {
-      CModelFlags flags(0, 0, 3, zeus::skWhite);
+      constexpr CModelFlags flags(0, 0, 3, zeus::skWhite);
       x5ac_tailModel->Render(mgr, tailXf, x90_actorLights.get(), flags);
     }
   }

--- a/Runtime/Particle/CDecal.cpp
+++ b/Runtime/Particle/CDecal.cpp
@@ -219,14 +219,14 @@ void CDecal::RenderMdl() {
   CGraphics::SetModelMatrix(worldXf);
 
   if (desc.x5c_24_DMAB) {
-    CModelFlags flags(7, 0, 1, color);
+    const CModelFlags flags(7, 0, 1, color);
     desc.x38_DMDL.m_token->Draw(flags);
   } else {
     if (color.a() == 1.f) {
-      CModelFlags flags(0, 0, 3, zeus::skWhite);
+      constexpr CModelFlags flags(0, 0, 3, zeus::skWhite);
       desc.x38_DMDL.m_token->Draw(flags);
     } else {
-      CModelFlags flags(5, 0, 1, color);
+      const CModelFlags flags(5, 0, 1, color);
       desc.x38_DMDL.m_token->Draw(flags);
     }
   }

--- a/Runtime/Weapon/CGunMotion.cpp
+++ b/Runtime/Weapon/CGunMotion.cpp
@@ -83,7 +83,7 @@ void CGunMotion::Update(float dt, CStateManager& mgr) {
 }
 
 void CGunMotion::Draw(const CStateManager& mgr, const zeus::CTransform& xf) const {
-  CModelFlags flags(0, 0, 3, zeus::skWhite);
+  constexpr CModelFlags flags(0, 0, 3, zeus::skWhite);
   x0_modelData.Render(mgr, xf, nullptr, flags);
 }
 

--- a/Runtime/Weapon/CGunWeapon.cpp
+++ b/Runtime/Weapon/CGunWeapon.cpp
@@ -271,17 +271,17 @@ void CGunWeapon::Draw(bool drawSuitArm, const CStateManager& mgr, const zeus::CT
 
   if (mgr.GetThermalDrawFlag() == EThermalDrawFlag::Hot && x200_beamId != CPlayerState::EBeamId::Ice) {
     /* Hot Draw */
-    zeus::CColor mulColor(flags.x4_color.a(), flags.x4_color.a());
-    zeus::CColor addColor(0.25f, 0.25f);
+    const zeus::CColor mulColor(flags.x4_color.a(), flags.x4_color.a());
+    constexpr zeus::CColor addColor(0.25f, 0.25f);
     if (x218_29_drawHologram) {
       DrawHologram(mgr, xf, flags);
     } else {
-      CModelFlags useFlags(0, 0, 3, zeus::skWhite);
+      constexpr CModelFlags useFlags(0, 0, 3, zeus::skWhite);
       x10_solidModelData->RenderThermal(xf, mulColor, addColor, useFlags);
     }
 
     if (drawSuitArm && xb0_suitArmModelData) {
-      CModelFlags useFlags(0, 0, 3, zeus::skWhite);
+      constexpr CModelFlags useFlags(0, 0, 3, zeus::skWhite);
       xb0_suitArmModelData->RenderThermal(xf, mulColor, addColor, useFlags);
     }
   } else {

--- a/Runtime/Weapon/CPlayerGun.cpp
+++ b/Runtime/Weapon/CPlayerGun.cpp
@@ -109,15 +109,15 @@ constexpr std::array chargeShakeTbl{
 constexpr CMaterialFilter sAimFilter =
     CMaterialFilter::MakeIncludeExclude({EMaterialTypes::Solid}, {EMaterialTypes::ProjectilePassthrough});
 
-const std::array<CModelFlags, 4> kThermalFlags{{
+constexpr std::array<CModelFlags, 4> kThermalFlags{{
     {0, 0, 3, zeus::skWhite},
     {5, 0, 3, zeus::CColor(0.f, 0.5f)},
     {0, 0, 3, zeus::skWhite},
     {0, 0, 3, zeus::skWhite},
 }};
 
-const CModelFlags kHandThermalFlag = {7, 0, 3, zeus::skWhite};
-const CModelFlags kHandHoloFlag = {1, 0, 3, zeus::CColor(0.75f, 0.5f, 0.f, 1.f)};
+constexpr CModelFlags kHandThermalFlag{7, 0, 3, zeus::skWhite};
+constexpr CModelFlags kHandHoloFlag{1, 0, 3, zeus::CColor(0.75f, 0.5f, 0.f, 1.f)};
 } // Anonymous namespace
 
 float CPlayerGun::CMotionState::gGunExtendDistance = 0.125f;

--- a/Runtime/Weapon/CProjectileWeapon.cpp
+++ b/Runtime/Weapon/CProjectileWeapon.cpp
@@ -235,7 +235,7 @@ void CProjectileWeapon::Render() {
   std::vector<CLight> useLights;
   useLights.push_back(CLight::BuildLocalAmbient({}, xc8_ambientLightColor));
   (**x108_model).GetInstance().ActivateLights(useLights);
-  CModelFlags flags(0, 0, 3, zeus::skWhite);
+  constexpr CModelFlags flags(0, 0, 3, zeus::skWhite);
   (*x108_model)->Draw(flags);
 }
 

--- a/Runtime/World/CFishCloud.cpp
+++ b/Runtime/World/CFishCloud.cpp
@@ -520,7 +520,7 @@ void CFishCloud::RenderBoid(int idx, const CBoid& boid, u32& drawMask,
   model.GetModelInst()->SetAmbientColor(zeus::skWhite);
   CGraphics::SetModelMatrix(zeus::lookAt(boid.x0_pos, boid.x0_pos + boid.xc_vel));
   if (thermalHot) {
-    CModelFlags thermFlags(0, 0, 3, zeus::skWhite);
+    constexpr CModelFlags thermFlags(0, 0, 3, zeus::skWhite);
     mData.RenderThermal(zeus::skWhite, zeus::CColor(0.f, 0.25f), thermFlags);
   } else {
     mData.GetAnimationData()->Render(model, flags, std::nullopt, nullptr);

--- a/Runtime/World/CMorphBall.cpp
+++ b/Runtime/World/CMorphBall.cpp
@@ -1674,8 +1674,8 @@ void CMorphBall::Render(const CStateManager& mgr, const CActorLights* lights) co
   RenderMorphBallTransitionFlash(mgr);
 
   if (x0_player.GetFrozenState()) {
-    CModelFlags fflags(0, 0, 3, zeus::skWhite);
-    x70_frozenBallModel->Render(mgr, zeus::CTransform::Translate(ballToWorld.origin), lights, fflags);
+    constexpr CModelFlags modelFlags(0, 0, 3, zeus::skWhite);
+    x70_frozenBallModel->Render(mgr, zeus::CTransform::Translate(ballToWorld.origin), lights, modelFlags);
   }
 
   RenderIceBreakEffect(mgr);

--- a/Runtime/World/CPlayer.cpp
+++ b/Runtime/World/CPlayer.cpp
@@ -1572,7 +1572,7 @@ void CPlayer::RenderReflectedPlayer(CStateManager& mgr) {
     }
     CPhysicsActor::Render(mgr);
     if (HasTransitionBeamModel()) {
-      const CModelFlags flags(0, 0, 3, zeus::skWhite);
+      constexpr CModelFlags flags(0, 0, 3, zeus::skWhite);
       x7f0_ballTransitionBeamModel->Render(mgr, x7f4_gunWorldXf, nullptr, flags);
     }
     break;

--- a/Runtime/World/CSnakeWeedSwarm.cpp
+++ b/Runtime/World/CSnakeWeedSwarm.cpp
@@ -416,7 +416,7 @@ void CSnakeWeedSwarm::RenderBoid(u32 idx, const CBoid& boid, u32& posesToBuild) 
   auto& modelData = *x1b0_modelData[modelIdx];
   auto& model = modelData.PickAnimatedModel(x1c4_which);
   auto& animData = *modelData.GetAnimationData();
-  const CModelFlags useFlags(0, 0, 3, zeus::skWhite);
+  constexpr CModelFlags useFlags(0, 0, 3, zeus::skWhite);
   if (posesToBuild & 1 << modelIdx) {
     posesToBuild &= ~(1 << modelIdx);
     animData.BuildPose();

--- a/Runtime/World/CWallCrawlerSwarm.cpp
+++ b/Runtime/World/CWallCrawlerSwarm.cpp
@@ -1062,7 +1062,7 @@ void CWallCrawlerSwarm::RenderBoid(const CBoid* boid, u32& drawMask, bool therma
   model.GetModelInst()->SetAmbientColor(boid->x40_ambientLighting);
   CGraphics::SetModelMatrix(boid->GetTransform());
   if (boid->x48_timeToDie > 0.f && !thermalHot) {
-    const CModelFlags useFlags(0, 0, 3, zeus::skWhite);
+    constexpr CModelFlags useFlags(0, 0, 3, zeus::skWhite);
     mData.GetAnimationData()->Render(model, useFlags, std::nullopt, nullptr);
     if (auto iceModel = mData.GetAnimationData()->GetIceModel()) {
       if (!iceModel->GetModelInst()->TryLockTextures()) {
@@ -1075,7 +1075,7 @@ void CWallCrawlerSwarm::RenderBoid(const CBoid* boid, u32& drawMask, bool therma
       mData.GetAnimationData()->Render(*iceModel, iceFlags, std::nullopt, nullptr);
     }
   } else if (thermalHot) {
-    const CModelFlags thermFlags(5, 0, 3, zeus::skWhite);
+    constexpr CModelFlags thermFlags(5, 0, 3, zeus::skWhite);
     mData.RenderThermal(zeus::skWhite, zeus::CColor(0.f, 0.25f), thermFlags);
   } else {
     mData.GetAnimationData()->Render(model, flags, std::nullopt, nullptr);


### PR DESCRIPTION
Allows more runtime initializes to potentially be elided.