### PR TITLE
CFluidPlane: Make use of std::array where applicable

### DIFF
--- a/Runtime/World/CFluidPlane.cpp
+++ b/Runtime/World/CFluidPlane.cpp
@@ -83,8 +83,7 @@ void CFluidPlane::AddRipple(const CRipple& ripple, const CScriptWater& water, CS
   mgr.GetFluidPlaneManager()->RippleManager().AddRipple(ripple);
 }
 
-void CFluidPlane::RenderStripWithRipples(float curY, const CFluidPlaneRender::SHFieldSample (&heights)[46][46],
-                                         const u8 (&flags)[9][9], int startYDiv,
+void CFluidPlane::RenderStripWithRipples(float curY, const Heights& heights, const Flags& flags, int startYDiv,
                                          const CFluidPlaneRender::SPatchInfo& info,
                                          std::vector<CFluidPlaneShader::Vertex>& vOut,
                                          std::vector<CFluidPlaneShader::PatchVertex>& pvOut) {
@@ -310,8 +309,7 @@ void CFluidPlane::RenderStripWithRipples(float curY, const CFluidPlaneRender::SH
   }
 }
 
-void CFluidPlane::RenderPatch(const CFluidPlaneRender::SPatchInfo& info,
-                              const CFluidPlaneRender::SHFieldSample (&heights)[46][46], const u8 (&flags)[9][9],
+void CFluidPlane::RenderPatch(const CFluidPlaneRender::SPatchInfo& info, const Heights& heights, const Flags& flags,
                               bool noRipples, bool flagIs1, std::vector<CFluidPlaneShader::Vertex>& vOut,
                               std::vector<CFluidPlaneShader::PatchVertex>& pvOut) {
   if (noRipples) {

--- a/Runtime/World/CFluidPlane.hpp
+++ b/Runtime/World/CFluidPlane.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <optional>
 #include <vector>
@@ -116,6 +117,10 @@ public:
 };
 
 class CFluidPlane {
+public:
+  using Flags = std::array<std::array<u8, 9>, 9>;
+  using Heights = std::array<std::array<CFluidPlaneRender::SHFieldSample, 46>, 46>;
+
 protected:
   CAssetId x4_texPattern1Id;
   CAssetId x8_texPattern2Id;
@@ -135,12 +140,12 @@ protected:
   float ProjectRippleVelocity(float baseI, float velDot) const;
   float CalculateRippleIntensity(float baseI) const;
 
-  virtual void RenderStripWithRipples(float curY, const CFluidPlaneRender::SHFieldSample (&heights)[46][46],
-                                      const u8 (&flags)[9][9], int startYDiv, const CFluidPlaneRender::SPatchInfo& info,
+  virtual void RenderStripWithRipples(float curY, const Heights& heights, const Flags& flags, int startYDiv,
+                                      const CFluidPlaneRender::SPatchInfo& info,
                                       std::vector<CFluidPlaneShader::Vertex>& vOut,
                                       std::vector<CFluidPlaneShader::PatchVertex>& pvOut);
-  void RenderPatch(const CFluidPlaneRender::SPatchInfo& info, const CFluidPlaneRender::SHFieldSample (&heights)[46][46],
-                   const u8 (&flags)[9][9], bool noRipples, bool flagIs1, std::vector<CFluidPlaneShader::Vertex>& vOut,
+  void RenderPatch(const CFluidPlaneRender::SPatchInfo& info, const Heights& heights, const Flags& flags,
+                   bool noRipples, bool flagIs1, std::vector<CFluidPlaneShader::Vertex>& vOut,
                    std::vector<CFluidPlaneShader::PatchVertex>& pvOut);
 
 public:

--- a/Runtime/World/CFluidPlaneCPU.cpp
+++ b/Runtime/World/CFluidPlaneCPU.cpp
@@ -110,14 +110,15 @@ void CFluidPlaneCPU::CalculateLightmapMatrix(const zeus::CTransform& areaXf, con
 }
 
 static bool sSineWaveInitialized = false;
-static float sGlobalSineWave[256] = {};
-static const float* InitializeSineWave() {
-  if (sSineWaveInitialized)
-    return sGlobalSineWave;
-  for (int i = 0; i < 256; ++i)
-    sGlobalSineWave[i] = std::sin(2.f * M_PIF * (i / 256.f));
+static CFluidPlaneCPU::SineTable sGlobalSineWave{};
+static void InitializeSineWave() {
+  if (sSineWaveInitialized) {
+    return;
+  }
+  for (size_t i = 0; i < sGlobalSineWave.size(); ++i) {
+    sGlobalSineWave[i] = std::sin(2.f * M_PIF * (float(i) / 256.f));
+  }
   sSineWaveInitialized = true;
-  return sGlobalSineWave;
 }
 
 #define kEnableWaterBumpMaps true
@@ -303,8 +304,7 @@ bool CFluidPlaneCPU::PrepareRipple(const CRipple& ripple, const CFluidPlaneRende
   return !(rippleOut.x14_gfromX > rippleOut.x18_gtoX || rippleOut.x1c_gfromY > rippleOut.x20_gtoY);
 }
 
-void CFluidPlaneCPU::ApplyTurbulence(float t, CFluidPlaneRender::SHFieldSample (&heights)[46][46],
-                                     const u8 (&flags)[9][9], const float sineWave[256],
+void CFluidPlaneCPU::ApplyTurbulence(float t, Heights& heights, const Flags& flags, const SineTable& sineWave,
                                      const CFluidPlaneRender::SPatchInfo& info,
                                      const zeus::CVector3f& areaCenter) const {
   if (!HasTurbulence()) {
@@ -334,9 +334,8 @@ void CFluidPlaneCPU::ApplyTurbulence(float t, CFluidPlaneRender::SHFieldSample (
   }
 }
 
-void CFluidPlaneCPU::ApplyRipple(const CFluidPlaneRender::SRippleInfo& rippleInfo,
-                                 CFluidPlaneRender::SHFieldSample (&heights)[46][46], u8 (&flags)[9][9],
-                                 const float sineWave[256], const CFluidPlaneRender::SPatchInfo& info) const {
+void CFluidPlaneCPU::ApplyRipple(const CFluidPlaneRender::SRippleInfo& rippleInfo, Heights& heights, Flags& flags,
+                                 const SineTable& sineWave, const CFluidPlaneRender::SPatchInfo& info) const {
   float lookupT = 256.f *
                   (1.f - rippleInfo.x0_ripple.GetTime() * rippleInfo.x0_ripple.GetOOTimeFalloff() *
                              rippleInfo.x0_ripple.GetOOTimeFalloff()) *
@@ -409,8 +408,9 @@ void CFluidPlaneCPU::ApplyRipple(const CFluidPlaneRender::SRippleInfo& rippleInf
 
             float divDist = (divDistSq != 0.f) ? std::sqrt(divDistSq) : 0.f;
             if (u8 rippleV = CFluidPlaneManager::RippleValues[lifeIdx][int(divDist * distFalloff)]) {
-              heights[k][l].height += rippleV * rippleInfo.x0_ripple.GetLookupAmplitude() *
-                                      sineWave[int(divDist * rippleInfo.x0_ripple.GetLookupPhase() + lookupT) & 0xff];
+              heights[k][l].height +=
+                  rippleV * rippleInfo.x0_ripple.GetLookupAmplitude() *
+                  sineWave[size_t(divDist * rippleInfo.x0_ripple.GetLookupPhase() + lookupT) & 0xff];
             } else {
               heights[k][l].height += 0.f;
             }
@@ -460,8 +460,9 @@ void CFluidPlaneCPU::ApplyRipple(const CFluidPlaneRender::SRippleInfo& rippleInf
 
               float divDist = (divDistSq != 0.f) ? std::sqrt(divDistSq) : 0.f;
               if (u8 rippleV = CFluidPlaneManager::RippleValues[lifeIdx][int(divDist * distFalloff)]) {
-                heights[k][l].height += rippleV * rippleInfo.x0_ripple.GetLookupAmplitude() *
-                                        sineWave[int(divDist * rippleInfo.x0_ripple.GetLookupPhase() + lookupT) & 0xff];
+                heights[k][l].height +=
+                    rippleV * rippleInfo.x0_ripple.GetLookupAmplitude() *
+                    sineWave[size_t(divDist * rippleInfo.x0_ripple.GetLookupPhase() + lookupT) & 0xff];
               } else {
                 heights[k][l].height += 0.f;
               }
@@ -485,8 +486,8 @@ void CFluidPlaneCPU::ApplyRipple(const CFluidPlaneRender::SRippleInfo& rippleInf
 }
 
 void CFluidPlaneCPU::ApplyRipples(const rstl::reserved_vector<CFluidPlaneRender::SRippleInfo, 32>& rippleInfos,
-                                  CFluidPlaneRender::SHFieldSample (&heights)[46][46], u8 (&flags)[9][9],
-                                  const float sineWave[256], const CFluidPlaneRender::SPatchInfo& info) const {
+                                  Heights& heights, Flags& flags, const SineTable& sineWave,
+                                  const CFluidPlaneRender::SPatchInfo& info) const {
   for (const CFluidPlaneRender::SRippleInfo& rippleInfo : rippleInfos)
     ApplyRipple(rippleInfo, heights, flags, sineWave, info);
   for (int i = 0; i < CFluidPlaneRender::numTilesInHField; ++i)
@@ -499,7 +500,7 @@ void CFluidPlaneCPU::ApplyRipples(const rstl::reserved_vector<CFluidPlaneRender:
     flags[CFluidPlaneRender::numTilesInHField + 1][i + 1] |= 2;
 }
 
-void CFluidPlaneCPU::UpdatePatchNoNormals(CFluidPlaneRender::SHFieldSample (&heights)[46][46], const u8 (&flags)[9][9],
+void CFluidPlaneCPU::UpdatePatchNoNormals(Heights& heights, const Flags& flags,
                                           const CFluidPlaneRender::SPatchInfo& info) {
   for (int i = 1; i <= (info.x1_ySubdivs + CFluidPlaneRender::numSubdivisionsInTile - 2) /
                            CFluidPlaneRender::numSubdivisionsInTile;
@@ -558,8 +559,8 @@ void CFluidPlaneCPU::UpdatePatchNoNormals(CFluidPlaneRender::SHFieldSample (&hei
   }
 }
 
-void CFluidPlaneCPU::UpdatePatchWithNormals(CFluidPlaneRender::SHFieldSample (&heights)[46][46],
-                                            const u8 (&flags)[9][9], const CFluidPlaneRender::SPatchInfo& info) {
+void CFluidPlaneCPU::UpdatePatchWithNormals(Heights& heights, const Flags& flags,
+                                            const CFluidPlaneRender::SPatchInfo& info) {
   float normalScale = -(2.f * info.x18_rippleResolution);
   float nz = 0.25f * 2.f * info.x18_rippleResolution;
   int curGridY = info.x2e_tileY * info.x2a_gridDimX - 1 + info.x28_tileX;
@@ -696,11 +697,9 @@ void CFluidPlaneCPU::UpdatePatchWithNormals(CFluidPlaneRender::SHFieldSample (&h
   }
 }
 
-bool CFluidPlaneCPU::UpdatePatch(float time, const CFluidPlaneRender::SPatchInfo& info,
-                                 CFluidPlaneRender::SHFieldSample (&heights)[46][46], u8 (&flags)[9][9],
-                                 const zeus::CVector3f& areaCenter,
-                                 const std::optional<CRippleManager>& rippleManager, int fromX, int toX,
-                                 int fromY, int toY) const {
+bool CFluidPlaneCPU::UpdatePatch(float time, const CFluidPlaneRender::SPatchInfo& info, Heights& heights, Flags& flags,
+                                 const zeus::CVector3f& areaCenter, const std::optional<CRippleManager>& rippleManager,
+                                 int fromX, int toX, int fromY, int toY) const {
   rstl::reserved_vector<CFluidPlaneRender::SRippleInfo, 32> rippleInfos;
   if (rippleManager) {
     for (const CRipple& ripple : rippleManager->GetRipples()) {
@@ -730,10 +729,10 @@ bool CFluidPlaneCPU::UpdatePatch(float time, const CFluidPlaneRender::SPatchInfo
   return false;
 }
 
-/* Used to be part of locked cache
- * These are too big for stack allocation */
-static CFluidPlaneRender::SHFieldSample lc_heights[46][46] = {};
-static u8 lc_flags[9][9] = {};
+// Used to be part of locked cache
+// These are too big for stack allocation
+static CFluidPlane::Heights lc_heights{};
+static CFluidPlane::Flags lc_flags{};
 
 void CFluidPlaneCPU::Render(const CStateManager& mgr, float alpha, const zeus::CAABox& aabb, const zeus::CTransform& xf,
                             const zeus::CTransform& areaXf, bool noNormals, const zeus::CFrustum& frustum,

--- a/Runtime/World/CFluidPlaneCPU.hpp
+++ b/Runtime/World/CFluidPlaneCPU.hpp
@@ -12,6 +12,9 @@ namespace urde {
 class CFluidUVMotion;
 
 class CFluidPlaneCPU : public CFluidPlane {
+public:
+  using SineTable = std::array<float, 256>;
+
 protected:
   class CTurbulence {
     float x0_speed;
@@ -65,23 +68,17 @@ protected:
 
   static bool PrepareRipple(const CRipple& ripple, const CFluidPlaneRender::SPatchInfo& info,
                             CFluidPlaneRender::SRippleInfo& rippleOut);
-  void ApplyTurbulence(float t, CFluidPlaneRender::SHFieldSample (&heights)[46][46], const u8 (&flags)[9][9],
-                       const float sineWave[256], const CFluidPlaneRender::SPatchInfo& info,
-                       const zeus::CVector3f& areaCenter) const;
-  void ApplyRipple(const CFluidPlaneRender::SRippleInfo& rippleInfo,
-                   CFluidPlaneRender::SHFieldSample (&heights)[46][46], u8 (&flags)[9][9], const float sineWave[256],
-                   const CFluidPlaneRender::SPatchInfo& info) const;
-  void ApplyRipples(const rstl::reserved_vector<CFluidPlaneRender::SRippleInfo, 32>& rippleInfos,
-                    CFluidPlaneRender::SHFieldSample (&heights)[46][46], u8 (&flags)[9][9], const float sineWave[256],
-                    const CFluidPlaneRender::SPatchInfo& info) const;
-  static void UpdatePatchNoNormals(CFluidPlaneRender::SHFieldSample (&heights)[46][46], const u8 (&flags)[9][9],
-                                   const CFluidPlaneRender::SPatchInfo& info);
-  static void UpdatePatchWithNormals(CFluidPlaneRender::SHFieldSample (&heights)[46][46], const u8 (&flags)[9][9],
-                                     const CFluidPlaneRender::SPatchInfo& info);
-  bool UpdatePatch(float time, const CFluidPlaneRender::SPatchInfo& info,
-                   CFluidPlaneRender::SHFieldSample (&heights)[46][46], u8 (&flags)[9][9],
-                   const zeus::CVector3f& areaCenter, const std::optional<CRippleManager>& rippleManager,
-                   int fromX, int toX, int fromY, int toY) const;
+  void ApplyTurbulence(float t, Heights& heights, const Flags& flags, const SineTable& sineWave,
+                       const CFluidPlaneRender::SPatchInfo& info, const zeus::CVector3f& areaCenter) const;
+  void ApplyRipple(const CFluidPlaneRender::SRippleInfo& rippleInfo, Heights& heights, Flags& flags,
+                   const SineTable& sineWave, const CFluidPlaneRender::SPatchInfo& info) const;
+  void ApplyRipples(const rstl::reserved_vector<CFluidPlaneRender::SRippleInfo, 32>& rippleInfos, Heights& heights,
+                    Flags& flags, const SineTable& sineWave, const CFluidPlaneRender::SPatchInfo& info) const;
+  static void UpdatePatchNoNormals(Heights& heights, const Flags& flags, const CFluidPlaneRender::SPatchInfo& info);
+  static void UpdatePatchWithNormals(Heights& heights, const Flags& flags, const CFluidPlaneRender::SPatchInfo& info);
+  bool UpdatePatch(float time, const CFluidPlaneRender::SPatchInfo& info, Heights& heights, Flags& flags,
+                   const zeus::CVector3f& areaCenter, const std::optional<CRippleManager>& rippleManager, int fromX,
+                   int toX, int fromY, int toY) const;
 
 public:
   CFluidPlaneCPU(CAssetId texPattern1, CAssetId texPattern2, CAssetId texColor, CAssetId bumpMap, CAssetId envMap,

--- a/Runtime/World/CFluidPlaneDoor.cpp
+++ b/Runtime/World/CFluidPlaneDoor.cpp
@@ -51,10 +51,10 @@ CFluidPlaneShader::RenderSetupInfo CFluidPlaneDoor::RenderSetup(const CStateMana
   return out;
 }
 
-/* Used to be part of locked cache
- * These are too big for stack allocation */
-static CFluidPlaneRender::SHFieldSample lc_heights[46][46] = {};
-static u8 lc_flags[9][9] = {};
+// Used to be part of locked cache
+// These are too big for stack allocation
+static CFluidPlane::Heights lc_heights{};
+static CFluidPlane::Flags lc_flags{};
 
 void CFluidPlaneDoor::Render(const CStateManager& mgr, float alpha, const zeus::CAABox& aabb,
                              const zeus::CTransform& xf, const zeus::CTransform& areaXf, bool noNormals,

--- a/Runtime/World/CFluidPlaneGPU.cpp
+++ b/Runtime/World/CFluidPlaneGPU.cpp
@@ -17,8 +17,7 @@ CFluidPlaneGPU::CFluidPlaneGPU(CAssetId texPattern1, CAssetId texPattern2, CAsse
   m_tessellation = true;
 }
 
-void CFluidPlaneGPU::RenderStripWithRipples(float curY, const CFluidPlaneRender::SHFieldSample (&heights)[46][46],
-                                            const u8 (&flags)[9][9], int startYDiv,
+void CFluidPlaneGPU::RenderStripWithRipples(float curY, const Heights& heights, const Flags& flags, int startYDiv,
                                             const CFluidPlaneRender::SPatchInfo& info,
                                             std::vector<CFluidPlaneShader::Vertex>& vOut,
                                             std::vector<CFluidPlaneShader::PatchVertex>& pvOut) {

--- a/Runtime/World/CFluidPlaneGPU.hpp
+++ b/Runtime/World/CFluidPlaneGPU.hpp
@@ -17,9 +17,8 @@ public:
                  float turbAmplitudeMin, float specularMin, float specularMax, float reflectionBlend,
                  float reflectionSize, float rippleIntensity, u32 maxVertCount);
 
-  void RenderStripWithRipples(float curY, const CFluidPlaneRender::SHFieldSample (&heights)[46][46],
-                              const u8 (&flags)[9][9], int startYDiv, const CFluidPlaneRender::SPatchInfo& info,
-                              std::vector<CFluidPlaneShader::Vertex>& vOut,
+  void RenderStripWithRipples(float curY, const Heights& heights, const Flags& flags, int startYDiv,
+                              const CFluidPlaneRender::SPatchInfo& info, std::vector<CFluidPlaneShader::Vertex>& vOut,
                               std::vector<CFluidPlaneShader::PatchVertex>& pvOut) override;
 };
 


### PR DESCRIPTION
Makes all the arrays strongly typed. We can also use type aliases to greatly shorten some type definitions and make them less verbose.