### PR TITLE
CScanDisplay: Eliminate implicit sign conversions

### DIFF
--- a/Runtime/CScannableObjectInfo.hpp
+++ b/Runtime/CScannableObjectInfo.hpp
@@ -12,6 +12,8 @@ class CScannableObjectInfo {
 public:
   enum class EPanelType {};
 
+  static constexpr size_t NumBuckets = 4;
+
   struct SBucket {
     CAssetId x0_texture;
     float x4_appearanceRange = 0.f;
@@ -29,14 +31,14 @@ private:
   float x8_totalDownloadTime = 0.f;
   u32 xc_category = 0;
   bool x10_important = false;
-  rstl::reserved_vector<SBucket, 4> x14_buckets;
+  rstl::reserved_vector<SBucket, NumBuckets> x14_buckets;
 
 public:
   CScannableObjectInfo(CInputStream&, CAssetId);
   CAssetId GetScannableObjectId() const { return x0_scannableObjectId; }
   CAssetId GetStringTableId() const { return x4_stringId; }
   float GetTotalDownloadTime() const { return x8_totalDownloadTime; }
-  const SBucket& GetBucket(s32 idx) const { return x14_buckets[idx]; }
+  const SBucket& GetBucket(size_t idx) const { return x14_buckets[idx]; }
   u32 GetCategory() const { return xc_category; }
   bool IsImportant() const { return x10_important; }
 };

--- a/Runtime/GuiSys/CScanDisplay.hpp
+++ b/Runtime/GuiSys/CScanDisplay.hpp
@@ -79,8 +79,8 @@ private:
   float x1b0_aPulse = 1.f;
   bool x1b4_scanComplete = false;
 
-  float GetDownloadStartTime(int idx) const;
-  float GetDownloadFraction(int idx, float scanningTime) const;
+  float GetDownloadStartTime(size_t idx) const;
+  float GetDownloadFraction(size_t idx, float scanningTime) const;
   static void SetScanMessageTypeEffect(CGuiTextPane* pane, bool type);
 
 public:

--- a/Runtime/MP1/CLogBookScreen.cpp
+++ b/Runtime/MP1/CLogBookScreen.cpp
@@ -214,10 +214,11 @@ void CLogBookScreen::UpdateBodyImagesAndText() {
     pane->SetAnimationParms(zeus::skZero2f, 0.f, 0.f);
   }
 
-  for (int i = 0; i < 4; ++i) {
+  for (size_t i = 0; i < CScannableObjectInfo::NumBuckets; ++i) {
     const CScannableObjectInfo::SBucket& bucket = scan->GetBucket(i);
-    if (bucket.x8_imagePos == UINT32_MAX)
+    if (bucket.x8_imagePos == UINT32_MAX) {
       continue;
+    }
     CAuiImagePane* pane = xf0_imagePanes[bucket.x8_imagePos];
     if (bucket.x14_interval > 0.f) {
       pane->SetAnimationParms(zeus::CVector2f(bucket.xc_size.x, bucket.xc_size.y), bucket.x14_interval,

--- a/Runtime/MP1/CPauseScreenBase.cpp
+++ b/Runtime/MP1/CPauseScreenBase.cpp
@@ -536,7 +536,7 @@ void CPauseScreenBase::OnWidgetScroll(CGuiWidget* widget, const boo::SScrollDelt
   }
 }
 
-std::string CPauseScreenBase::GetImagePaneName(u32 i) {
+std::string CPauseScreenBase::GetImagePaneName(size_t i) {
   static constexpr std::array PaneSuffixes{
       "0", "1", "2", "3", "01", "12", "23", "012", "123", "0123",
       "4", "5", "6", "7", "45", "56", "67", "456", "567", "4567",

--- a/Runtime/MP1/CPauseScreenBase.hpp
+++ b/Runtime/MP1/CPauseScreenBase.hpp
@@ -102,7 +102,7 @@ protected:
   void OnWidgetScroll(CGuiWidget* widget, const boo::SScrollDelta& delta, int accumX, int accumY);
 
 public:
-  static std::string GetImagePaneName(u32 i);
+  static std::string GetImagePaneName(size_t i);
 
   CPauseScreenBase(const CStateManager& mgr, CGuiFrame& frame, const CStringTable& pauseStrg, bool isLogBook = false);
 


### PR DESCRIPTION
Removes implicit sign conversions and also dehardcodes quite a bit of repeated sizes.

Making this a PR so someone can give it a once-over.