### PR TITLE
CGuiWidgetDrawParms: Make constexpr constructible

### DIFF
--- a/Runtime/GuiSys/CGuiWidgetDrawParms.cpp
+++ b/Runtime/GuiSys/CGuiWidgetDrawParms.cpp
@@ -1,5 +1,0 @@
-#include "Runtime/GuiSys/CGuiWidgetDrawParms.hpp"
-
-namespace urde {
-const CGuiWidgetDrawParms CGuiWidgetDrawParms::Default = {};
-}

--- a/Runtime/GuiSys/CGuiWidgetDrawParms.hpp
+++ b/Runtime/GuiSys/CGuiWidgetDrawParms.hpp
@@ -8,10 +8,11 @@ struct CGuiWidgetDrawParms {
   float x0_alphaMod = 1.f;
   zeus::CVector3f x4_cameraOffset;
 
-  CGuiWidgetDrawParms() = default;
-  CGuiWidgetDrawParms(float alphaMod, const zeus::CVector3f& cameraOff)
+  constexpr CGuiWidgetDrawParms() = default;
+  constexpr CGuiWidgetDrawParms(float alphaMod, const zeus::CVector3f& cameraOff)
   : x0_alphaMod(alphaMod), x4_cameraOffset(cameraOff) {}
-  static const CGuiWidgetDrawParms Default;
+
+  static constexpr CGuiWidgetDrawParms Default() { return {}; }
 };
 
 } // namespace urde

--- a/Runtime/GuiSys/CHudDecoInterface.cpp
+++ b/Runtime/GuiSys/CHudDecoInterface.cpp
@@ -324,7 +324,7 @@ void CHudDecoInterfaceScan::Update(float dt, const CStateManager& stateMgr) {
 void CHudDecoInterfaceScan::Draw() {
   x18_scanDisplay.Draw();
   if (x10_loadedScanHudFlat) {
-    x10_loadedScanHudFlat->Draw(CGuiWidgetDrawParms::Default);
+    x10_loadedScanHudFlat->Draw(CGuiWidgetDrawParms::Default());
   }
 }
 

--- a/Runtime/GuiSys/CMakeLists.txt
+++ b/Runtime/GuiSys/CMakeLists.txt
@@ -17,7 +17,7 @@ set(GUISYS_SOURCES
     CGuiTextPane.hpp CGuiTextPane.cpp
     CGuiTextSupport.hpp CGuiTextSupport.cpp
     CGuiWidget.hpp CGuiWidget.cpp
-    CGuiWidgetDrawParms.hpp CGuiWidgetDrawParms.cpp
+    CGuiWidgetDrawParms.hpp
     CSplashScreen.hpp CSplashScreen.cpp
     CGuiCompoundWidget.hpp CGuiCompoundWidget.cpp
     CSaveableState.hpp CSaveableState.cpp

--- a/Runtime/MP1/CFrontEndUI.cpp
+++ b/Runtime/MP1/CFrontEndUI.cpp
@@ -296,7 +296,7 @@ CFrontEndUI::SNewFileSelectFrame::ProcessUserInput(const CFinalInput& input, CFr
 
 void CFrontEndUI::SNewFileSelectFrame::Draw() const {
   if (x1c_loadedFrame && x10c_saveReady)
-    x1c_loadedFrame->Draw(CGuiWidgetDrawParms::Default);
+    x1c_loadedFrame->Draw(CGuiWidgetDrawParms::Default());
 }
 
 void CFrontEndUI::SNewFileSelectFrame::HandleActiveChange(CGuiTableGroup* active) {
@@ -909,7 +909,7 @@ void CFrontEndUI::SFusionBonusFrame::SGBALinkFrame::FinishedLoading() {
   SetUIText(EUIType::InsertPak);
 }
 
-void CFrontEndUI::SFusionBonusFrame::SGBALinkFrame::Draw() { x8_frme->Draw(CGuiWidgetDrawParms::Default); }
+void CFrontEndUI::SFusionBonusFrame::SGBALinkFrame::Draw() { x8_frme->Draw(CGuiWidgetDrawParms::Default()); }
 
 CFrontEndUI::SFusionBonusFrame::SGBALinkFrame::SGBALinkFrame(CGuiFrame* linkFrame, CGBASupport* support,
                                                              bool linkInProgress)
@@ -1103,7 +1103,7 @@ void CFrontEndUI::SFusionBonusFrame::Draw() const {
   if (x0_gbaLinkFrame)
     x0_gbaLinkFrame->Draw();
   else if (x24_loadedFrame)
-    x24_loadedFrame->Draw(CGuiWidgetDrawParms::Default);
+    x24_loadedFrame->Draw(CGuiWidgetDrawParms::Default());
 }
 
 void CFrontEndUI::SFusionBonusFrame::DoCancel(CGuiTableGroup* caller) {
@@ -1289,7 +1289,7 @@ CFrontEndUI::SFrontEndFrame::ProcessUserInput(const CFinalInput& input, CFrontEn
   return x4_action;
 }
 
-void CFrontEndUI::SFrontEndFrame::Draw() const { x14_loadedFrme->Draw(CGuiWidgetDrawParms::Default); }
+void CFrontEndUI::SFrontEndFrame::Draw() const { x14_loadedFrme->Draw(CGuiWidgetDrawParms::Default()); }
 
 void CFrontEndUI::SFrontEndFrame::HandleActiveChange(CGuiTableGroup* active) {
   active->SetColors(zeus::skWhite, zeus::CColor{0.627450f, 0.627450f, 0.627450f, 0.784313f});

--- a/Runtime/MP1/CSamusHud.cpp
+++ b/Runtime/MP1/CSamusHud.cpp
@@ -1429,7 +1429,7 @@ void CSamusHud::Draw(const CStateManager& mgr, float alpha, CInGameGuiManager::E
     }
 
     if (x274_loadedFrmeBaseHud) {
-      x274_loadedFrmeBaseHud->Draw(CGuiWidgetDrawParms::Default);
+      x274_loadedFrmeBaseHud->Draw(CGuiWidgetDrawParms::Default());
     }
   }
 

--- a/Runtime/MP1/CSaveGameScreen.cpp
+++ b/Runtime/MP1/CSaveGameScreen.cpp
@@ -329,7 +329,7 @@ void CSaveGameScreen::SetUIColors() {
 void CSaveGameScreen::Draw() const {
   SCOPED_GRAPHICS_DEBUG_GROUP("CSaveGameScreen::Draw", zeus::skPurple);
   if (x50_loadedFrame)
-    x50_loadedFrame->Draw(CGuiWidgetDrawParms::Default);
+    x50_loadedFrame->Draw(CGuiWidgetDrawParms::Default());
 }
 
 void CSaveGameScreen::ContinueWithoutSaving() {


### PR DESCRIPTION
We can allow this structure to be constructed in a constexpr context.

This also allows us to remove the cpp file, given it's no longer necessary.