### PR TITLE
rstl: Make iterator tag use std::contiguous_iterator_tag

### DIFF
--- a/Runtime/rstl.hpp
+++ b/Runtime/rstl.hpp
@@ -34,7 +34,7 @@ public:
     using difference_type = std::ptrdiff_t;
     using pointer = T*;
     using reference = T&;
-    using iterator_category = std::random_access_iterator_tag;
+    using iterator_category = std::contiguous_iterator_tag;
 
     const T& operator*() const { return *m_val; }
     const T* operator->() const { return m_val; }


### PR DESCRIPTION
Given we're iterating over a contiguous sequence with iterators like these, we can use the contiguous_iterator_tag introduced within C++20 to signify this.