### PR TITLE
CSfxManager: Make use of designated initializers

### DIFF
--- a/Runtime/Audio/CSfxManager.cpp
+++ b/Runtime/Audio/CSfxManager.cpp
@@ -393,33 +393,35 @@ void CSfxManager::UpdateEmitter(const CSfxHandle& handle, const zeus::CVector3f&
 
 CSfxHandle CSfxManager::AddEmitter(u16 id, const zeus::CVector3f& pos, const zeus::CVector3f& dir, bool useAcoustics,
                                    bool looped, s16 prio, s32 areaId) {
-  CAudioSys::C3DEmitterParmData parmData;
-  parmData.x0_pos = pos;
-  parmData.xc_dir = dir;
-  parmData.x18_maxDist = 150.f;
-  parmData.x1c_distComp = 0.1f;
-  parmData.x20_flags = 1; // Continuous parameter update
-  parmData.x24_sfxId = id;
-  parmData.x26_maxVol = 1.f;
-  parmData.x27_minVol = 0.165f;
-  parmData.x28_important = false;
-  parmData.x29_prio = 0x7f;
+  const CAudioSys::C3DEmitterParmData parmData{
+      .x0_pos = pos,
+      .xc_dir = dir,
+      .x18_maxDist = 150.f,
+      .x1c_distComp = 0.1f,
+      .x20_flags = 1, // Continuous parameter update
+      .x24_sfxId = id,
+      .x26_maxVol = 1.f,
+      .x27_minVol = 0.165f,
+      .x28_important = false,
+      .x29_prio = 0x7f,
+  };
   return AddEmitter(parmData, useAcoustics, prio, looped, areaId);
 }
 
 CSfxHandle CSfxManager::AddEmitter(u16 id, const zeus::CVector3f& pos, const zeus::CVector3f& dir, float vol,
                                    bool useAcoustics, bool looped, s16 prio, s32 areaId) {
-  CAudioSys::C3DEmitterParmData parmData;
-  parmData.x0_pos = pos;
-  parmData.xc_dir = dir;
-  parmData.x18_maxDist = 150.f;
-  parmData.x1c_distComp = 0.1f;
-  parmData.x20_flags = 1; // Continuous parameter update
-  parmData.x24_sfxId = id;
-  parmData.x26_maxVol = std::max(vol, 0.165f);
-  parmData.x27_minVol = 0.165f;
-  parmData.x28_important = false;
-  parmData.x29_prio = 0x7f;
+  const CAudioSys::C3DEmitterParmData parmData{
+      .x0_pos = pos,
+      .xc_dir = dir,
+      .x18_maxDist = 150.f,
+      .x1c_distComp = 0.1f,
+      .x20_flags = 1, // Continuous parameter update
+      .x24_sfxId = id,
+      .x26_maxVol = std::max(vol, 0.165f),
+      .x27_minVol = 0.165f,
+      .x28_important = false,
+      .x29_prio = 0x7f,
+  };
   return AddEmitter(parmData, useAcoustics, prio, looped, areaId);
 }
 


### PR DESCRIPTION
Same behavior, less duplication of variable names.

Originally I'd push this to master, but want to double check that the appveyor buildbot will compile with it.