### PR TITLE
Bugfix: Xcode build "loop variable <X> is always a copy " error fix

### DIFF
--- a/Runtime/MP1/World/CMetroidPrimeRelay.cpp
+++ b/Runtime/MP1/World/CMetroidPrimeRelay.cpp
@@ -49,7 +49,7 @@ void CMetroidPrimeRelay::GetOrBuildMetroidPrimeExo(CStateManager& mgr) {
     return;
   }
 
-  for (const auto& act : mgr.GetPhysicsActorObjectList()) {
+  for (const auto act : mgr.GetPhysicsActorObjectList()) {
     if (CPatterned::CastTo<CMetroidPrimeExo>(act) != nullptr) {
       return;
     }

--- a/Runtime/World/CScriptMazeNode.cpp
+++ b/Runtime/World/CScriptMazeNode.cpp
@@ -116,7 +116,7 @@ void CScriptMazeNode::AcceptScriptMsg(EScriptObjectMessage msg, TUniqueId uid, C
             }
           }
         }
-        for (const auto& ent : mgr.GetAllObjectList()) {
+        for (const auto ent : mgr.GetAllObjectList()) {
           if (TCastToPtr<CScriptMazeNode> node = ent) {
             if (node->xe8_col == xe8_col - 1 && node->xec_row == xec_row && node->xf0_side == ESide::Right) {
               auto& cell = maze->GetCell(xe8_col - 1, xec_row);


### PR DESCRIPTION
Xcode: v12.3
MacOS: Big Sur

On building, receive two errors of the same type:

<img width="760" alt="Screen Shot 2020-12-21 at 2 06 23 AM" src="https://user-images.githubusercontent.com/53711879/102794802-e6f74280-4379-11eb-9a8c-4ddcadef0dc9.png">

This change allows the build to complete without errors. 