### PR TITLE
CGraphics: FPS Counter and debug overlay

### DIFF
--- a/Editor/ViewManager.cpp
+++ b/Editor/ViewManager.cpp
@@ -66,6 +66,9 @@ void ViewManager::TestGameView::think() {
       if (m_cvarCommons.m_debugOverlayShowFrameCounter->toBoolean())
         overlayText += fmt::format(FMT_STRING("Frame: {}\n"), g_StateManager->GetUpdateFrameIndex());
 
+      if (m_cvarCommons.m_debugOverlayShowFramerate->toBoolean())
+          overlayText += fmt::format(FMT_STRING("FPS: {}\n"), urde::CGraphics::GetFPS());
+
       if (m_cvarCommons.m_debugOverlayShowInGameTime->toBoolean()) {
         double igt = g_GameState->GetTotalPlayTime();
         u32 ms = u64(igt * 1000) % 1000;

--- a/Runtime/Graphics/CGraphics.cpp
+++ b/Runtime/Graphics/CGraphics.cpp
@@ -34,6 +34,9 @@ SViewport g_Viewport = {
     0, 0, 640, 480, 640 / 2.f, 480 / 2.f, 0.0f,
 };
 u32 CGraphics::g_FrameCounter = 0;
+u32 CGraphics::g_Framerate = 0;
+u32 CGraphics::g_FramesPast = 0;
+frame_clock::time_point CGraphics::g_FrameStartTime = frame_clock::now();
 
 const std::array<zeus::CMatrix3f, 6> CGraphics::skCubeBasisMats{{
     /* Right */
@@ -126,6 +129,8 @@ void CGraphics::EndScene() {
   CLineRenderer::UpdateBuffers();
 
   ++g_FrameCounter;
+
+  UpdateFPSCounter();
 }
 
 void CGraphics::SetAlphaCompare(ERglAlphaFunc comp0, u8 ref0, ERglAlphaOp op, ERglAlphaFunc comp1, u8 ref1) {}
@@ -442,6 +447,18 @@ float CGraphics::GetSecondsMod900() {
 void CGraphics::TickRenderTimings() {
   g_RenderTimings = (g_RenderTimings + 1) % u32(900 * 60);
   g_DefaultSeconds = g_RenderTimings / 60.f;
+}
+
+static constexpr u64 FPS_REFRESH_RATE = 1000; 
+void CGraphics::UpdateFPSCounter() {
+  ++g_FramesPast;
+
+  std::chrono::duration<double, std::milli> timeElapsed = frame_clock::now() - g_FrameStartTime;
+  if (timeElapsed.count() > FPS_REFRESH_RATE) {
+      g_Framerate = g_FramesPast;
+      g_FrameStartTime = frame_clock::now(); 
+      g_FramesPast = 0;
+  }
 }
 
 boo::IGraphicsDataFactory::Platform CGraphics::g_BooPlatform = boo::IGraphicsDataFactory::Platform::Null;

--- a/Runtime/Graphics/CGraphics.hpp
+++ b/Runtime/Graphics/CGraphics.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <vector>
+#include <chrono>
 
 #include "Runtime/RetroTypes.hpp"
 
@@ -17,6 +18,8 @@
 #include <zeus/CTransform.hpp>
 #include <zeus/CVector2i.hpp>
 #include <zeus/CVector2f.hpp>
+
+using frame_clock = std::chrono::high_resolution_clock;
 
 namespace urde {
 extern hecl::CVar* g_disableLighting;
@@ -309,7 +312,12 @@ public:
   static float GetSecondsMod900();
   static void TickRenderTimings();
   static u32 g_FrameCounter;
+  static u32 g_Framerate;
+  static u32 g_FramesPast;
+  static frame_clock::time_point g_FrameStartTime;
   static u32 GetFrameCounter() { return g_FrameCounter; }
+  static u32 GetFPS() { return g_Framerate; }
+  static void UpdateFPSCounter();
 
   static boo::IGraphicsDataFactory::Platform g_BooPlatform;
   static const boo::SystemChar* g_BooPlatformName;


### PR DESCRIPTION
Implemented CGraphics::GetFPS() which returns the fps value that is updated at the end of each scene, and displays it if the [debugOverlayShowFramerate](https://github.com/AxioDL/hecl/pull/39) cvar is set. This FPS value is the amount of frames that have past at the end of every second, calculated using the Chrono library.

The FPS counter isn't coded exactly like the function found in MP1's binary, the primary differences are the FPS counter uses Chrono to gather time, doesn't write a "previous framerate" value (which I believe is unused in the game as well) and is capable of working with a variable framerate. Since Boo isn't written to be a replica of the game's graphics engine I doubt this will be an issue.