### PR TITLE
[Windows] Remove constexpr from Lambda functions to fix compiler errors.

### DIFF
--- a/Runtime/MP1/World/CBouncyGrenade.cpp
+++ b/Runtime/MP1/World/CBouncyGrenade.cpp
@@ -115,7 +115,7 @@ void CBouncyGrenade::Think(float dt, CStateManager& mgr) {
     const zeus::CTransform& orientation = GetTransform().getRotation();
     const zeus::CVector3f& translation = GetTranslation();
     const zeus::CVector3f& scale = GetModelData()->GetScale();
-    auto UpdateElementGen = [ orientation, translation, scale, dt ](CElementGen & gen) constexpr {
+    auto UpdateElementGen = [ orientation, translation, scale, dt ](CElementGen & gen) {
       gen.SetOrientation(orientation);
       gen.SetGlobalTranslation(translation);
       gen.SetGlobalScale(scale);

--- a/Runtime/World/CScriptMazeNode.cpp
+++ b/Runtime/World/CScriptMazeNode.cpp
@@ -371,7 +371,7 @@ void CMazeState::GenerateObstacles() {
     Initialize();
   }
 
-  auto GetRandom = [this](s32 offset) constexpr {
+  auto GetRandom = [this](s32 offset) {
     s32 tmp = x0_rand.Next();
     return tmp + ((tmp / 5) * -5) + offset;
   };


### PR DESCRIPTION
Recently applying constexpr to these lambdas has been producing an error on Windows 10
```
error: constexpr function never produces a constant expression [-Winvalid-constexpr]
```

I understand the intention is to find the root of the problem and fix it, however until then Windows (and possibly other platforms) are unable to compile without removing `constexpr`. Since this has no serious downside, I believe we should just remove them so that those having this error can compile.