### PR TITLE
Improve CFileDvdRequest::PostCancelRequest

### DIFF
--- a/Runtime/CDvdFile.cpp
+++ b/Runtime/CDvdFile.cpp
@@ -28,6 +28,9 @@ public:
   }
   bool IsComplete() override { return m_complete.load(); }
   void PostCancelRequest() override {
+    if (m_complete.load() || m_cancel.load()) {
+      return;
+    }
     std::unique_lock waitlk{CDvdFile::m_WaitMutex};
     m_cancel.store(true);
   }


### PR DESCRIPTION
Do nothing if either m_complete or m_cancel is set, avoiding waiting for the mutex for no reason.